### PR TITLE
fix(toggle): rend le composant compatible avec vite+svelte

### DIFF
--- a/src/component/toggle/script/toggle/toggle-input.js
+++ b/src/component/toggle/script/toggle/toggle-input.js
@@ -6,7 +6,7 @@ class ToggleInput extends api.core.Instance {
   }
 
   get isChecked () {
-    return this.hasAttribute('checked');
+    return this.node.checked;
   }
 }
 


### PR DESCRIPTION
initialise correctement l'état checked du composant même si l'attribut html 'checked' est absent

Aujourd'hui le composant ne permet pas d'initialiser le composant en état checked avec [vite](https://vitejs.dev/guide/)+[svelte](https://svelte.dev/).
Le comportement erroné est visible dans le repo [demo-vite-dsfr](https://github.com/emillumine/demo-vite-dsfr). Il s'agit du projet d'exemple obtenu avec `npm init vite` dans lequel on a ajouté le dsfr et un composant Toggle.svelte.

Pour lancer le projet : 

```
npm install
npm run dev
```

Le dsfr a été installé dans public/dsfr.
Le composant toggle possède l'attribut html "checked" (src/lib/Toggle.svelte) mais il n'est pas activé sur la page.
