### PR TITLE
refactor: modification du gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,9 @@
 node_modules/
 */sassdoc/
 
-.DS_Store
 lerna-debug.log
-/.idea/.gitignore
-/.idea/codeStyles/codeStyleConfig.xml
-/.idea/design-system-developpement.iml
-/.idea/misc.xml
-/.idea/modules.xml
-/.idea/codeStyles/Project.xml
-/.idea/inspectionProfiles/Project_Default.xml
-/.idea/templateLanguages.xml
-/.idea/vcs.xml
-/.idea/watcherTasks.xml
-/.idea/
 public/
 
 .config/
 /dist/
 /example/
-
-yarn.lock
-package-lock.json


### PR DESCRIPTION
- package-lock.json : Si vous utilisez uniquement yarn, le fichier ne devrait pas être généré ?
- yarn.lock: il ne devrait pas être ignoré

Concernant le reste, je trouve plus pertinent que ces fichiers (configurations de l'IDE propre au développeur) soient dans un gitignore global (https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files#configuring-ignored-files-for-all-repositories-on-your-computer).