### PR TITLE
:recycle: refactor(radio,checkbox,toggle): passage input en bleu et refactorisation [DS-2897,DS-2899, DS-2182, DS-2778, DS-3048]

### DIFF
--- a/module/color/mixin/_data-uri-svg.scss
+++ b/module/color/mixin/_data-uri-svg.scss
@@ -25,7 +25,7 @@
   $light: result.get($light-colors, $value);
   $light: specificity.important($light, $important);
 
-  @if $legacy {
+  @if $legacy and $prop != false {
     @include legacy.is(ie11) {
       #{$prop}: #{url(utilities.data-uri(string.encode-svg($light, true), svg))};
     }
@@ -41,6 +41,8 @@
       --data-uri-svg: #{url(utilities.data-uri(string.encode-svg($dark, false), svg))};
     }
 
-    #{$prop}: var(--data-uri-svg);
+    @if $prop != false {
+      #{$prop}: var(--data-uri-svg);
+    }
   }
 }

--- a/src/component/checkbox/deprecated/style/_module.scss
+++ b/src/component/checkbox/deprecated/style/_module.scss
@@ -18,3 +18,9 @@
     }
   }
 }
+
+#{ns-group(checkbox)} {
+  input[type='checkbox'] {
+    margin-top: spacing.space(3v);
+  }
+}

--- a/src/component/checkbox/index.scss
+++ b/src/component/checkbox/index.scss
@@ -7,3 +7,4 @@
 @import '../../scheme/index';
 @import '../form/index';
 @import 'style/setting';
+@import 'style/tool';

--- a/src/component/checkbox/legacy.scss
+++ b/src/component/checkbox/legacy.scss
@@ -11,5 +11,6 @@
 
 @import 'index';
 @import 'style/scheme';
+@import 'style/legacy';
 
 @include _checkbox-scheme(true);

--- a/src/component/checkbox/style/_legacy.scss
+++ b/src/component/checkbox/style/_legacy.scss
@@ -1,0 +1,15 @@
+////
+/// Checkbox legacy
+/// @group checkbox
+////
+
+@use 'module/selector';
+@use 'module/legacy';
+
+@include legacy.is(ie11) {
+  #{selector.ns(checkbox-group)} {
+    input[type="checkbox"] {
+      opacity: 1;
+    }
+  }
+}

--- a/src/component/checkbox/style/_module.scss
+++ b/src/component/checkbox/style/_module.scss
@@ -4,8 +4,9 @@
 ////
 
 @use 'module/spacing';
+@use 'module/selector';
 
-#{ns(checkbox-group)} {
+#{selector.ns(checkbox-group)} {
   @include relative;
 
   input[type="checkbox"] {
@@ -19,8 +20,9 @@
       -webkit-tap-highlight-color: transparent;
       @include display-flex(row, center, flex-start, wrap);
       @include margin-left(8v);
+      --data-uri-svg: none;
 
-      #{ns(hint-text)} {
+      #{selector.ns(hint-text)} {
         @include margin(0);
         @include size(100%);
       }
@@ -32,10 +34,10 @@
         @include absolute(0, null, null, -8v);
         @include size(6v, 6v);
         @include margin-right(2v);
-        background-size: spacing.space(4v);
-        background-position: center;
-        background-repeat: no-repeat;
         border-radius: spacing.space(1v);
+        background-size: spacing.space(1v 1v), spacing.space(calc(100% - 1v) 1px), spacing.space(1v 1v), spacing.space(1px calc(100% - 2v)), spacing.space(1v 1v), spacing.space(calc(100% - 2v) 1px), spacing.space(1v 1v), spacing.space(1px calc(100% - 2v)), spacing.space(4v);
+		    background-position: 0 0, spacing.space(1v) 0, 100% 0, 0 spacing.space(1v), 100% 100%, calc(100% - spacing.space(1v)) 100%, 0 100%, 100% spacing.space(1v), center;
+		    background-repeat: no-repeat;
         // transition: background-color 0.1s, color 0.1s;
       }
     }
@@ -70,7 +72,7 @@
     }
   }
 
-  #{ns(message)} {
+  #{selector.ns(message)} {
     &:first-child {
       @include margin-top(2v);
     }

--- a/src/component/checkbox/style/_scheme.scss
+++ b/src/component/checkbox/style/_scheme.scss
@@ -6,26 +6,15 @@
 @use 'module/color';
 @use 'module/disabled';
 
-/**
- * L'input de type checkbox avec son label est contenu dans un groupe
- * Ce groupe contient également les textes de validation, d'erreur et d'aide (optionnels)
- */
 @mixin _checkbox-scheme($legacy: false) {
   #{ns(checkbox-group)} {
-    /**
-    * On cache l'input de type checkbox pour le styler via le label
-    */
     input[type="checkbox"] {
       + label {
         @include before {
-          @include color.box-shadow(action-high grey, (legacy:$legacy));
+          @include color.box-shadow(action-high blue-france, (legacy:$legacy));
         }
       }
 
-      /**
-      * On applique les styles au pseudo élément before du label quand l'input présente
-      * un état check ou active
-      */
       &:checked,
       &:active:not(:disabled) {
         + label {
@@ -36,9 +25,6 @@
         }
       }
 
-      /**
-      * Mixins pour appliquer les styles correspondant au focus ainsi qu'à l'état disabled
-      */
       @include disabled.selector {
         & + label {
           @include before {
@@ -57,12 +43,13 @@
       }
     }
 
-    /**
-    * Modificateur pour gérer l'état erreur
-    */
     &--error {
       input[type="checkbox"] + label {
         @include color.text(default error, (legacy:$legacy));
+
+        @include before {
+          @include color.box-shadow(border plain error, (legacy:$legacy));
+        }
       }
 
       @include before {
@@ -70,16 +57,43 @@
       }
     }
 
-    /**
-    * Modificateur pour gérer l'état validé
-    */
     &--valid {
       input[type="checkbox"] + label {
         @include color.text(default success, (legacy:$legacy));
+
+        @include before {
+          @include color.box-shadow(border plain success, (legacy:$legacy));
+        }
       }
 
       @include before {
         @include color.box-shadow(plain success, (legacy:$legacy), left-2-in);
+      }
+    }
+  }
+
+  #{ns(fieldset)} {
+    &--error {
+      #{ns(checkbox-group)} {
+        input[type="checkbox"] {
+          + label {
+            @include before {
+              @include color.box-shadow(border plain error, (legacy:$legacy));
+            }
+          }
+        }
+      }
+    }
+
+    &--valid {
+      #{ns(checkbox-group)} {
+        input[type="checkbox"] {
+          + label {
+            @include before {
+              @include color.box-shadow(border plain success, (legacy:$legacy));
+            }
+          }
+        }
       }
     }
   }

--- a/src/component/checkbox/style/_scheme.scss
+++ b/src/component/checkbox/style/_scheme.scss
@@ -15,8 +15,7 @@
         }
       }
 
