### PR TITLE
:bug: fix(password): correctif erreur getModifierState [DS-2940]

### DIFF
--- a/src/component/password/script/password/password-input.js
+++ b/src/component/password/script/password/password-input.js
@@ -23,9 +23,7 @@ class PasswordInput extends api.core.Instance {
   }
 
   capslock (event) {
-    if (typeof event?.getModifierState !== 'function') {
-      return;
-    }
+    if (event && typeof event.getModifierState !== 'function') return;
     if (event.getModifierState('CapsLock')) {
       this.node.parentNode.setAttribute(api.internals.ns.attr('capslock'), '');
     } else {

--- a/src/component/password/script/password/password-input.js
+++ b/src/component/password/script/password/password-input.js
@@ -23,6 +23,9 @@ class PasswordInput extends api.core.Instance {
   }
 
   capslock (event) {
+    if (typeof event?.getModifierState !== 'function') {
+      return;
+    }
     if (event.getModifierState('CapsLock')) {
       this.node.parentNode.setAttribute(api.internals.ns.attr('capslock'), '');
     } else {


### PR DESCRIPTION
Lorsque le navigateur fait l'autocompletion du champ password, il lance un évènement qui n'est pas forcément un évènement de clavier et provoque une erreur indiquant que la fonction getModifierState n'existe pas.