### PR TITLE
:bug: fix(consent): consent placeholder video mal centré [DS-3026]

### DIFF
--- a/src/core/style/media/module/_responsive.scss
+++ b/src/core/style/media/module/_responsive.scss
@@ -14,7 +14,7 @@
     @include aspect-ratio();
     display: block;
 
-    &__player, & > #{ns(consent-placeholder)} {
+    &__player {
       @include size(100%, 100%);
       display: block;
       border: 0;


### PR DESCRIPTION
Dans le cas d'une video le placeholder est en display block
Retrait de la propriété non désirée