-      &:checked,
-      &:active:not(:disabled) {
+      &:checked {
         + label {
           @include before {
             @include color.background(active blue-france, (legacy:$legacy));

--- a/src/component/checkbox/style/_scheme.scss
+++ b/src/component/checkbox/style/_scheme.scss
@@ -5,21 +5,22 @@
 
 @use 'module/color';
 @use 'module/disabled';
+@use 'module/selector';
 
 @mixin _checkbox-scheme($legacy: false) {
-  #{ns(checkbox-group)} {
+  #{selector.ns(checkbox-group)} {
     input[type="checkbox"] {
       + label {
         @include before {
-          @include color.box-shadow(action-high blue-france, (legacy:$legacy));
+          @include color.background-image(border action-high blue-france, (), checkbox-background-image());
         }
       }
 
       &:checked {
         + label {
           @include before {
-            @include color.background(active blue-france, (legacy:$legacy));
-            @include color.data-uri-svg(inverted grey, (legacy: $legacy), $checkbox-svg);
+            @include color.background(active blue-france);
+            @include color.data-uri-svg(inverted grey, (), $checkbox-svg, false);
           }
         }
       }
@@ -27,15 +28,16 @@
       @include disabled.selector {
         & + label {
           @include before {
-            @include disabled.colors((legacy: $legacy, box-shadow: true));
+            @include disabled.colors();
+            @include color.background-image(disabled grey, (), checkbox-background-image());
           }
         }
 
         &:checked {
           & + label {
             @include before {
-              @include disabled.colors((legacy: $legacy, text: true, background: true));
-              @include color.data-uri-svg(text disabled grey, (legacy: $legacy), $checkbox-svg);
+              @include disabled.colors((background: true));
+              @include color.data-uri-svg(text disabled grey, (), $checkbox-svg, false);
             }
           }
         }
@@ -47,12 +49,12 @@
         @include color.text(default error, (legacy:$legacy));
 
         @include before {
-          @include color.box-shadow(border plain error, (legacy:$legacy));
+          @include color.background-image(border plain error, (), checkbox-background-image());
         }
       }
 
       @include before {
-        @include color.box-shadow(plain error, (legacy:$legacy), left-2-in);
+        @include color.background(border plain error, (legacy:$legacy));
       }
     }
 
@@ -61,23 +63,23 @@
         @include color.text(default success, (legacy:$legacy));
 
         @include before {
-          @include color.box-shadow(border plain success, (legacy:$legacy));
+          @include color.background-image(border plain success, (), checkbox-background-image());
         }
       }
 
       @include before {
-        @include color.box-shadow(plain success, (legacy:$legacy), left-2-in);
+        @include color.background(border plain success, (legacy:$legacy));
       }
     }
   }
 
-  #{ns(fieldset)} {
+  #{selector.ns(fieldset)} {
     &--error {
-      #{ns(checkbox-group)} {
+      #{selector.ns(checkbox-group)} {
         input[type="checkbox"] {
           + label {
             @include before {
-              @include color.box-shadow(border plain error, (legacy:$legacy));
+              @include color.background-image(border plain error, (), checkbox-background-image());
             }
           }
         }
@@ -85,11 +87,11 @@
     }
 
     &--valid {
-      #{ns(checkbox-group)} {
+      #{selector.ns(checkbox-group)} {
         input[type="checkbox"] {
           + label {
             @include before {
-              @include color.box-shadow(border plain success, (legacy:$legacy));
+              @include color.background-image(border plain success, (), checkbox-background-image());
             }
           }
         }

--- a/src/component/checkbox/style/_tool.scss
+++ b/src/component/checkbox/style/_tool.scss
@@ -1,0 +1,9 @@
+////
+/// Radio Tool
+/// @group radio
+////
+
+@function checkbox-background-image() {
+  $data: 'radial-gradient(at 5px 4px, transparent 4px, $COLOR 4px, $COLOR 5px, transparent 6px), linear-gradient($COLOR, $COLOR), radial-gradient(at calc(100% - 5px) 4px, transparent 4px, $COLOR 4px, $COLOR 5px, transparent 6px), linear-gradient($COLOR, $COLOR), radial-gradient(at calc(100% - 5px) calc(100% - 4px), transparent 4px, $COLOR 4px, $COLOR 5px, transparent 6px), linear-gradient($COLOR, $COLOR), radial-gradient(at 5px calc(100% - 4px), transparent 4px, $COLOR 4px, $COLOR 5px, transparent 6px), linear-gradient($COLOR, $COLOR), var(--data-uri-svg)';
+  @return $data;
+}

--- a/src/component/form/style/_scheme.scss
+++ b/src/component/form/style/_scheme.scss
@@ -88,7 +88,8 @@
     input {
       @include disabled.selector {
         + label,
-        + label #{ns(hint-text)} {
+        + label #{ns(hint-text)},
+        + label + #{ns(hint-text)} {
           @include disabled.colors((legacy: $legacy, text: true));
         }
       }

--- a/src/component/form/style/_scheme.scss
+++ b/src/component/form/style/_scheme.scss
@@ -27,7 +27,8 @@
     }
 
     &--disabled {
-      label {
+      label,
+      #{ns(hint-text)} {
         @include disabled.colors((legacy: $legacy, text: true));
       }
     }
@@ -78,8 +79,18 @@
   #{ns(fieldset)} {
     @include disabled.selector {
       #{ns(label)},
+      #{ns(hint-text)},
       #{ns(fieldset__legend)} {
         @include disabled.colors((legacy: $legacy, text: true));
+      }
+    }
+
+    input {
+      @include disabled.selector {
+        + label,
+        + label #{ns(hint-text)} {
+          @include disabled.colors((legacy: $legacy, text: true));
+        }
       }
     }
 

--- a/src/component/radio/deprecated/style/_module.scss
+++ b/src/component/radio/deprecated/style/_module.scss
@@ -2,12 +2,18 @@
 
 #{ns(fieldset)} {
   #{ns(fieldset__content)} {
