### PR TITLE
fix: correctifs ejs form [DS-1854]

### DIFF
--- a/src/component/content/example/sample/media-img.ejs
+++ b/src/component/content/example/sample/media-img.ejs
@@ -1,7 +1,7 @@
 <%
 let data = {
     ...locals.content || {},
-    img: imgData('img/placeholder.16x9.png', true),
+    img: imgData('img/placeholder.16x9.png'),
     caption: '© Légende de l‘image'
 };
 %>

--- a/src/component/form/template/ejs/fieldset.ejs
+++ b/src/component/form/template/ejs/fieldset.ejs
@@ -40,7 +40,7 @@ if (fieldset.valid !== undefined) {
     fieldsetAttrs['role'] = 'group';
 }
 
-if (fieldset.disabled === true) fieldsetAttrs['disabled'] = 'disabled';
+if (fieldset.disabled === true) fieldsetAttrs['disabled'] = '';
 
 if (fieldset.hint != undefined) describedby.push(fieldset.id + '-desc-hint');
 if (fieldset.error != undefined) describedby.push(fieldset.id + '-desc-error');

--- a/src/component/input/example/index.ejs
+++ b/src/component/input/example/index.ejs
@@ -16,9 +16,9 @@
 
 <%- sample('Default input type textarea', './sample/textarea.ejs', {input: { id:'textarea' }}, true); %>
 
-<%- sample('Type password', './sample/input-password.ejs', {input: { id:'text-input-password', group: true }}, true); %>
+<%- sample('Type password', './sample/input-password.ejs', {input: { id:'text-input-password' }}, true); %>
 
-<%- sample('Combo Input + bouton', './sample/input-button.ejs', {input: { id:'text-input-button', group: true }}, true); %>
+<%- sample('Combo Input + bouton', './sample/input-button.ejs', {input: { id:'text-input-button' }}, true); %>
 
 <%- sample('Default input with placeholder', './sample/input-text.ejs', {input: { id:'text-input-placeholder', placeholder:'placeholder'}}, true); %>
 

--- a/src/component/input/example/sample/input-button.ejs
+++ b/src/component/input/example/sample/input-button.ejs
@@ -7,9 +7,4 @@
     data.addon = true;
     data.button = input.button || {label:'Envoyer', type: 'submit'};
 %>
-<% if (input.group === true) { %>
 <%- include('../../template/ejs/input-group', {input:data}); %>
-<% }
-else { %>
-<%- include('../../template/ejs/input', {input:data}); %>
-<% } %>

--- a/src/component/radio/example/sample/radio-rich.ejs
+++ b/src/component/radio/example/sample/radio-rich.ejs
@@ -6,11 +6,6 @@ let data = {...radio, ...jsonData};
 data.label = radio.label || 'Label radio';
 data.image = radio.image || imgData('img/placeholder.1x1.png');
 data.rich = true;
-
 %>
-<% if (/*locals.group === */true) { %>
-    <%- include('../../template/ejs/radio-group', {radio: data}); %>
-<% }
-else { %>
-    <%- include('../../template/ejs/radio', {radio: data}); %>
-<% } %>
+
+<%- include('../../template/ejs/radio-group', {radio: data}); %>

--- a/src/component/radio/example/sample/radio.ejs
+++ b/src/component/radio/example/sample/radio.ejs
@@ -3,12 +3,6 @@ let radio = locals.radio || {}
 let jsonData = JSON.parse(include('../../../form/example/sample/data', {form:radio}));
 let data = {...radio, ...jsonData};
 
-data.label = 'Label radio';
-
+data.label = radio.label || 'Label radio';
 %>
-<% if (/*locals.group === */true) { %>
-    <%- include('../../template/ejs/radio-group', {radio: data}); %>
-<% }
-else { %>
-    <%- include('../../template/ejs/radio', {radio: data}); %>
-<% } %>
+<%- include('../../template/ejs/radio-group', {radio: data}); %>

--- a/src/component/select/example/index.ejs
+++ b/src/component/select/example/index.ejs
@@ -4,8 +4,8 @@
 
 <%- sample('Liste déroulante désactivée', './sample/select', {select: { id:'select-disabled', disabled:true}}, true); %>
 
-<%- sample('Liste déroulante avec texte de description', './sample/select', {select: { id:'select-hint', hint: true, group:true}}, true); %>
+<%- sample('Liste déroulante avec texte de description', './sample/select', {select: { id:'select-hint', hint: true}}, true); %>
 
-<%- sample('Liste déroulante valide', './sample/select', {select: { id:'select-valid', valid: true, group:true}}, true); %>
+<%- sample('Liste déroulante valide', './sample/select', {select: { id:'select-valid', valid: true}}, true); %>
 
-<%- sample('Liste déroulante erreur', './sample/select', {select: { id:'select-error', error: true, group:true}}, true); %>
+<%- sample('Liste déroulante erreur', './sample/select', {select: { id:'select-error', error: true}}, true); %>

--- a/src/component/select/example/sample/select.ejs
+++ b/src/component/select/example/sample/select.ejs
@@ -12,7 +12,7 @@
     ];
     let data = {...select, ...jsonData};
 %>
