### PR TITLE
:bug: fix(password, account): correction capslock safari [DS-2942]

### DIFF
--- a/src/component/input/input-base/style/_module.scss
+++ b/src/component/input/input-base/style/_module.scss
@@ -20,6 +20,10 @@
     font-style: italic;
   }
 
+  @include contact-auto-fill-button {
+    cursor: pointer;
+  }
+
   /**
    * On applique une hauteur maximale si l'élément n'est pas un textarea
    */

--- a/src/component/input/input-base/style/_scheme.scss
+++ b/src/component/input/input-base/style/_scheme.scss
@@ -16,6 +16,10 @@
       @include color.text(mention grey, (legacy:$legacy));
     }
 
+    @include contact-auto-fill-button {
+      @include color.background(text label grey, (legacy:$legacy, hover: true));
+    }
+
     @include disabled.selector((legacy: $legacy), (text: true, box-shadow: bottom-2-in));
 
     @include autofill {

--- a/src/component/input/input-base/style/_tool.scss
+++ b/src/component/input/input-base/style/_tool.scss
@@ -18,3 +18,10 @@
     @content;
   }
 }
+
+@mixin contact-auto-fill-button {
+  &::-webkit-contacts-auto-fill-button{
+    @content;
+  }
+
+}

--- a/src/component/input/input-base/style/_tool.scss
+++ b/src/component/input/input-base/style/_tool.scss
@@ -20,8 +20,7 @@
 }
 
 @mixin contact-auto-fill-button {
-  &::-webkit-contacts-auto-fill-button{
+  &::-webkit-contacts-auto-fill-button {
     @content;
   }
-
 }

--- a/src/component/password/script/password/password-input.js
+++ b/src/component/password/script/password/password-input.js
@@ -23,7 +23,8 @@ class PasswordInput extends api.core.Instance {
   }
 
   capslock (event) {
-    if (event.getModifierState('CapsLock')) {
+    console.log(typeof event.getModifierState === 'function');
+    if (event && typeof event.getModifierState === 'function' && event.getModifierState('CapsLock')) {
       this.node.parentNode.setAttribute(api.internals.ns.attr('capslock'), '');
     } else {
       this.node.parentNode.removeAttribute(api.internals.ns.attr('capslock'));

--- a/src/component/password/script/password/password-input.js
+++ b/src/component/password/script/password/password-input.js
@@ -23,7 +23,6 @@ class PasswordInput extends api.core.Instance {
   }
 
   capslock (event) {
-    console.log(typeof event.getModifierState === 'function');
     if (event && typeof event.getModifierState === 'function' && event.getModifierState('CapsLock')) {
       this.node.parentNode.setAttribute(api.internals.ns.attr('capslock'), '');
     } else {

--- a/src/component/password/script/password/password-input.js
+++ b/src/component/password/script/password/password-input.js
@@ -23,7 +23,7 @@ class PasswordInput extends api.core.Instance {
   }
 
   capslock (event) {
-    if (event && typeof event.getModifierState === 'function' && event.getModifierState('CapsLock')) {
+    if (event.getModifierState('CapsLock')) {
       this.node.parentNode.setAttribute(api.internals.ns.attr('capslock'), '');
     } else {
       this.node.parentNode.removeAttribute(api.internals.ns.attr('capslock'));

--- a/src/component/password/script/password/password-toggle.js
+++ b/src/component/password/script/password/password-toggle.js
@@ -29,7 +29,6 @@ class PasswordToggle extends api.core.Instance {
 
   toggle () {
     this.isChecked = !this._isChecked;
-    // this.node.checked = this.isChecked;
   }
 
   swapFont (families) {

--- a/src/component/password/style/_module.scss
+++ b/src/component/password/style/_module.scss
@@ -14,6 +14,12 @@
     }
   }
 
+  :not(#{ns-attr(capslock)}) {
+    #{ns(password__input)} {
+      @include padding-right(4v);
+    }
+  }
+
   &__checkbox {
     @include absolute(0, 0);
   }

--- a/src/component/password/style/_module.scss
+++ b/src/component/password/style/_module.scss
@@ -20,6 +20,10 @@
 
   &__input {
     @include margin-bottom(3v);
+
+    &::-webkit-caps-lock-indicator {
+      content: none;
+    }
   }
 
   &__label {

--- a/src/component/password/template/ejs/password.ejs
+++ b/src/component/password/template/ejs/password.ejs
@@ -35,6 +35,8 @@ input.type = 'password';
 input.icon = true; // ajoute le wrapper pour l'icone capslock
 input.required = true;
 input.attributes = input.attributes || {};
+input.attributes.autocapitalize = "off";
+input.attributes.autocorrect = "off";
 input.messages = password.messages;
 
 let checkbox = false;

--- a/src/page/account/login/example/data/login.json.ejs
+++ b/src/page/account/login/example/data/login.json.ejs
@@ -53,7 +53,9 @@ fieldsetElements.push({
     attributes: {
       ...attributes,
       'autocomplete': 'username',
-      'aria-required': true
+      'aria-required': true,
+      'autocapitalize': 'off',
+      'autocorrect': 'off',
     },
     name: 'username'
   }

--- a/src/page/account/register/example/data/login.json.ejs
+++ b/src/page/account/register/example/data/login.json.ejs
@@ -23,7 +23,11 @@ elements.push({
     id: uniqueId('username'),
     label: getText('login.username', 'login'),
     hint: getText('login.username.hint', 'login'),
-    name: 'username'
+    name: 'username',
+    attributes: {
+      'autocapitalize': 'off',
+      'autocorrect': 'off',
+    },
   }
 })
 


### PR DESCRIPTION
- Correction erreur js sur le champ password au clic sur le trousseau (safari)
- Retrait icone native capslock safari
- Ajout attribut `autocapitalize='off'` sur les champs password et email pour désactiver la majuscule au début (mobile)
- Ajout attribut `autocorrect` sur les champs password et email pour désactiver la correction orthographique