### PR TITLE
:bug: fix(modal): correctif prise de focus au focus-trap [DS-3211]

### DIFF
--- a/src/component/modal/script/modal/focus-trap.js
+++ b/src/component/modal/script/modal/focus-trap.js
@@ -77,7 +77,7 @@ class FocusTrap {
     if (!this.isTrapping) return;
     this.isTrapping = false;
     const focusables = this.focusables;
-    if (focusables.length) focusables[0].focus();
+    if (focusables.length && focusables.indexOf(document.activeElement) === -1) focusables[0].focus();
     this.element.setAttribute('aria-modal', true);
     window.addEventListener('keydown', this.handling);
     document.body.addEventListener('focus', this.focusing, true);


### PR DESCRIPTION
à l'ouverture de la modale, le focus est automatiquement déplacé sur le premier des éléments interactifs de la modale. 
Ce comportement pose problème lorsque le focus est déjà sur un des éléments contenus dans la modale.

Ajout d'une condition qui vérifie que le focus n'est pas déjà sur un des éléments interactifs de la modale avant de déplacer le focus.
