### PR TITLE
:bug: fix(core): corrige liens pour retro-compat sur firefox [DS-3288]

### DIFF
--- a/src/core/style/_outdated.scss
+++ b/src/core/style/_outdated.scss
@@ -7,4 +7,8 @@
   :root#{ns-attr(scrolling)} body {
     position: sticky;
   }
+  
+  :root {
+    --underline-thickness: calc(#{$underline-thickness} + 0.25px);
+  }
 }

--- a/src/core/style/action/tool/_link.scss
+++ b/src/core/style/action/tool/_link.scss
@@ -17,7 +17,7 @@ $underline-thickness: 0.0625em;
   --underline-hover-width: 0;
   --underline-idle-width: var(--underline-max-width);
   --underline-x: calc(var(--underline-max-width) * 0);
-  --underline-thickness: max(1px, #{$underline-thickness});
+  --underline-thickness: #{$underline-thickness};
 }
 
 @mixin enable-underline() {


### PR DESCRIPTION
- La fonction css max(), mise en place pour corriger le bug d'affichage d'un soulignement d'une épaisseur inférieure à 1px, est supportée à partir de la version 78 de firefox, ce qui est insuffisant.
- Le précédent bug est maintenant corrigé avec un léger épaississement du trait sur firefox (0.25px)