### PR TITLE
🐛 fix(transcription): corrige largeur du bouton a l'ouverture de la modale [DS-3070]

### DIFF
--- a/src/component/transcription/style/_module.scss
+++ b/src/component/transcription/style/_module.scss
@@ -7,6 +7,7 @@
 
 #{ns(transcription)} {
   position: relative;
+  @include size(100%);
 
   @include before('', block) {
     @include absolute(0, 0, 0, 0, 100%, 100%);


### PR DESCRIPTION
à l'ouverture de la modale de la transcription, le déplacement des éléments en position fixed change la taille du bouton de la transcription à sa taille minimum. 
La largeur étendue à 100% permet de la conserver constante.