### PR TITLE
🐛 fix(input): ajout d'une bordure en mode contraste élevé

### DIFF
--- a/src/core/style/action/module/_input.scss
+++ b/src/core/style/action/module/_input.scss
@@ -2,6 +2,7 @@
 /// Core Module : Reset input & form field
 /// @group core
 ////
+@use 'module/media-query';
 
 input,
 select,
@@ -15,6 +16,10 @@ textarea {
   border: 0;
   background-color: transparent;
   margin: 0; // Address margins set differently in Firefox 4+, Safari, and Chrome.
+
+  @include media-query.high-contrast() {
+    border: 1px solid var(--border-plain-grey);
+  }
 }
 
 // Fix for NVDA


### PR DESCRIPTION
Je me suis permis de recréer une PR corrigeant l'issue #578, étant donné que la version 1.9.1 a été release et que la PR #577 a été close en conséquent par @lab9fr