### PR TITLE
fix(colors): expose warning

### DIFF
--- a/src/component/alert/example/index.ejs
+++ b/src/component/alert/example/index.ejs
@@ -2,7 +2,7 @@
 const sample = getSample(include);
 %>
 
-<p>Préciser le type d'alerte (Information/Succès/Erreur) dans le titre ou, à défaut, dans le contenu de l'alerte<br>
+<p>Préciser le type d'alerte (Information/Succès/Erreur/Attention) dans le titre ou, à défaut, dans le contenu de l'alerte<br>
 Le titre est défini par la classe "fr-alert__title", la balise &#60;p&#62; peut être remplacée par un niveau de titre hx suivant le contexte</p>
 
 <%- sample('Alerte par défaut', './sample/alert-default', {}, true); %>
@@ -13,7 +13,7 @@ Le titre est défini par la classe "fr-alert__title", la balise &#60;p&#62; peut
 
 <%- sample('Alerte erreur', './sample/alert-default', {type: "error", title: "Erreur détectée dans le formulaire"}, true); %>
 
-<!-- <%- sample('Alerte attention', './sample/alert-default', {type: "warning", title: "Attention"}, true); %> -->
+<%- sample('Alerte attention', './sample/alert-default', {type: "warning", title: "Attention"}, true); %>
 
 <%- sample('Alerte avec bouton fermer', './sample/alert-default', {type: "info", title: "Information Covid", buttonClose: true}, true); %>
 

--- a/src/scheme/style/setting/_sets.scss
+++ b/src/scheme/style/setting/_sets.scss
@@ -45,7 +45,7 @@ $scheme-sets: (
   // Couleurs fonctionnelles
   info:$info $info-dark-mode,
   success:$success $success-dark-mode,
-  // warning:$warning $warning-dark-mode, // inutilisé pour le moment
+  warning:$warning $warning-dark-mode,
   error:$error $error-dark-mode,
   // Rouge Marianne
   rm300: $red-marianne-300 $grey-700,


### PR DESCRIPTION
Bonjour, sauf erreur, la couleur `warning` est définie dans `src/scheme/style/setting/_colors.scss` mais pas exposée en tant que `var(--warning)`.

Or il existe une classe `fr-alert--warning` avec l'icône associée et tout ce qu'il faut, ce serait pratique svp de l'exposer également :)

J'ai vu un exemple commenté dans `src/component/alert/example/index.ejs`, il doit y avoir une explication :)

Merci
