### PR TITLE
fix(stepper): cache le détail de la dernière étape en css [DS-2446]

### DIFF
--- a/src/component/stepper/style/_module.scss
+++ b/src/component/stepper/style/_module.scss
@@ -30,6 +30,8 @@
     @include text-style(xs);
   }
 
+  @include hide-last-step-detail();
+
   &__steps {
     --default-steps: calc(var(--steps) - var(--current-step));
     --default-outer: calc((100% + 6px) / var(--default-steps));

--- a/src/component/stepper/style/_tool.scss
+++ b/src/component/stepper/style/_tool.scss
@@ -18,3 +18,16 @@
     }
   }
 }
+
+// cache le detail de la dernière étape
+@mixin hide-last-step-detail () {
+  $lastActives: ();
+
+  @for $i from 2 through map-get($stepper-settings, max-steps) {
+    $lastActives: append($lastActives, '#{ns(stepper__steps)}#{ns-attr(steps, $i)}#{ns-attr(current-step, $i)} + #{ns(stepper__details)}', $separator: comma);
+  }
+
+  #{$lastActives} {
+    display: none;
+  }
+}


### PR DESCRIPTION
utiliser fr-unhidden sur le detail pour overrider le comportement