### PR TITLE
fix(input): correction bug icone date-picker firefox version 109+ [DS-2547]

### DIFF
--- a/src/component/input/input-base/style/_module.scss
+++ b/src/component/input/input-base/style/_module.scss
@@ -29,21 +29,19 @@
 
   &[type=date] {
     min-height: 2.5rem;
-    background-repeat: no-repeat;
-    background-position: spacing.space(calc(100% - 3v) 50%);
-    background-size: spacing.space(4v) spacing.space(4v);
-    @include padding-right(9v);
 
-    @supports not selector(::-webkit-calendar-picker-indicator) {
-      background-image: none;
-      @include padding-right(4v);
-    }
+    @supports selector(::-webkit-calendar-picker-indicator) {
+      background-repeat: no-repeat;
+      background-position: spacing.space(calc(100% - 3v) 50%);
+      background-size: spacing.space(4v) spacing.space(4v);
+      @include padding-right(9v);
 
-    &::-webkit-calendar-picker-indicator {
-      display: block;
-      @include padding(4v);
-      @include margin-right(-10v);
-      opacity: 0;
+      &::-webkit-calendar-picker-indicator {
+        display: block;
+        @include padding(4v);
+        @include margin-right(-10v);
+        opacity: 0;
+      }
     }
   }
 }

--- a/src/component/input/input-base/style/_module.scss
+++ b/src/component/input/input-base/style/_module.scss
@@ -34,6 +34,11 @@
     background-size: spacing.space(4v) spacing.space(4v);
     @include padding-right(9v);
 
+    @supports not selector(::-webkit-calendar-picker-indicator) {
+      background-image: none;
+      @include padding-right(4v);
+    }
+
     &::-webkit-calendar-picker-indicator {
       display: block;
       @include padding(4v);

--- a/src/component/input/input-base/style/_scheme.scss
+++ b/src/component/input/input-base/style/_scheme.scss
@@ -23,11 +23,15 @@
       @include color.text-fill(label grey, (legacy:$legacy));
     }
 
-    &[type=date] {
-      @include color.data-uri-svg(text title grey, (legacy: $legacy), $input-calendar-line);
+    @if not $legacy {
+      @supports selector(::-webkit-calendar-picker-indicator) {
+        &[type=date] {
+          @include color.data-uri-svg(text title grey, (legacy: $legacy), $input-calendar-line);
 
-      @include disabled.selector((legacy: $legacy), (text: true, box-shadow: bottom-2-in)) {
-        @include color.data-uri-svg(text disabled grey, (legacy: $legacy), $input-calendar-line);
+          @include disabled.selector((legacy: $legacy), (text: true, box-shadow: bottom-2-in)) {
+            @include color.data-uri-svg(text disabled grey, (legacy: $legacy), $input-calendar-line);
+          }
+        }
       }
     }
 


### PR DESCRIPTION
Depuis la version 109 de Firefox, l'icone date-picker est en double sur les champ type date

- Ajout de l'icone date-picker si le navigateur le supporte uniquement