### PR TITLE
🐛 fix(core): La valeur no-wrap n’existe pas dans la spécification CSS

### DIFF
--- a/src/core/style/display/module/_hr.scss
+++ b/src/core/style/display/module/_hr.scss
@@ -20,7 +20,7 @@ hr {
     @include text-style(sm);
     text-transform: uppercase;
     @include font-weight(bold);
-    @include display-flex(row, center, center, no-wrap, inline);
+    @include display-flex(row, center, center, nowrap, inline);
     @include _pseudo(before after, '', inline-flex) {
       height: 1px;
       width: 100%;


### PR DESCRIPTION
Il y a un `-` en trop.

Voir https://www.w3.org/TR/css-flexbox-1/#flex-wrap-property

partial-fix de #593 