### PR TITLE
fix(core): changement de taille des textes lg et xl en 18px et 20px fixe [DS-2427]

### DIFF
--- a/src/core/style/typography/setting/_text.scss
+++ b/src/core/style/typography/setting/_text.scss
@@ -46,7 +46,6 @@ $text-settings: (
   lg: (
     breakpoints: (
       first: 18,
-      md: 20,
     ),
     margin: text
   ),
@@ -54,7 +53,6 @@ $text-settings: (
     alt: lead,
     breakpoints: (
       first: 20,
-      md: 22,
     ),
     margin: text
   )


### PR DESCRIPTION
La taille des textes LG et XL ne sont désormais plus responsive : 
LG : 18px (mobile) et 20px (desktop) => devient 18px fixe
XL : 20px (mobile) et 22px (desktop) => devient 20px fixe

Classes concernées : 
- fr-text--lg
- fr-text--xl et fr-text--lead

Composants affectés : 
- callout
- highlight lg
- search lg
- button lg
- link lg