### PR TITLE
✨ feat(analytics): exemple analytics standalone [DS-3250]

### DIFF
--- a/src/analytics/standalone/example/index.ejs
+++ b/src/analytics/standalone/example/index.ejs
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Analytics standalone</title>
+    <link href="../component/connect/connect.standalone.css" rel="stylesheet" />
+    <script>
+      window['<%= namespace %>'] = {
+        verbose: true,
+        production: false,
+        analytics: {
+          domain: 'gva.et-gv.fr',
+          page: {
+            categories: ['category1', 'category2', 'category3'],
+            template: 'nom template', // page template
+          },
+          site: {
+            entity: 'Pages de test du SIG', // Entity responsible for website
+          },
+        }
+      };
+    </script>
+  </head>
+
+  <body style="margin: 20px; padding: 0;">
+    <h1>Titre de la page</h1>
+    <%- include('../../../component/connect/example/index', {standalone: true}); %>
+    <script src='analytics.module.standalone.js'></script>
+  </body>
+</html>


### PR DESCRIPTION
Ajout d'une page d'exemple d'utilisation du package analytics sans import du dsfr (standalone), dans /standalone/analytics/index.html