-    #{ns-group(radio)} {
-      &--sm {
-        label {
-          &::before {
-            @include margin-top(4v);
-          }
+    #{ns-group(radio)}:not(#{ns(radio-rich)}) {
+      input[type="radio"] {
+        + label {
+          background-position: calc(-#{space(1v)} + 1px) calc(#{space(2v)} + 1px), calc(-#{space(1v)} + 1px) calc(#{space(2v)} + 1px);
+        }
+      }
+    }
+
+    #{ns-group(radio)}--sm:not(#{ns(radio-rich)}) {
+      input[type="radio"] {
+        + label {
+          background-position: calc(-#{space(0.5v)} + 1px) calc(#{space(4v)} - 1px), calc(-#{space(0.5v)} + 1px) calc(#{space(4v)} - 1px);
         }
       }
     }

--- a/src/component/radio/deprecated/style/_module.scss
+++ b/src/component/radio/deprecated/style/_module.scss
@@ -5,7 +5,7 @@
     #{ns-group(radio)}:not(#{ns(radio-rich)}) {
       input[type="radio"] {
         + label {
-          background-position: calc(-#{space(1v)} + 1px) calc(#{space(2v)} + 1px), calc(-#{space(1v)} + 1px) calc(#{space(2v)} + 1px);
+          background-position: calc(#{space(-1v)} + 1px) calc(#{space(2v)} + 1px), calc(#{space(-1v)} + 1px) calc(#{space(2v)} + 1px);
         }
       }
     }
@@ -13,7 +13,7 @@
     #{ns-group(radio)}--sm:not(#{ns(radio-rich)}) {
       input[type="radio"] {
         + label {
-          background-position: calc(-#{space(0.5v)} + 1px) calc(#{space(4v)} - 1px), calc(-#{space(0.5v)} + 1px) calc(#{space(4v)} - 1px);
+          background-position: calc(#{space(-0.5v)} + 1px) calc(#{space(4v)} - 1px), calc(#{space(-0.5v)} + 1px) calc(#{space(4v)} - 1px);
         }
       }
     }

--- a/src/component/radio/style/_tool.scss
+++ b/src/component/radio/style/_tool.scss
@@ -21,8 +21,5 @@
 }
 
 @function radio-rich-background-image($checked: true) {
-    @return 'linear-gradient(0deg, $color#3, $color#3), linear-gradient(0deg, $color#3, $color#3), linear-gradient(0deg, $color#3, $color#3), linear-gradient(0deg, $color#3, $color#3), #{radio-background-image($checked, sm)}';
+  @return 'linear-gradient(0deg, $color#3, $color#3), linear-gradient(0deg, $color#3, $color#3), linear-gradient(0deg, $color#3, $color#3), linear-gradient(0deg, $color#3, $color#3), #{radio-background-image($checked, sm)}';
 }
-
-
-

--- a/src/component/radio/style/_tool.scss
+++ b/src/component/radio/style/_tool.scss
@@ -3,17 +3,26 @@
 /// @group radio
 ////
 
-@function radio-box-shadow ($checked: true, $size: md) {
+@use 'sass:math';
+
+@function radio-background-image($checked: true, $size: md) {
   $max: 12;
   @if $size == sm {
     $max: 8;
   }
 
-  $out: $max * 0.5;
-
-  @if not $checked {
-    $out: $max;
+  @if $checked {
+    $in: $max * 0.5;
+    @return 'radial-gradient(transparent #{$max - 2}px, $color#1 #{$max - 1}px, transparent #{$max}px), radial-gradient($color#2 #{$in - 1}px, transparent #{$in}px)';
   }
-
-  @return all-1-in all-#{$out}-in all-#{$max}-in;
+  @else {
+    @return 'radial-gradient(transparent #{$max - 2}px, $color#1 #{$max - 1}px, transparent #{$max}px)';
+  }
 }
+
+@function radio-rich-background-image($checked: true) {
+    @return 'linear-gradient(0deg, $color#3, $color#3), linear-gradient(0deg, $color#3, $color#3), linear-gradient(0deg, $color#3, $color#3), linear-gradient(0deg, $color#3, $color#3), #{radio-background-image($checked, sm)}';
+}
+
+
+

--- a/src/component/radio/style/module/_default.scss
+++ b/src/component/radio/style/module/_default.scss
@@ -16,19 +16,22 @@
       @include relative;
       -webkit-tap-highlight-color: transparent;
       @include display-flex(row, center, flex-start, wrap);
-      @include margin-left(8v);
+      @include padding-left(8v);
+      background-position: calc(-#{space(1v)} + 1px) calc(-#{space(1v)} + 1px), calc(-#{space(1v)} + 1px) calc(-#{space(1v)} + 1px);
+      background-size: #{space(7.5v)} #{space(7.5v)}, #{space(7.5v)} #{space(7.5v)};
+      background-repeat: no-repeat, no-repeat;
+
+      // empty efore for the focus
+      @include before('') {
+        @include size(6v, 6v);
+        @include absolute;
+        border-radius: #{space(6v)};
+        @include margin-left(-8v);
+      }
 
       #{ns(hint-text)} {
         @include margin(0);
         @include size(100%);
-      }
-
-      @include before('', inline-block) {
-        @include absolute(0, null, null, -8v);
-        @include size(6v, 6v);
-        @include margin-right(2v);
-        border-radius: 50%;
-        // transition: box-shadow 0.3s;
       }
     }
   }

--- a/src/component/radio/style/module/_default.scss
+++ b/src/component/radio/style/module/_default.scss
@@ -3,7 +3,10 @@
 /// @group radio
 ////
 
-#{ns-group(radio)} {
+@use 'module/spacing';
+@use 'module/selector';
+
+#{selector.ns-group(radio)} {
   @include relative;
 
   input[type="radio"] {
@@ -17,19 +20,19 @@
       -webkit-tap-highlight-color: transparent;
       @include display-flex(row, center, flex-start, wrap);
       @include padding-left(8v);
-      background-position: calc(#{space(-1v)} + 1px) calc(#{space(-1v)} + 1px), calc(#{space(-1v)} + 1px) calc(#{space(-1v)} + 1px);
-      background-size: #{space(7.5v)} #{space(7.5v)}, #{space(7.5v)} #{space(7.5v)};
+      background-position: calc(#{spacing.space(-1v)} + 1px) calc(#{spacing.space(-1v)} + 1px), calc(#{spacing.space(-1v)} + 1px) calc(#{spacing.space(-1v)} + 1px);
+      background-size: #{spacing.space(7.5v)} #{spacing.space(7.5v)}, #{spacing.space(7.5v)} #{spacing.space(7.5v)};
       background-repeat: no-repeat, no-repeat;
 
-      // empty efore for the focus
+      // empty before for the focus
       @include before('') {
         @include size(6v, 6v);
-        @include absolute;
-        border-radius: #{space(6v)};
+        @include absolute(0);
+        border-radius: #{spacing.space(6v)};
         @include margin-left(-8v);
       }
 
-      #{ns(hint-text)} {
+      #{selector.ns(hint-text)} {
         @include margin(0);
         @include size(100%);
       }

--- a/src/component/radio/style/module/_default.scss
+++ b/src/component/radio/style/module/_default.scss
@@ -17,7 +17,7 @@
       -webkit-tap-highlight-color: transparent;
       @include display-flex(row, center, flex-start, wrap);
       @include padding-left(8v);
-      background-position: calc(-#{space(1v)} + 1px) calc(-#{space(1v)} + 1px), calc(-#{space(1v)} + 1px) calc(-#{space(1v)} + 1px);
+      background-position: calc(#{space(-1v)} + 1px) calc(#{space(-1v)} + 1px), calc(#{space(-1v)} + 1px) calc(#{space(-1v)} + 1px);
       background-size: #{space(7.5v)} #{space(7.5v)}, #{space(7.5v)} #{space(7.5v)};
       background-repeat: no-repeat, no-repeat;
 

--- a/src/component/radio/style/module/_rich.scss
+++ b/src/component/radio/style/module/_rich.scss
@@ -4,8 +4,9 @@
 ////
 
 @use 'module/spacing';
+@use 'module/selector';
 
-#{ns(radio-rich)} {
+#{selector.ns(radio-rich)} {
   @include relative;
 
   input[type="radio"] {
@@ -25,15 +26,17 @@
       background-size: 100% 1px, 1px 100%, 100% 1px, 1px 100%, #{space(4.5v)} #{space(4.5v)}, #{space(4.5v)} #{space(4.5v)};
       background-repeat: no-repeat, no-repeat, no-repeat, no-repeat, no-repeat, no-repeat;
       background-position: 0 0, 100% 0, 0 100%, 0 0, #{space(7v)} 50%, #{space(7v) 50%};
+      // retire le focus sur l'input
+      @include before(none);
 
-      #{ns(hint-text)} {
+      #{selector.ns(hint-text)} {
         @include margin-left(0);
       }
     }
 
     &:disabled,
     &[disabled] {
-      ~ #{ns(radio-rich__img)} {
+      ~ #{selector.ns(radio-rich__img)} {
         filter: grayscale(1);
       }
     }
@@ -43,7 +46,7 @@
       @include enable-tint;
     }
 
-    @include hover-brighten('&:not(:disabled) ~ label', '~ #{ns(radio-rich__img)}');
+    @include hover-brighten('&:not(:disabled) ~ label', '~ #{selector.ns(radio-rich__img)}');
   }
 
   &__img {
@@ -62,8 +65,8 @@
   }
 }
 
-#{ns(control)} {
-  > #{ns(radio-rich)}#{ns-group(radio)} {
+#{selector.ns(control)} {
+  > #{selector.ns(radio-rich)}#{selector.ns-group(radio)} {
     @include margin-y(0);
   }
 }

--- a/src/component/radio/style/module/_rich.scss
+++ b/src/component/radio/style/module/_rich.scss
@@ -20,14 +20,11 @@
       @include size(100%);
       @include padding-top(2v);
       @include padding-bottom(2v);
