### PR TITLE
fix(checkboxes, radios): input en position absolue [DS-1924]

### DIFF
--- a/examples/example.ejs
+++ b/examples/example.ejs
@@ -8,7 +8,7 @@
 
     <%- include(root + 'src/core/templates/ejs/favicons/favicons.ejs', {path: '../../dist/favicons/'}); %>
 
-    <%- include(root + '/examples/styles', { required: ['core', 'schemes', 'links', 'accordions', 'forms', 'checkboxes', 'utilities', 'buttons'] }); %>
+    <%- include(root + '/examples/styles', { required: ['core', 'schemes', 'links', 'accordions', 'forms', 'checkboxes', 'utilities', 'buttons', 'legacy'] }); %>
 
     <style>
      <%- include(root + 'examples/styles.css'); %>

--- a/src/checkboxes/example/samples/checkbox.ejs
+++ b/src/checkboxes/example/samples/checkbox.ejs
@@ -1,7 +1,7 @@
 <%
 let data = JSON.parse(include('../../../forms/example/samples/data'));
 
-data.label = '1 Label checkbox';
+data.label = 'Label checkbox';
 if (locals.checkboxAttrs !== undefined) data = {...data, checkboxAttrs: locals.checkboxAttrs}
 
 %>

--- a/src/checkboxes/styles/_module.scss
+++ b/src/checkboxes/styles/_module.scss
@@ -40,9 +40,8 @@
        */
       @include icon(check-line, sm, before) {
         @include display-flex(row, center, center);
-        @include absolute(0);
+        @include absolute(0, null, null, -8v);
         @include margin-top(3v);
-        left: #{space(-8v)};
         @include size(6v, 6v);
         @include margin-right(2v);
         border-radius: space(1v);

--- a/src/checkboxes/styles/_module.scss
+++ b/src/checkboxes/styles/_module.scss
@@ -25,6 +25,7 @@
       @include padding(3v 0);
       -webkit-tap-highlight-color: transparent;
       @include display-flex(row, center, flex-start, wrap);
+      @include margin-left(8v);
 
       /**
        * Style du texte d'aide dans le label
@@ -32,7 +33,6 @@
       #{ns(hint-text)} {
         @include margin(0);
         @include size(100%);
-        @include margin-left(8v);
       }
 
       /**
@@ -40,7 +40,9 @@
        */
       @include icon(check-line, sm, before) {
         @include display-flex(row, center, center);
-        flex-shrink: 0;
+        @include absolute(0);
+        @include margin-top(3v);
+        left: #{space(-8v)};
         @include size(6v, 6v);
         @include margin-right(2v);
         border-radius: space(1v);
@@ -79,14 +81,8 @@
       + label {
         @include before {
           @include size(4v, 4v);
-        }
-
-        @include after {
-          left: 0;
-        }
-
-        #{ns(hint-text)} {
-          @include margin-left(6v);
+          @include margin-top(4v);
+          left: #{space(-7v)};
         }
       }
     }

--- a/src/radios/styles/_legacy.scss
+++ b/src/radios/styles/_legacy.scss
@@ -21,4 +21,14 @@
       }
     }
   }
+
+  /**
+  * Correctif alignement vertical IE
+  * Inconvéniant : fixe la height à la min-height, soit 5.5 rem
+  */
+  #{ns(radio-rich)} {
+    input[type="radio"] + #{ns(label)} {
+      @include height(1px);
+    }
+  }
 }

--- a/src/radios/styles/_module.scss
+++ b/src/radios/styles/_module.scss
@@ -62,11 +62,10 @@
        * On utilise un pseudo element before pour customiser l'aspect du bouton radio
        */
       @include before('', inline-block) {
-        @include absolute(0);
+        @include absolute(0, null, null, -8v);
         @include size(6v, 6v);
         @include margin-top(3v);
         @include margin-right(2v);
-        left: #{space(-8v)};
         border: 1px solid;
         border-radius: 50%;
         transform-origin: center;

--- a/src/radios/styles/_module.scss
+++ b/src/radios/styles/_module.scss
@@ -48,6 +48,7 @@
       @include text-style(md);
       -webkit-tap-highlight-color: transparent;
       @include display-flex(row, center, flex-start, wrap);
+      @include margin-left(8v);
 
       /**
        * Style du texte d'aide dans le label
@@ -55,16 +56,17 @@
       #{ns(hint-text)} {
         @include margin(0);
         @include size(100%);
-        @include margin-left(8v);
       }
 
       /**
        * On utilise un pseudo element before pour customiser l'aspect du bouton radio
        */
       @include before('', inline-block) {
+        @include absolute(0);
         @include size(6v, 6v);
+        @include margin-top(3v);
         @include margin-right(2v);
-        flex-shrink: 0;
+        left: #{space(-8v)};
         border: 1px solid;
         border-radius: 50%;
         transform-origin: center;
@@ -95,10 +97,7 @@
       & + label {
         @include before {
           @include size(4v, 4v);
-        }
-
-        #{ns(hint-text)} {
-          @include margin-left(6v);
+          @include margin-top(4v);
         }
       }
     }

--- a/src/radios/styles/modules/_radios-rich.scss
+++ b/src/radios/styles/modules/_radios-rich.scss
@@ -3,8 +3,9 @@
   input[type="radio"] + #{ns(label)} {
 
     @include padding-left(14v);
+    @include margin-left(0);
     min-height: space(22v);
-    @include size(100%, 1px); // height 1px, fix IE vertical center
+    @include size(100%);
     @include padding-top(2v);
     @include padding-bottom(2v);
     @include padding-right(26v);
@@ -18,15 +19,18 @@
       */
     @include before {
       @include size(4v, 4v);
-      @include absolute(null, null, null, 7v);
+      @include absolute(50%, null, null, 7v);
+      @include margin-top(-2v);
     }
 
     /**
       * On délimite l'espace pour l'image de droite et une icône illustrative par défaut
       */
     @include after('') {
-      @include absolute(0, 0);
+      @include absolute(50%, 0);
       @include margin(1v);
+      @include margin-top(-10v);
+
       @include padding-left(1v);
       @include display-flex(null, center, center);
       @include size(21v, 20v);


### PR DESCRIPTION
Problèmes : 
Les labels passent à la ligne du bouton si plus grand que l'écran.
Les radios riches ne s'étendent pas verticalement

Solution apportée : 
Position absolute sur les inputs
Margin-left sur le label
Les radios riches ne s'étendent pas que sur IE maintenant (pour conserver l'alignement vertical et éviter un breaking change)

Evolutions : 
Les radios et checkboxes en taille SM sont maintenant plus espacés du label (comme sur la lib UI)
Ajout du css du package legacy dans les dépendances des pages d'exemples
L'input reste maintenant aligné en haut si le label passe sur plusieurs lignes