### PR TITLE
fix(input): fr-input--error sur un textarea le passe en rouge [DS-1577]

### DIFF
--- a/src/component/input/style/_scheme.scss
+++ b/src/component/input/style/_scheme.scss
@@ -4,7 +4,6 @@
 ////
 
 textarea#{ns(input)} {
-  @include scheme-element-box-shadow-color(g600, true, 0 2px 0 0 $COLOR);
   min-height: space(15v);
 }
 


### PR DESCRIPTION
On retire le box shadow particulier sur les textarea. 
=> L'icone native pour agrandir le textarea passe par dessus le box shadow