### PR TITLE
:bug: fix(build): changement des path pour compiler sur windows [DS-2992]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Si vous souhaitez contribuer au DSFR, veuillez prendre connaissance des document
 
 ## Installation
 ### Installation locale
-Le **DSFR** est basé sur une architecture [NodeJS](https://nodejs.org/), il est donc nécessaire d’installer une version récente de nodeJs. Dans le terminal nous utiliserons les commandes de **npm** ou **yarn** pour lancer les scripts.
+Le **DSFR** est basé sur une architecture [NodeJS](https://nodejs.org/), il est donc nécessaire d’installer une version récente de nodeJs. Dans le terminal nous utiliserons les commandes de **npm** ou **yarn** (v1.22.19) pour lancer les scripts.
 
 Le dépôt est disponible à cette adresse: https://github.com/GouvernementFR/dsfr
 

--- a/tool/build/scripts.js
+++ b/tool/build/scripts.js
@@ -5,6 +5,7 @@ const { terser } = require('rollup-plugin-terser');
 const sourcemaps = require('rollup-plugin-sourcemaps');
 const virtual = require('@rollup/plugin-virtual');
 const banner2 = require('rollup-plugin-banner2');
+const path = require('path');
 // const prettier = require('rollup-plugin-prettier');
 const fs = require('fs');
 const log = require('../utilities/log');
@@ -73,7 +74,7 @@ const process = async (pck, data, dir, filename, minify, legacy, map, standalone
 };
 
 const buildScript = async (pck, minify, legacy, map, standalone) => {
-  const src = root(`${pck.path}${standalone ? '/standalone' : ''}`);
+  const src = root(`${pck.path}${standalone ? '/standalone' : ''}`).replaceAll(path.sep, '/');
   const dir = root(`${standalone ? pck.standalone.dist : pck.dist}/`);
   let data = `import '${src}/main.js'\n`;
 
@@ -97,7 +98,7 @@ const buildScript = async (pck, minify, legacy, map, standalone) => {
 };
 
 const buildSchemeBootScript = async () => {
-  const src = root('src/scheme');
+  const src = root('src/scheme').replaceAll(path.sep, '/');
   const data = `import '${src}/boot.js'\n`;
 
   const input = {

--- a/tool/build/styles.js
+++ b/tool/build/styles.js
@@ -8,6 +8,7 @@ const cssnano = require('cssnano');
 const mqpacker = require('mqpacker');
 const postcssBanner = require('postcss-banner');
 const root = require('../utilities/root');
+const path = require('path');
 const log = require('../utilities/log');
 const getBanner = require('../generate/banner').getBanner;
 
@@ -15,7 +16,7 @@ const process = async (pck, css, plugins, options) => {
   plugins.push(postcssBanner({ banner: getBanner(), important: true }));
   const result = await postcss(plugins)
     .process(css, options);
-  const filename = result.opts.to.substring(result.opts.to.lastIndexOf('/') + 1);
+  const filename = path.parse(result.opts.to).base;
 
   if (pck.inject) {
     if (!pck.injection) pck.injection = {};

--- a/tool/utilities/file.js
+++ b/tool/utilities/file.js
@@ -5,14 +5,15 @@ const log = require('./log');
 
 // Create Directories
 const createDir = (dirPath) => {
-  fs.mkdirSync(dirPath, { recursive: true }, (error) => {
+  if (dirPath != '') fs.mkdirSync(dirPath, { recursive: true }, (error) => {
     if (error) log.error(error);
   });
 };
 
+// Create Files Parent 
 const createFileParent = (filePath) => {
-  const index = filePath.lastIndexOf('/', filePath);
-  const parent = filePath.substring(0, index);
+  const pathParse = path.parse(filePath);
+  const parent = pathParse.dir;
   if (!fs.existsSync(parent)) createDir(parent);
 };
 

--- a/tool/utilities/file.js
+++ b/tool/utilities/file.js
@@ -5,12 +5,12 @@ const log = require('./log');
 
 // Create Directories
 const createDir = (dirPath) => {
-  if (dirPath != '') fs.mkdirSync(dirPath, { recursive: true }, (error) => {
+  if (dirPath !== '') fs.mkdirSync(dirPath, { recursive: true }, (error) => {
     if (error) log.error(error);
   });
 };
 
-// Create Files Parent 
+// Create Files Parent
 const createFileParent = (filePath) => {
   const pathParse = path.parse(filePath);
   const parent = pathParse.dir;


### PR DESCRIPTION
Sur windows il n'est pas possible de recompiler le projet avec yarn build

Correction des path dans les tools (windows utilise "\" et linux et mac "/")