### PR TITLE
fix: package.json licence etalab 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Système de Design de l'Etat - DSFR",
   "repository": "git@github.com:GouvernementFR/dsfr.git",
   "author": "Service d'Information du Gouvernement <jean-charles.hourdeaux@pm.gouv.fr>",
+  "licence": "etalab-2.0",
   "config": {
     "prefix": "fr",
     "namespace": "dsfr",


### PR DESCRIPTION
yarn remonte un warning depuis qu'on a enlevé private du package.json

Ajout de la licence etalab-2.0 qui est définie par son code SPDX