### PR TITLE
Fix: définition d'une valeur par défaut de l'objet de configuration window.dsfr [DS-2085]

### DIFF
--- a/src/core/script/api/options/options.js
+++ b/src/core/script/api/options/options.js
@@ -19,7 +19,7 @@ class Options {
     this.preventManipulation = false;
   }
 
-  configure (settings, start) {
+  configure (settings = {}, start) {
     this.startCallback = start;
     if (settings.verbose === true) inspector.level = 0;
     this.mode = settings.mode || Modes.AUTO;


### PR DESCRIPTION
@lab9fr j'ai défini une valeur par défaut pour les settings pour ne pas être obligé de passer l'objet `window.dsfr` à l'instanciation de l'api.

NB : 
si on instancie pas l'objet dsfr on a une erreur au chargement de la lib : 
<img width="1436" alt="Capture d’écran 2021-10-13 à 18 20 05" src="https://user-images.githubusercontent.com/10864245/137173952-2f2e65c2-6345-4026-9c0c-4dd0f4a20843.png">

