### PR TITLE
fix(tabs): visibilite des tabs non actifs

### DIFF
--- a/src/tabs/styles/_module.scss
+++ b/src/tabs/styles/_module.scss
@@ -149,6 +149,7 @@
     **/
     @at-root #{&}:not(&--selected) {
       visibility: hidden;
+      display: none;
     }
   }
 }


### PR DESCRIPTION
Fix issue when an element inside the tab manage his own visibility (like sidemenu) and then become visible even when the tab is not selected
https://gouvfr.atlassian.net/servicedesk/customer/portal/1/DSFR-322