-      @include padding-right(26v);
-      @include display-flex(column, flex-start, center);
-
-      @include before {
-        @include size(4v, 4v);
-        @include absolute(50%, null, null, 7v);
-        @include margin-top(-2v);
-      }
+      @include padding-right(6v);
+      @include display-flex(column, stretch, center);
+      background-size: 100% 1px, 1px 100%, 100% 1px, 1px 100%, #{space(4.5v)} #{space(4.5v)}, #{space(4.5v)} #{space(4.5v)};
+      background-repeat: no-repeat, no-repeat, no-repeat, no-repeat, no-repeat, no-repeat;
+      background-position: 0 0, 100% 0, 0 100%, 0 0, #{space(7v)} 50%, #{space(7v) 50%};
 
       #{ns(hint-text)} {
         @include margin-left(0);

--- a/src/component/radio/style/module/_sm.scss
+++ b/src/component/radio/style/module/_sm.scss
@@ -9,12 +9,14 @@
     top: #{space(1v)};
 
     & + label {
-      @include margin-left(6v);
+      @include padding-left(6v);
+      background-position: calc(-#{space(0.5v)} + 1px) calc(#{space(1v)} - 1px), calc(-#{space(0.5v)} + 1px) calc(#{space(1v)} - 1px);
+      background-size: #{space(4.5v)} #{space(4.5v)}, #{space(4.5v)} #{space(4.5v)};
 
       @include before {
-        left: #{space(-6v)};
         @include size(4v, 4v);
-        @include margin-top(1v);
+        border-radius: #{space(4v)};
+        @include margin-left(-6v);
       }
     }
   }

