### PR TITLE
✨ feat(github): ajout de templates d'issue github [DS-3201]

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.md
+++ b/.github/ISSUE_TEMPLATE/1-bug.md
@@ -1,0 +1,34 @@
+---
+name: Rapporter un bug
+about: Rapporter un bug pour améliorer le DSFR
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+### Décrire le bug
+Une description claire et précise du bug.
+
+### Les étapes pour reproduire le bug
+Exemple :
+1. Aller à  '...'
+2. Cliquer sur  '....'
+3. Scroller jusqu’à '....'
+4. Réduire la page
+5. Le problème apparaît
+
+### Comportement attendu
+Une description claire et concise de ce qui devrait se produire.
+
+### Capture d’écran
+Ajouter des captures d’écran ou un exemple de code pour préciser le bug et le contexte.
+
+### Configuration et système utilisé
+- **Version du DSFR : **
+- **Appareil (mobile, tablette, desktop) : **
+- **Système d’exploitation : **
+- **Navigateur et version : **
+
+### Informations complémentaires
+Ajouter toute autre information concernant le problème.

--- a/.github/ISSUE_TEMPLATE/2-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/2-suggestion.md
@@ -1,8 +1,8 @@
 ---
-name: Proposer une suggestion
+name: Proposer une évolution
 about: Suggérer une nouvelle idée, une amélioration, au Système de Design de l'État.
 title: ''
-labels: suggestion
+labels: évolution
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/2-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/2-suggestion.md
@@ -1,0 +1,22 @@
+---
+name: Proposer une suggestion
+about: Suggérer une nouvelle idée, une amélioration, au Système de Design de l'État.
+title: ''
+labels: suggestion
+assignees: ''
+
+---
+
+**Si votre suggestion concerne un composant existant, merci de décrire le problème rencontré de façon claire et concise**
+Exemple : sur le composant [...], je ne peux pas [...].
+
+**Décrivez le comportement souhaité**
+Une description claire et concise de ce que vous souhaitez qu'il se passe.
+
+**Si vous avez déjà identifié une correction**
+Une description précise de toutes les solutions ou fonctionnalités que vous avez considérées/essayées.
+
+**Contexte & informations complémentaires**
+Préciser le contexte, les cas d'usages ou scénarios envisageables.
+Ajouter des captures d'écrans pour clarifier la demande.
+

--- a/.github/ISSUE_TEMPLATE/3-doc.md
+++ b/.github/ISSUE_TEMPLATE/3-doc.md
@@ -1,0 +1,17 @@
+---
+name: Problème sur la documentation
+about: Rapporter une erreur ou proposer une suggestion pour améliorer la documentation du DSFR.
+title: ''
+labels: documentation
+assignees: ''
+
+---
+
+###  Documentation associée
+Si la suggestion concerne une documentation existante, préciser de laquelle il s’agit. Ajouter un lien si possible.
+
+###  Suggestion
+Comment cette documentation pourrait être améliorée.
+
+###  Sources (si applicable)
+Merci de fournir les différentes sources et recherches qui pourraient appuyer cette suggestion.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Contactez nous
+    url: https://www.systeme-de-design.gouv.fr/centre-de-support
+    about: Retrouvez plus d'information sur systeme-de-design.gouv.fr


### PR DESCRIPTION
Création de template d'issue Github pour indiquer les informations demandées lors d'un report de 
- bug
- évolution
- documentation