### PR TITLE
:bug: fix(input): ajout d'une bordure en mode contraste élevé

### DIFF
--- a/src/core/style/action/module/_input.scss
+++ b/src/core/style/action/module/_input.scss
@@ -2,6 +2,7 @@
 /// Core Module : Reset input & form field
 /// @group core
 ////
+@use 'module/media-query';
 
 input,
 select,
@@ -15,6 +16,10 @@ textarea {
   border: 0;
   background-color: transparent;
   margin: 0; // Address margins set differently in Firefox 4+, Safari, and Chrome.
+
+  @include media-query.high-contrast() {
+    border: 1px solid var(--border-plain-grey);
+  }
 }
 
 // Fix for NVDA


### PR DESCRIPTION
## Contexte
Suite à un audit d'accessibilité pour un projet au DSFR, il nous a été exprimé le fait que les input étaient difficilement visibles en contraste élevé (seule la box-shadow permet de noter la présence d'un input), particulièrement sur les pages de connexion et de création de compte qui sont sur fond gris, légèrement plus clair que le background de l'input.

## Correctif proposé
Pour pallier à ce problème, l'idée est de refaire apparaître la bordure pour les utilisateurs utilisant le mode contraste élevé