--- a/src/component/radio/style/module/_sm.scss
+++ b/src/component/radio/style/module/_sm.scss
@@ -10,7 +10,7 @@
 
     & + label {
       @include padding-left(6v);
-      background-position: calc(-#{space(0.5v)} + 1px) calc(#{space(1v)} - 1px), calc(-#{space(0.5v)} + 1px) calc(#{space(1v)} - 1px);
+      background-position: calc(#{space(-0.5v)} + 1px) calc(#{space(1v)} - 1px), calc(#{space(-0.5v)} + 1px) calc(#{space(1v)} - 1px);
       background-size: #{space(4.5v)} #{space(4.5v)}, #{space(4.5v)} #{space(4.5v)};
 
       @include before {

--- a/src/component/radio/style/module/_sm.scss
+++ b/src/component/radio/style/module/_sm.scss
@@ -3,19 +3,23 @@
 /// @group radio
 ////
 
-#{ns-group(radio)}--sm {
+@use 'module/spacing';
+@use 'module/selector';
+
+#{selector.ns-group(radio)}--sm {
   input[type="radio"] {
     @include size(4v, 4v);
-    top: #{space(1v)};
+    top: #{spacing.space(1v)};
 
     & + label {
       @include padding-left(6v);
-      background-position: calc(#{space(-0.5v)} + 1px) calc(#{space(1v)} - 1px), calc(#{space(-0.5v)} + 1px) calc(#{space(1v)} - 1px);
-      background-size: #{space(4.5v)} #{space(4.5v)}, #{space(4.5v)} #{space(4.5v)};
+      background-position: calc(#{spacing.space(-0.5v)} + 1px) calc(#{spacing.space(1v)} - 1px), calc(#{spacing.space(-0.5v)} + 1px) calc(#{spacing.space(1v)} - 1px);
+      background-size: #{spacing.space(4.5v)} #{spacing.space(4.5v)}, #{spacing.space(4.5v)} #{spacing.space(4.5v)};
 
       @include before {
+        top: #{spacing.space(1v)};
         @include size(4v, 4v);
-        border-radius: #{space(4v)};
+        border-radius: #{spacing.space(4v)};
         @include margin-left(-6v);
       }
     }

--- a/src/component/radio/style/scheme/_default.scss
+++ b/src/component/radio/style/scheme/_default.scss
@@ -82,6 +82,7 @@
           & + label {
             @include color.background-image((disabled grey), (legacy:$legacy), radio-background-image(false));
           }
+
           &:checked + label {
             @include color.background-image((disabled grey) (disabled grey), (legacy:$legacy), radio-background-image(true));
           }

--- a/src/component/radio/style/scheme/_default.scss
+++ b/src/component/radio/style/scheme/_default.scss
@@ -10,31 +10,80 @@
   #{ns-group(radio)} {
     input[type="radio"] {
       & + label {
-        @include before {
-          @include color.box-shadow((action-high grey) (background default grey) (background action-high blue-france), (legacy:$legacy), radio-box-shadow(false));
-        }
+        @include color.background-image((action-high blue-france), (legacy:$legacy), radio-background-image(false));
       }
 
       @include disabled.selector {
         + label {
-          @include before {
-            @include color.box-shadow((disabled grey) (background default grey) (text disabled grey), (legacy:$legacy), radio-box-shadow(false));
-          }
+          @include color.background-image((disabled grey), (legacy:$legacy), radio-background-image(false));
         }
       }
 
       &:checked {
         + label {
-          @include before {
-            @include color.box-shadow((action-high grey) (background default grey) (background action-high blue-france), (legacy:$legacy), radio-box-shadow(true));
-          }
+          @include color.background-image((action-high blue-france) (action-high blue-france), (legacy:$legacy), radio-background-image(true));
         }
 
         @include disabled.selector {
           + label {
-            @include before {
-              @include color.box-shadow((disabled grey) (background default grey) (text disabled grey), (legacy:$legacy), radio-box-shadow(true));
-            }
+            @include color.background-image((disabled grey) (disabled grey), (legacy:$legacy), radio-background-image(true));
+          }
+        }
+      }
+    }
+  }
+
+  #{ns(fieldset)} {
+    &--error {
+      #{ns-group(radio)} {
+        input[type="radio"] {
+          & + label {
+            @include color.background-image((border plain error), (legacy:$legacy), radio-background-image(false));
+          }
+
+          &:checked + label {
+            @include color.background-image((border plain error) (action-high blue-france), (legacy:$legacy), radio-background-image(true));
+          }
+        }
+      }
+    }
+
+    &--valid {
+      #{ns-group(radio)} {
+        input[type="radio"] {
+          & + label {
+            @include color.background-image((border plain success), (legacy:$legacy), radio-background-image(false));
+          }
+
+          &:checked + label {
+            @include color.background-image((border plain success) (action-high blue-france), (legacy:$legacy), radio-background-image(true));
+          }
+        }
+      }
+    }
+
+    &--info {
+      #{ns-group(radio)} {
+        input[type="radio"] {
+          & + label {
+            @include color.background-image((border plain info), (legacy:$legacy), radio-background-image(false));
+          }
+
+          &:checked + label {
+            @include color.background-image((border plain info) (action-high blue-france), (legacy:$legacy), radio-background-image(true));
+          }
+        }
+      }
+    }
+
+    @include disabled.selector {
+      #{ns-group(radio)} {
+        input[type="radio"] {
+          & + label {
+            @include color.background-image((disabled grey), (legacy:$legacy), radio-background-image(false));
+          }
+          &:checked + label {
+            @include color.background-image((disabled grey) (disabled grey), (legacy:$legacy), radio-background-image(true));
           }
         }
       }

--- a/src/component/radio/style/scheme/_default.scss
+++ b/src/component/radio/style/scheme/_default.scss
@@ -5,9 +5,10 @@
 
 @use 'module/color';
 @use 'module/disabled';
+@use 'module/selector';
 
 @mixin _radio-scheme-md($legacy: false) {
-  #{ns-group(radio)} {
+  #{selector.ns-group(radio)} {
     input[type="radio"] {
       & + label {
         @include color.background-image((action-high blue-france), (legacy:$legacy), radio-background-image(false));
@@ -33,9 +34,9 @@
     }
   }
 
-  #{ns(fieldset)} {
+  #{selector.ns(fieldset)} {
     &--error {
-      #{ns-group(radio)} {
+      #{selector.ns-group(radio)} {
         input[type="radio"] {
           & + label {
             @include color.background-image((border plain error), (legacy:$legacy), radio-background-image(false));
@@ -49,7 +50,7 @@
     }
 
     &--valid {
-      #{ns-group(radio)} {
+      #{selector.ns-group(radio)} {
         input[type="radio"] {
           & + label {
             @include color.background-image((border plain success), (legacy:$legacy), radio-background-image(false));
@@ -63,7 +64,7 @@
     }
 
     &--info {
-      #{ns-group(radio)} {
+      #{selector.ns-group(radio)} {
         input[type="radio"] {
           & + label {
             @include color.background-image((border plain info), (legacy:$legacy), radio-background-image(false));
@@ -76,9 +77,9 @@
       }
     }
 
-    @include disabled.selector {
-      #{ns-group(radio)} {
-        input[type="radio"] {
+    & #{selector.ns-group(radio)} {
+      input[type="radio"] {
+        @include disabled.selector {
           & + label {
             @include color.background-image((disabled grey), (legacy:$legacy), radio-background-image(false));
           }

--- a/src/component/radio/style/scheme/_rich.scss
+++ b/src/component/radio/style/scheme/_rich.scss
@@ -88,9 +88,9 @@
       }
     }
 
-    @include disabled.selector {
-      #{ns(radio-rich)} {
-        input[type="radio"] {
+    #{ns(radio-rich)} {
+      input[type="radio"] {
+        @include disabled.selector {
           & + label {
             @include color.background-image((disabled grey) (disabled grey) (border default grey), (legacy: $legacy), '#{radio-rich-background-image(false)}');
           }

--- a/src/component/radio/style/scheme/_rich.scss
+++ b/src/component/radio/style/scheme/_rich.scss
@@ -5,6 +5,7 @@
 
 @use 'module/color';
 @use 'module/disabled';
+@use 'module/selector';
 
 @mixin _radio-scheme-rich($legacy: false) {
   #{ns(radio-rich)} {

--- a/src/component/radio/style/scheme/_rich.scss
+++ b/src/component/radio/style/scheme/_rich.scss
@@ -14,37 +14,88 @@
 
     input[type="radio"] {
       + label {
-        @include color.box-shadow(default grey, (legacy:$legacy), all-1-in);
-        @include color.background(default grey, (legacy:$legacy));
-
-        @include before {
-          @include color.box-shadow((action-high grey) (background default grey) (background action-high blue-france), (legacy:$legacy), radio-box-shadow(false, sm));
-        }
+        @include color.background-image((action-high blue-france) (action-high blue-france) (border default grey), (legacy: $legacy), '#{radio-rich-background-image(false)}');
+        @include color.background((background default grey), (legacy: $legacy));
       }
 
       @include disabled.selector {
         + label {
-          @include before {
-            @include color.box-shadow((disabled grey) (background default grey) (text disabled grey), (legacy:$legacy), radio-box-shadow(false, sm));
+          @include color.background-image((disabled grey) (disabled grey) (border default grey), (legacy: $legacy), '#{radio-rich-background-image(false)}');
+        }
+
+        ~ #{selector.ns(radio-rich__pictogram)} {
+          svg * {
+            @include color.fill(text disabled grey, (legacy: $legacy));
           }
         }
       }
 
       &:checked {
         + label {
-          @include color.box-shadow(action-high blue-france, (legacy:$legacy), all-1-in);
-
-          @include before {
-            @include color.box-shadow((action-high grey) (background default grey) (background action-high blue-france), (legacy:$legacy), radio-box-shadow(true, sm));
-          }
+          @include color.background-image((action-high blue-france) (action-high blue-france) (action-high blue-france), (legacy: $legacy), '#{radio-rich-background-image(true)}');
         }
 
         @include disabled.selector {
           + label {
-            @include color.box-shadow(text disabled grey, (legacy:$legacy), all-1-in);
-            @include before {
-              @include color.box-shadow((disabled grey) (background default grey) (text disabled grey), (legacy:$legacy), radio-box-shadow(true, sm));
-            }
+            @include color.background-image((disabled grey) (disabled grey) (text disabled grey), (legacy: $legacy), '#{radio-rich-background-image(true)}');
+          }
+        }
+      }
+    }
+  }
+
+  #{ns(fieldset)} {
+    &--error {
+      #{ns(radio-rich)} {
+        input[type="radio"] {
+          & + label {
+            @include color.background-image((border plain error) (action-high blue-france) (border default grey), (legacy: $legacy), '#{radio-rich-background-image(false)}');
+          }
+
+          &:checked + label {
+            @include color.background-image((border plain error) (action-high blue-france) (action-high blue-france), (legacy: $legacy), '#{radio-rich-background-image(true)}');
+          }
+        }
+      }
+    }
+
+    &--valid {
+      #{ns(radio-rich)} {
+        input[type="radio"] {
+          & + label {
+            @include color.background-image((border plain success) (action-high blue-france) (border default grey), (legacy: $legacy), '#{radio-rich-background-image(false)}');
+          }
+
+          &:checked + label {
+            @include color.background-image((border plain success) (action-high blue-france) (action-high blue-france), (legacy: $legacy), '#{radio-rich-background-image(true)}');
+          }
+        }
+      }
+    }
+
+    &--info {
+      #{ns(radio-rich)} {
+        input[type="radio"] {
+          & + label {
+            @include color.background-image((border plain info) (action-high blue-france) (border default grey), (legacy: $legacy), '#{radio-rich-background-image(false)}');
+          }
+
+          &:checked + label {
+            @include color.background-image((border plain info) (action-high blue-france) (action-high blue-france), (legacy: $legacy), '#{radio-rich-background-image(true)}');
+          }
+        }
+      }
+    }
+
+    @include disabled.selector {
+      #{ns(radio-rich)} {
+        input[type="radio"] {
+          & + label {
+            @include color.background-image((disabled grey) (disabled grey) (border default grey), (legacy: $legacy), '#{radio-rich-background-image(false)}');
+          }
+
+          &:checked + label {
+            @include color.background-image((disabled grey) (disabled grey) (border default grey), (legacy: $legacy), '#{radio-rich-background-image(true)}');
           }
         }
       }

--- a/src/component/radio/style/scheme/_sm.scss
+++ b/src/component/radio/style/scheme/_sm.scss
@@ -82,6 +82,7 @@
           & + label {
             @include color.background-image((disabled grey), (legacy:$legacy), radio-background-image(false, sm));
           }
+
           &:checked + label {
             @include color.background-image((disabled grey) (disabled grey), (legacy:$legacy), radio-background-image(true, sm));
           }

--- a/src/component/radio/style/scheme/_sm.scss
+++ b/src/component/radio/style/scheme/_sm.scss
@@ -10,31 +10,80 @@
   #{ns-group(radio)}--sm {
     input[type="radio"] {
       + label {
-        @include before {
-          @include color.box-shadow((action-high grey) (background default grey) (background action-high blue-france), (legacy:$legacy), radio-box-shadow(false, sm));
-        }
+        @include color.background-image((action-high blue-france), (legacy:$legacy), radio-background-image(false, sm));
       }
 
       @include disabled.selector() {
         + label {
-          @include before {
-            @include color.box-shadow((disabled grey) (background disabled grey) (text disabled grey), (legacy:$legacy), radio-box-shadow(false, sm));
-          }
+          @include color.background-image((disabled grey), (legacy:$legacy), radio-background-image(false, sm));
         }
       }
 
       &:checked {
         + label {
-          @include before {
-            @include color.box-shadow((action-high grey) (background default grey) (background action-high blue-france), (legacy:$legacy), radio-box-shadow(true, sm));
-          }
+          @include color.background-image((action-high blue-france) (action-high blue-france), (legacy:$legacy), radio-background-image(true, sm));
         }
 
         @include disabled.selector {
           + label {
-            @include before {
-              @include color.box-shadow((disabled grey) (background disabled grey) (text disabled grey), (legacy:$legacy), radio-box-shadow(true, sm));
-            }
+            @include color.background-image((disabled grey), (legacy:$legacy), radio-background-image(true, sm));
+          }
+        }
+      }
+    }
+  }
+
+  #{ns(fieldset)} {
+    &--error {
+      #{ns-group(radio)}--sm {
+        input[type="radio"] {
+          & + label {
+            @include color.background-image((border plain error), (legacy:$legacy), radio-background-image(false, sm));
+          }
+
+          &:checked + label {
+            @include color.background-image((border plain error, action-high blue-france), (legacy:$legacy), radio-background-image(true, sm));
+          }
+        }
+      }
+    }
+
+    &--valid {
+      #{ns-group(radio)}--sm {
+        input[type="radio"] {
+          & + label {
+            @include color.background-image((border plain success), (legacy:$legacy), radio-background-image(false, sm));
+          }
+
+          &:checked + label {
+            @include color.background-image((border plain success) (action-high blue-france), (legacy:$legacy), radio-background-image(true, sm));
+          }
+        }
+      }
+    }
+
+    &--info {
+      #{ns-group(radio)}--sm {
+        input[type="radio"] {
+          & + label {
+            @include color.background-image((border plain info), (legacy:$legacy), radio-background-image(false, sm));
+          }
+
+          &:checked + label {
+            @include color.background-image((border plain info) (action-high blue-france), (legacy:$legacy), radio-background-image(true, sm));
+          }
+        }
+      }
+    }
+
+    @include disabled.selector {
+      #{ns-group(radio)}--sm {
+        input[type="radio"] {
+          & + label {
+            @include color.background-image((disabled grey), (legacy:$legacy), radio-background-image(false, sm));
+          }
+          &:checked + label {
+            @include color.background-image((disabled grey) (disabled grey), (legacy:$legacy), radio-background-image(true, sm));
           }
         }
       }

--- a/src/component/radio/style/scheme/_sm.scss
+++ b/src/component/radio/style/scheme/_sm.scss
@@ -76,9 +76,9 @@
       }
     }
 
-    @include disabled.selector {
-      #{ns-group(radio)}--sm {
-        input[type="radio"] {
+    #{ns-group(radio)}--sm {
+      input[type="radio"] {
+        @include disabled.selector {
           & + label {
             @include color.background-image((disabled grey), (legacy:$legacy), radio-background-image(false, sm));
           }

--- a/src/component/toggle/example/index.ejs
+++ b/src/component/toggle/example/index.ejs
@@ -18,13 +18,27 @@
 
 <%- sample('Toggle simple disabled et pré-coché avec bouton + label à droite + état', './sample/toggle-default.ejs', {toggle: {state: true, disabled: true, checked:true}}, true, './layout'); %>
 
-<%- sample('Groupe de toggles simple avec bouton + label à droite + séparateur', './sample/toggle-group.ejs', {toggle: {border:true, groupId: 'group-1-'}}, true, './layout'); %>
+<%- sample('Toggle simple en erreur', './sample/toggle-default.ejs', {toggle: {state: false, error: true}}, true, './layout'); %>
 
-<%- sample('Groupe de toggles simple avec bouton + label à droite + séparateur + texte d’aide', './sample/toggle-group.ejs', {toggle: {border:true, groupId: 'group-1-', hint: true}}, true, './layout'); %>
+<%- sample('Toggle avec état - en erreur', './sample/toggle-default.ejs', {toggle: {state: true, error: true}}, true, './layout'); %>
 
-<%- sample('Groupe de toggles simple avec bouton + label à droite + état + séparateur', './sample/toggle-group.ejs', {toggle: {border: true, state: true, groupId: 'group-2-'}}, true, './layout'); %>
+<%- sample('Toggle simple valide', './sample/toggle-default.ejs', {toggle: {state: false, valid: true}}, true, './layout'); %>
 
-<%- sample('Groupe de toggles simple avec bouton + label à droite + état + séparateur + texte d’aide', './sample/toggle-group.ejs', {toggle: {border: true, state: true, groupId: 'group-2-', hint: true}}, true, './layout'); %>
+<%- sample('Toggle avec état - valide', './sample/toggle-default.ejs', {toggle: {state: true, valid: true}}, true, './layout'); %>
+
+<%- sample('Groupe de toggles simple avec bouton + label à droite', './sample/toggle-group.ejs', {toggle: {groupId: 'group-1-'}}, true, './layout'); %>
+
+<%- sample('Groupe de toggles simple avec bouton + label à droite + séparateur', './sample/toggle-group.ejs', {toggle: {border:true, groupId: 'group-2-'}}, true, './layout'); %>
+
+<%- sample('Groupe de toggles simple avec bouton + label à droite + séparateur + texte d’aide', './sample/toggle-group.ejs', {toggle: {border:true, groupId: 'group-3-', hint: true}}, true, './layout'); %>
+
+<%- sample('Groupe de toggles simple avec bouton + label à droite + état + séparateur', './sample/toggle-group.ejs', {toggle: {border: true, state: true, groupId: 'group-4-'}}, true, './layout'); %>
+
+<%- sample('Groupe de toggles simple avec bouton + label à droite + état + séparateur + texte d’aide', './sample/toggle-group.ejs', {toggle: {border: true, state: true, groupId: 'group-5-', hint: true}}, true, './layout'); %>
+
+<%- sample('Groupe de toggles simple avec bouton + label à droite + état + séparateur + texte d’aide + erreur', './sample/toggle-group.ejs', {toggles: {error: true}, toggle: {border: true, state: true, groupId: 'group-6-', hint: true}}, true, './layout'); %>
+
+<%- sample('Groupe de toggles simple avec bouton + label à droite + état + séparateur + texte d’aide + valide', './sample/toggle-group.ejs', {toggles: {valid: true}, toggle: {border: true, state: true, groupId: 'group-7-', hint: true}}, true, './layout'); %>
 
 <%- sample('Toggle simple avec bouton + label à gauche', './sample/toggle-default.ejs', {toggle: {state: false, left: true}}, true, './layout'); %>
 
@@ -42,11 +56,11 @@
 
 <%- sample('Toggle simple disabled avec bouton + label à gauche + état', './sample/toggle-default.ejs', {toggle: {state: true, left: true, disabled: true}}, true, './layout'); %>
 
-<%- sample('Groupe de toggles simple avec bouton + label à gauche + séparateur', './sample/toggle-group.ejs', {toggle: {border:true, groupId: 'group-3-', left: true}}, true, './layout'); %>
+<%- sample('Groupe de toggles simple avec bouton + label à gauche + séparateur', './sample/toggle-group.ejs', {toggle: {border:true, groupId: 'group-8-', left: true}}, true, './layout'); %>
 
-<%- sample('Groupe de toggles simple avec bouton + label à gauche + séparateur + texte d’aide', './sample/toggle-group.ejs', {toggle: {border:true, groupId: 'group-3-', left: true, hint: true}}, true, './layout'); %>
+<%- sample('Groupe de toggles simple avec bouton + label à gauche + séparateur + texte d’aide', './sample/toggle-group.ejs', {toggle: {border:true, groupId: 'group-9-', left: true, hint: true}}, true, './layout'); %>
 
-<%- sample('Groupe de toggles simple avec bouton + label à gauche + état + séparateur', './sample/toggle-group.ejs', {toggle: {border: true, state: true, groupId: 'group-4-', left: true}}, true, './layout'); %>
+<%- sample('Groupe de toggles simple avec bouton + label à gauche + état + séparateur', './sample/toggle-group.ejs', {toggle: {border: true, state: true, groupId: 'group-10-', left: true}}, true, './layout'); %>
 
-<%- sample('Groupe de toggles simple avec bouton + label à gauche + état + séparateur + texte d’aide', './sample/toggle-group.ejs', {toggle: {border: true, state: true, groupId: 'group-4-', left: true, hint: true}}, true, './layout'); %>
+<%- sample('Groupe de toggles simple avec bouton + label à gauche + état + séparateur + texte d’aide', './sample/toggle-group.ejs', {toggle: {border: true, state: true, groupId: 'group-11-', left: true, hint: true}}, true, './layout'); %>
 

--- a/src/component/toggle/example/sample/toggle-group.ejs
+++ b/src/component/toggle/example/sample/toggle-group.ejs
@@ -1,11 +1,28 @@
 <%
+const toggles = locals.toggles || {};
+const toggle = locals.toggle || {};
 
 let data = {
   label: 'Label action interrupteur',
-  ...locals.toggle || {},
+  ...toggle || {},
   hint: toggle.hint === true ? 'Texte d’aide pour clarifier l’action' : toggle.hint,
+}
+
+const elements = [];
+elements.push({
+  type: 'toggle',
+  data: {
+    ...data
+  }
+});
+
+const fieldset = {
+  elements: elements,
+  valid: toggles.valid === true ? validData(toggles.valid) : toggles.valid,
+  error: toggles.error === true ? errorData(toggles.error) : toggles.error,
+  id: uniqueId('toggle-group'),
 }
 
 %>
 
-<%- include('../../template/ejs/toggle-group', {toggle:data}); %>
+<%- include('../../../form/example/sample/fieldset', {fieldset: fieldset}) %>

--- a/src/component/toggle/style/_legacy.scss
+++ b/src/component/toggle/style/_legacy.scss
@@ -19,6 +19,7 @@
 
     &__list {
       list-style: none;
+      @include padding(0);
     }
   }
 }

--- a/src/component/toggle/style/_scheme.scss
+++ b/src/component/toggle/style/_scheme.scss
@@ -92,7 +92,7 @@
 
     input[type="checkbox"] {
       &:checked {
-        ~ #{ns(toggle__label)}  {
+        ~ #{ns(toggle__label)} {
           @include before {
             @include color.data-uri-svg((border plain error) (action-high blue-france), (legacy: $legacy), $toggle-checked-svg);
           }
@@ -126,5 +126,4 @@
       }
     }
   }
-
 }

--- a/src/component/toggle/style/_scheme.scss
+++ b/src/component/toggle/style/_scheme.scss
@@ -11,6 +11,7 @@
     label {
       @include before {
         @include color.text(active blue-france, (legacy:$legacy));
+        @include color.data-uri-svg(action-high blue-france, (legacy: $legacy), $toggle-unchecked-svg);
       }
 
       @include after {
@@ -27,6 +28,10 @@
         @include color.background(active blue-france, (legacy:$legacy));
 
         ~ #{ns(toggle__label)} {
+          @include before {
+            @include color.data-uri-svg((action-high blue-france) (action-high blue-france), (legacy: $legacy), $toggle-checked-svg);
+          }
+
           @include after {
             @include color.data-uri-svg(action-high blue-france, (legacy: $legacy), $toggle-svg);
           }
@@ -38,6 +43,10 @@
           @include disabled.colors((legacy: $legacy, background: true));
 
           ~ #{ns(toggle__label)} {
+            @include before {
+              @include color.data-uri-svg((background disabled grey) (background disabled grey), (legacy: $legacy), $toggle-checked-svg);
+            }
+
             @include after {
               @include color.data-uri-svg(text disabled grey, (legacy: $legacy), $toggle-svg);
             }
@@ -47,6 +56,7 @@
         ~ #{ns(toggle__label)} {
           @include before {
             @include disabled.colors((legacy: $legacy, text: true));
+            @include color.data-uri-svg((background disabled grey), (legacy: $legacy), $toggle-unchecked-svg);
           }
 
           @include after {
@@ -60,11 +70,61 @@
       @include color.text(mention grey, (legacy:$legacy));
     }
 
-    /*
-    * Ajout d'un séparateur
-    */
     &--border-bottom {
       @include color.box-shadow(default grey, (legacy:$legacy), bottom-1-in);
     }
   }
+
+  #{ns(toggle--error)},
+  #{ns(fieldset--error)} #{ns(toggle)} {
+    label {
+      @include color.text(default error, (legacy:$legacy));
+
+      @include before {
+        @include color.text(default error, (legacy:$legacy));
+        @include color.data-uri-svg(border plain error, (legacy: $legacy), $toggle-unchecked-svg);
+      }
+
+      @include after {
+        @include color.box-shadow(border plain error, (legacy:$legacy), all-1-in);
+      }
+    }
+
+    input[type="checkbox"] {
+      &:checked {
+        ~ #{ns(toggle__label)}  {
+          @include before {
+            @include color.data-uri-svg((border plain error) (action-high blue-france), (legacy: $legacy), $toggle-checked-svg);
+          }
+        }
+      }
+    }
+  }
+
+  #{ns(toggle--valid)},
+  #{ns(fieldset--valid)} #{ns(toggle)} {
+    label {
+      @include color.text(default success, (legacy:$legacy));
+
+      @include before {
+        @include color.text(default success, (legacy:$legacy));
+        @include color.data-uri-svg(border plain success, (legacy: $legacy), $toggle-unchecked-svg);
+      }
+
+      @include after {
+        @include color.box-shadow(border plain success, (legacy:$legacy), all-1-in);
+      }
+    }
+
+    input[type="checkbox"] {
+      &:checked {
+        ~ #{ns(toggle__label)} {
+          @include before {
+            @include color.data-uri-svg((border plain success) (action-high blue-france), (legacy: $legacy), $toggle-checked-svg);
+          }
+        }
+      }
+    }
+  }
+
 }

--- a/src/component/toggle/style/_setting.scss
+++ b/src/component/toggle/style/_setting.scss
@@ -4,3 +4,7 @@
 ////
 
 $toggle-svg: "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='$COLOR' d='M10 15.17l9.2-9.2 1.4 1.42L10 18l-6.36-6.36 1.4-1.42z'/></svg>";
+
+$toggle-unchecked-svg: "<svg width='40' stroke='$COLOR' height='24' viewBox='0 0 40 24' fill='transparent' xmlns='http://www.w3.org/2000/svg'><rect x='0.5' y='0.5' width='39' height='23' rx='11.5' /></svg>";
+
+$toggle-checked-svg: "<svg width='40' stroke='$color#1' height='24' viewBox='0 0 40 24' fill='$color#2' xmlns='http://www.w3.org/2000/svg'><rect x='0.5' y='0.5' width='39' height='23' rx='11.5' /></svg>";

--- a/src/component/toggle/style/module/_default.scss
+++ b/src/component/toggle/style/module/_default.scss
@@ -42,7 +42,7 @@
     &#{ns-attr(unchecked-label)}#{ns-attr(checked-label)} {
       @include padding-left(0);
 
-      @include before(attr(#{ns-attr(unchecked-label, null, true)})){
+      @include before(attr(#{ns-attr(unchecked-label, null, true)})) {
         @include margin-right(calc(var(--toggle-status-width) - #{spacing.space(2v)}));
       };
 

--- a/src/component/toggle/style/module/_default.scss
+++ b/src/component/toggle/style/module/_default.scss
@@ -36,7 +36,6 @@
     --toggle-status-width: auto;
     display: inline-flex;
     width: spacing.space(calc(100% - 10v));
-    flex: 1;
     min-height: spacing.space(6v);
     @include text-style(md);
 

--- a/src/component/toggle/style/module/_default.scss
+++ b/src/component/toggle/style/module/_default.scss
@@ -13,25 +13,11 @@
   @include set-text-margin(0);
   @include set-title-margin(0);
 
-  /*
-   * On utilise un input de type checkbox pour gérer le toggle
-   * On reset ses styles afin de ne garder que son fonctionnement et son espacement
-   * On l'utilisera égalemement pour afficher l'état du toggle (optionnel)
-   */
   input[type="checkbox"] {
-    flex-shrink: 0;
     @include size(10v, 6v);
-    border-radius: spacing.space(3v);
-    @include margin(0);
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    appearance: none;
+    @include absolute;
+    opacity: 0;
 
-    /*
-     * On applique des styles aux pseudo-elements du label quand l'input est check.
-     * On change l'ordre du texte d'état du label dans le content pour afficher
-     * la valeur correspondant à l'état checked (optionnel).
-     */
     &:checked {
       ~ #{ns(toggle__label)} {
         &#{ns-attr(unchecked-label)}#{ns-attr(checked-label)} {
@@ -52,44 +38,33 @@
     width: spacing.space(calc(100% - 10v));
     flex: 1;
     min-height: spacing.space(6v);
-    @include padding-left(8v);
     @include text-style(md);
 
-    /*
-     * Si les data attributes sont présents, on assigne un content au pseudo element before,
-     * et on enlève le padding left du label.
-     */
     &#{ns-attr(unchecked-label)}#{ns-attr(checked-label)} {
       @include padding-left(0);
 
-      @include before(attr(#{ns-attr(unchecked-label, null, true)}));
+      @include before(attr(#{ns-attr(unchecked-label, null, true)})){
+        @include margin-right(calc(var(--toggle-status-width) - #{spacing.space(2v)}));
+      };
 
       + #{ns(hint-text)} {
         @include margin-top(2v);
       }
     }
 
-    /*
-     * On prévoit un pseudo-élément pour afficher l'état du bouton( optionnel)
-     * On récupère le text via l'attribut [data-fr-unchecked-label]
-     */
-    @include before {
+    @include before('') {
       flex-shrink: 0;
       display: block;
-      min-width: spacing.space(10v);
       height: spacing.space(calc(5v + 1px));
-      @include margin-top(6v);
-      @include margin-left(-10v);
-      @include margin-right(4v);
+      @include padding-top(6v);
       @include text-style(xs);
-      outline: none !important;
-      width: var(--toggle-status-width);
+      border-radius: spacing.space(3v);
+      @include margin-right(8v);
+      min-width: spacing.space(10v);
+      max-width: spacing.space(10v);
+      background-repeat: no-repeat;
     }
 
-    /*
-     * On inclut l'icône check en background dans un pseudo-element after
-     *
-     */
     @include after('') {
       @include display-flex(null,center,center);
       @include absolute(4v, null, null, 0, 6v, 6v);
@@ -103,6 +78,7 @@
   #{ns(hint-text)} {
     display: block;
     @include margin-top(4v);
+    @include margin-bottom(0);
     @include text-style(xs);
     flex-basis: 100%;
   }

--- a/src/component/toggle/style/module/_default.scss
+++ b/src/component/toggle/style/module/_default.scss
@@ -44,6 +44,7 @@
 
       @include before(attr(#{ns-attr(unchecked-label, null, true)})) {
         @include margin-right(calc(var(--toggle-status-width) - #{spacing.space(2v)}));
+        @include margin-bottom(4v);
       };
 
       + #{ns(hint-text)} {
@@ -51,9 +52,8 @@
       }
     }
 
-    @include before('') {
+    @include before('', block) {
       flex-shrink: 0;
-      display: block;
       height: spacing.space(calc(5v + 1px));
       @include padding-top(6v);
       @include text-style(xs);

--- a/src/component/toggle/style/module/_group.scss
+++ b/src/component/toggle/style/module/_group.scss
@@ -3,9 +3,20 @@
 /// @group toggle
 ////
 
-/*
- * On surcharge les styles de base
- */
 #{ns(toggle)}__list {
   @include disable-list-style;
+}
+
+#{ns(fieldset)} {
+  #{ns(toggle)}__list {
+    li:first-child #{ns(toggle)} {
+      @include padding-top(0);
+
+      label {
+        @include after {
+          top: 0;
+        }
+      }
+    }
+  }
 }

--- a/src/component/toggle/style/module/_variants.scss
+++ b/src/component/toggle/style/module/_variants.scss
@@ -5,17 +5,16 @@
 
 @use 'module/spacing';
 
-/*
- * Passage du label ferré à gauche, le toggle ferré à droite
- */
 #{ns(toggle--label-left)} {
   #{ns(toggle__input)} {
     order: 1;
     @include margin(0 0 0 auto);
 
-    &#{ns-attr(checked-label)} ~ #{ns(toggle__label)} {
-      @include padding-left(0);
-      @include padding-right(4v);
+    + label#{ns-attr(checked-label)} {
+      @include before {
+        @include margin-right(0);
+        @include margin-left(calc(var(--toggle-status-width) - #{spacing.space(2v)}));
+      }
     }
   }
 
@@ -28,9 +27,10 @@
     @include before {
       flex-shrink: 0;
       order: 1;
-      @include margin-right(-10v);
       @include margin-left(4v);
+      @include margin-right(0);
       text-align: right;
+      direction: rtl;
     }
 
     @include after {

--- a/src/component/toggle/template/ejs/toggle.ejs
+++ b/src/component/toggle/template/ejs/toggle.ejs
@@ -43,6 +43,12 @@ if (toggle.border !== undefined) {
 if (toggle.left !== undefined) {
   classes.push(prefix +'-toggle--label-left');
 }
+if (toggle.error !== undefined) {
+  classes.push(prefix +'-toggle--error');
+}
+if (toggle.valid !== undefined) {
+  classes.push(prefix +'-toggle--valid');
+}
 if (toggle.disabled) inputAttr['disabled'] = '';
 if (toggle.checked) inputAttr['checked'] = '';
 %>

--- a/src/core/style/action/setting/_elements.scss
+++ b/src/core/style/action/setting/_elements.scss
@@ -69,6 +69,12 @@ $action-elements: (
       selector: '&:disabled, &:disabled + label',
     )
   ),
+  radio-rich: (
+    selector: '.fr-radio-rich > input[type="radio"]',
+    focus: (
+      selector: ' + label'
+    )
+  ),
   input-upload: (
     selector: 'input[type="file"]',
     cursor: (


### PR DESCRIPTION
Uniformisation des champs à cocher toggle/radio/checkbox

toggle:
- Ajout des variants toggle error/valid
- Retrait du css sur input `appearance:none` 
- bordure en background svg
- le toggle est maintenant placé dans un fieldset

radio:
- Le contour devient bleu
- retrait du fond blanc du radio bouton (transparence)
- input déssiné en background image

radio-rich: 
- L'outline au focus englobe tout le radio-riche, plus l'input

checkbox:
- Le contour devient bleu
- correction changement d'état au mouse-down (:active), maintenant au mouse up

Form: 
- les hint-text des champs désactivés passent en couleur `--text-disabled-grey`
