### PR TITLE
:sparkles: feat(footer): évolution des mentions légales [DS-3140]

### DIFF
--- a/src/component/footer/example/sample/footer.ejs
+++ b/src/component/footer/example/sample/footer.ejs
@@ -39,7 +39,7 @@ if (footer.bottom === true) data.bottom = {
     {label: 'Données personnelles'},
     {label: 'Gestion des cookies'}
   ],
-  copyright: 'Sauf mention contraire, tous les contenus de ce site sont sous <a href="https://github.com/etalab/licence-ouverte/blob/master/LO.md" target="_blank">licence etalab-2.0</a>'
+  copyright: 'Sauf mention explicite de propriété intellectuelle détenue par des tiers, les contenus de ce site sont proposés sous <a href="https://github.com/etalab/licence-ouverte/blob/master/LO.md" target="_blank">licence etalab-2.0</a>'
 };
 %>
 


### PR DESCRIPTION
Nouveau texte : ”Sauf mention explicite de propriété intellectuelle détenue par des tiers, les contenus de ce site sont proposés sous”