### PR TITLE
fix(legacy): retire les polyfills legacy du script module [DS-2304]

### DIFF
--- a/src/legacy.js
+++ b/src/legacy.js
@@ -1,4 +1,5 @@
 import api from './api.js';
+import './legacy/legacy.js';
 import './core/legacy.js';
 import './component/legacy.js';
 export default api;

--- a/src/legacy/legacy.js
+++ b/src/legacy/legacy.js
@@ -1,0 +1,2 @@
+// TODO : Supprimer ce fichier après modification du build pour ne pas charger le pck Legacy dans le script dsfr.module.js
+import './script/index';

--- a/src/legacy/main.js
+++ b/src/legacy/main.js
@@ -1,1 +1,2 @@
-import './script/index';
+// TODO : Reactiver l'import après modification du build pour ne pas charger le pck Legacy dans le script dsfr.module.js
+// import './script/index';


### PR DESCRIPTION
Quickfix pour corriger les erreurs JS sur les navigateurs modernes, en attendant de corriger le build pour ignorer le package '/legacy' au build du script 'dsfr.module.js'