-<% if (select.group === true) { %>
+<% if (/*select.group === */true) { %>
 <%- include('../../template/ejs/select-group', {select: data}); %>
 <% }
 else { %>

--- a/src/component/select/example/sample/select.ejs
+++ b/src/component/select/example/sample/select.ejs
@@ -2,7 +2,7 @@
     let select = locals.select || {};
     let jsonData = JSON.parse(include('../../../form/example/sample/data', {form:select}));
     select.placeholder = select.placeholder || 'Selectionnez une option';
-    select.label = select.label ||  'Label pour liste déroulante'
+    select.label = select.label ||  'Label pour liste déroulante';
 
     select.options = [
         {value:'1', label:'Option 1'},
@@ -12,9 +12,5 @@
     ];
     let data = {...select, ...jsonData};
 %>
-<% if (/*select.group === */true) { %>
+
 <%- include('../../template/ejs/select-group', {select: data}); %>
-<% }
-else { %>
-<%- include('../../template/ejs/select', {select: data}); %>
-<% } %>

--- a/src/component/toggle/template/ejs/toggle.ejs
+++ b/src/component/toggle/template/ejs/toggle.ejs
@@ -41,10 +41,12 @@
   if (toggle.left !== undefined) {
     classes.push(prefix +'-toggle--label-left');
   }
+  if (toggle.disabled) inputAttr['disabled'] = '';
+  if (toggle.checked) inputAttr['checked'] = '';
 %>
 
 <div <%- includeClasses(classes)%>>
-  <input type="checkbox" class="<%= prefix %>-toggle__input" <%- includeAttrs(inputAttr)%> id="<% if(toggle.groupId){ %><%= toggle.groupId %><%= toggle.id %><% } else {%><%= toggle.id %><% } %>"<% if(toggle.disabled){ %>disabled="disabled"<%}%><% if(toggle.checked){ %>checked="true"<%}%>>
+  <input type="checkbox" class="<%= prefix %>-toggle__input" <%- includeAttrs(inputAttr)%> id="<% if(toggle.groupId){ %><%= toggle.groupId %><%= toggle.id %><% } else {%><%= toggle.id %><% } %>">
   <label class="<%= prefix %>-toggle__label" for="<% if(toggle.groupId){ %><%= toggle.groupId %><%= toggle.id %><% } else {%><%= toggle.id %><% } %>" <% if(toggle.state){ %> data-<%= prefix %>-checked-label="Activé" data-<%= prefix %>-unchecked-label="Désactivé" <% } %>><%- toggle.label %></label>
   <% if(toggle.hint){ %><p class="<%= prefix %>-hint-text" id="<%= toggle.groupId %><%= toggle.id %>-hint-text">Texte d’aide pour clarifier l’action</p><% } %>
 </div>

--- a/src/component/upload/template/ejs/upload.ejs
+++ b/src/component/upload/template/ejs/upload.ejs
@@ -15,6 +15,8 @@
 
 * upload.error (string, optional) : ajoute un texte d'erreur
 
+* upload.valid (string, optional) : ajoute un texte de succès
+
 * upload.success (string, optional) : ajoute un texte de succès
 
 * upload.multiple (boolean, optional) : Active la selection multiple de fichiers [defaut: false]
@@ -31,6 +33,7 @@
  let labelAttrs = upload.labelAttrs || {};
  let labelClass = upload.labelClasses || [];
  if (upload.error) groupClasses.push(prefix + '-input-group--error');
+ if (upload.valid) groupClasses.push(prefix + '-input-group--valid');
  if (upload.disabled) uploadAttrs['disabled'] = '';
  if (upload.multiple) uploadAttrs['multiple'] = '';
  %>
@@ -38,5 +41,5 @@
 <div <%- includeClasses(groupClasses); %>>
   <%- include('../../../form/template/ejs/label', {label : {label: upload.label, hint: upload.hint, id: upload.id, attributes: labelAttrs}}); %>
   <input <%- includeClasses(uploadClasses); %> <%- includeAttrs(uploadAttrs); %> type="file" id="<%= upload.id %>" name="<%= upload.name %>">
-  <%- include('../../../form/template/ejs/message', upload); %>
+  <%- include('../../../form/template/ejs/message', {message: upload}); %>
 </div>


### PR DESCRIPTION


ajout de fichier | manque le message d’erreur |   | OK |  
-- | -- | -- | -- | --
form | sur l’exemple ‘Ensemble de champs de saisie désactivés’<fieldset disabled=”disabled” … | passer en disabled uniquement<fieldset disabled … | OK |  
Content | valeur alt à modifier | 1<img src="/img/image.jpg" class="fr-responsive-img" alt="[À MODIFIER \| vide ou texte alternatif de l’image]" /> 2<!-- L’alternative de l’image (attribut alt) doit toujours être présent, sa valeur peut-être vide ou non selon votre contexte --> vide ou texte alternatif de l’imageL’alternative de l’image (attribut alt) doit toujours être présent, sa valeur peut-être vide ou non selon votre contexteCe sera plus vrai et plus correctEn attendant -  si pas possible rapdiment de modifier la function alt - mettre à vide | OK |  
Select | exemple disabled n’est pas “wrappé” par un bloc disabledfr-input-group--disabledle label n’est pas grisé du coup…. |   | OK |  
Toggle | disabled=”disabled” | disabled seulement | OK |  

