### PR TITLE
🐛 fix(button, theme): retrait propriété css :where [DS-2759]

### DIFF
--- a/module/selector/mixin/_theme.scss
+++ b/module/selector/mixin/_theme.scss
@@ -8,7 +8,7 @@
   }
   $selector: &;
   @at-root {
-    :root:where(#{namespace.ns-attr(theme, $theme)}) {
+    :root#{namespace.ns-attr(theme, $theme)} {
       @include utilities.nest($selector) {
         @content;
       }

--- a/src/component/button/style/module/_group.scss
+++ b/src/component/button/style/module/_group.scss
@@ -158,7 +158,7 @@
   /**
   * fr-btns-group--md : (défaut) Fixe les boutons à la taille MD
   */
-  &:where(:not(#{ns-group(btns)}--sm):not(#{ns-group(btns)}--lg)) {
+  &:not(#{ns-group(btns)}--sm):not(#{ns-group(btns)}--lg) {
     #{ns(btn)} {
       @include has-not-icon {
         @include nest-btn(md, false, null, null, false);


### PR DESCRIPTION
La propriété CSS :where est encore trop récente (chrome 88).

-> retrait de cette propriété