### PR TITLE
fix(core): reset bordure des inputs [DS-1983]

### DIFF
--- a/src/core/style/reset/module/_input.scss
+++ b/src/core/style/reset/module/_input.scss
@@ -9,5 +9,7 @@
   textarea {
     @include font-family;
     @include text-adjustments;
+    border-radius: 0;
+    border: 0;
   }
 }


### PR DESCRIPTION
Reset du border et border-radius pour surcharger le comportement par défaut d'IOS sur les input[type=submit] notamment.