### PR TITLE
fix(icons): restore the GitHub social icon

### DIFF
--- a/src/component/follow/deprecated/example/sample/data.ejs
+++ b/src/component/follow/deprecated/example/sample/data.ejs
@@ -21,6 +21,10 @@ data.socials = {
     {
       label: "youtube",
       url: contentPlaceholder("Lien vers le youtube de l'organisation"),
+    },
+    {
+      label: "github",
+      url: contentPlaceholder("Lien vers le GitHub de l'organisation"),
     }
   ]
 };

--- a/src/component/follow/deprecated/style/_module.scss
+++ b/src/component/follow/deprecated/style/_module.scss
@@ -36,4 +36,5 @@
   @include social-deprecated-icon(instagram, instagram-fill);
   @include social-deprecated-icon(linkedin, linkedin-box-fill);
   @include social-deprecated-icon(youtube, youtube-fill);
+  @include social-deprecated-icon(github, github-fill);
 }

--- a/src/component/follow/example/sample/data.ejs
+++ b/src/component/follow/example/sample/data.ejs
@@ -31,6 +31,12 @@ data.socials = {
       type: "youtube",
       url: contentPlaceholder("Lien vers le youtube de l'organisation"),
       title: contentPlaceholder("Intitulé du lien") + " - nouvelle fenêtre",
+    },
+    {
+      label: "github",
+      type: "github",
+      url: contentPlaceholder("Lien vers le GitHub de l'organisation"),
+      title: contentPlaceholder("Intitulé du lien") + " - nouvelle fenêtre",
     }
   ]
 };

--- a/src/component/follow/style/_legacy.scss
+++ b/src/component/follow/style/_legacy.scss
@@ -19,6 +19,10 @@
         @include icon-legacy(facebook-circle-fill, md);
       }
 
+      &--github {
+        @include icon-legacy(github-fill, md);
+      }
+
       &--twitter {
         @include icon-legacy(twitter-fill);
       }

--- a/src/component/follow/style/_module.scss
+++ b/src/component/follow/style/_module.scss
@@ -161,6 +161,7 @@
   }
 
   @include social-icon(facebook, facebook-circle-fill);
+  @include social-icon(github, github-fill);
   @include social-icon(twitter, twitter-fill);
   @include social-icon(instagram, instagram-fill);
   @include social-icon(linkedin, linkedin-box-fill);

--- a/src/component/share/style/_legacy.scss
+++ b/src/component/share/style/_legacy.scss
@@ -24,6 +24,9 @@
     #{ns(btn)}--facebook {
       @include icon-legacy(facebook-circle-line, md, before);
     }
+    #{ns(btn)}--github {
+      @include icon-legacy(github-line, md, before);
+    }
     #{ns(btn)}--twitter {
       @include icon-legacy(twitter-line, md, before);
     }


### PR DESCRIPTION
L'icone GitHub est présente mais pas exposée dans la librairie.