### PR TITLE
:bug: fix(account): met a jour la hiérarchie html des modèles de page [DS-3289,  DS-3290]

### DIFF
--- a/src/page/account/login/example/data/login.json.ejs
+++ b/src/page/account/login/example/data/login.json.ejs
@@ -119,7 +119,7 @@ elements.push({
 
 const data = {
   id: uniqueId('login'),
-  legend: `<h5>${getText('login.legend', 'login')}</h5>`,
+  legend: `<h2 class=${prefix}-h5>${getText('login.legend', 'login')}</h2>`,
   elements: elements
 };
  %>

--- a/src/page/account/recover/example/data/recover.json.ejs
+++ b/src/page/account/recover/example/data/recover.json.ejs
@@ -1,7 +1,7 @@
 <%
 const data = {
   id: 'recover',
-  legend: `<h5>${getText('recover.legend', 'recover')}</h5>`,
+  legend: `<h2 class="${prefix}-h5">${getText('recover.legend', 'recover')}</h2>`,
   classes: [`${prefix}-mb-0`],
   elements:[
     {

--- a/src/page/account/register/example/2-steps/2a-login/index.ejs
+++ b/src/page/account/register/example/2-steps/2a-login/index.ejs
@@ -26,6 +26,7 @@ const register = {
     {
       type: 'connect',
       data: {
+        markup: 'h3',
         title: getText('connect.title', 'register'),
         desc: getText('connect.desc', 'register'),
         connect: connect

--- a/src/page/account/register/example/2-steps/2a-login/index.ejs
+++ b/src/page/account/register/example/2-steps/2a-login/index.ejs
@@ -2,7 +2,7 @@
 const sample = getSample(include);
 
 const connect = JSON.parse(include('../../../../../../component/connect/example/data/connect.json.ejs'));
-const form = JSON.parse(include('../../data/login.json.ejs', {}));
+const form = JSON.parse(include('../../data/login.json.ejs', { login: { markup: 'h3' }}));
 
 const buttonsGroup = JSON.parse(include('../../data/buttons-group.json.ejs', { page: { currentStep: 1, stepCount: 3}}));
 

--- a/src/page/account/register/example/data/address.json.ejs
+++ b/src/page/account/register/example/data/address.json.ejs
@@ -3,7 +3,7 @@ const addressData = JSON.parse(include('../../../../../pattern/address/example/d
 
 const data = {
   id: 'identity',
-  legend: `<h5>${getText('address.legend', 'register')}</h5>`,
+  legend: `<h2 class="${prefix}-h5">${getText('address.legend', 'register')}</h2>`,
   classes: [prefix + '-mb-0'],
   elements: [
     {

--- a/src/page/account/register/example/data/address.json.ejs
+++ b/src/page/account/register/example/data/address.json.ejs
@@ -3,7 +3,7 @@ const addressData = JSON.parse(include('../../../../../pattern/address/example/d
 
 const data = {
   id: 'identity',
-  legend: `<h2 class="${prefix}-h5">${getText('address.legend', 'register')}</h2>`,
+  legend: `<h3 class="${prefix}-h5">${getText('address.legend', 'register')}</h3>`,
   classes: [prefix + '-mb-0'],
   elements: [
     {

--- a/src/page/account/register/example/data/identity.json.ejs
+++ b/src/page/account/register/example/data/identity.json.ejs
@@ -4,7 +4,7 @@ const nameData = JSON.parse(include('../../../../../pattern/name/example/data/na
 
 const data = {
   id: 'identity',
-  legend: `<h5>${getText('identity.legend', 'register')}</h5>`,
+  legend: `<h3 class="${prefix}-h5">${getText('identity.legend', 'register')}</h3>`,
   classes: [prefix + '-mb-0'],
   elements: [
     {

--- a/src/page/account/register/example/data/login.json.ejs
+++ b/src/page/account/register/example/data/login.json.ejs
@@ -76,7 +76,7 @@ elements.push({
 
 const data = {
   id: uniqueId('login'),
-  legend: `<h2 class=${prefix}-h5>${getText('login.legend', 'register')}</h2>`,
+  legend: `<h3 class=${prefix}-h5>${getText('login.legend', 'register')}</h3>`,
   classes: [prefix + '-mb-0'],
   elements: elements
 };

--- a/src/page/account/register/example/data/login.json.ejs
+++ b/src/page/account/register/example/data/login.json.ejs
@@ -1,5 +1,8 @@
 <%
 
+const login = locals.login || {};
+const markup = login.markup || 'h2';
+
 const elements = [];
 
 elements.push({
@@ -76,7 +79,7 @@ elements.push({
 
 const data = {
   id: uniqueId('login'),
-  legend: `<h3 class=${prefix}-h5>${getText('login.legend', 'register')}</h3>`,
+  legend: `<${markup} class=${prefix}-h5>${getText('login.legend', 'register')}<${markup}/>`,
   classes: [prefix + '-mb-0'],
   elements: elements
 };

--- a/src/page/account/register/example/data/login.json.ejs
+++ b/src/page/account/register/example/data/login.json.ejs
@@ -76,7 +76,7 @@ elements.push({
 
 const data = {
   id: uniqueId('login'),
-  legend: `<h5>${getText('login.legend', 'register')}</h5>`,
+  legend: `<h2 class=${prefix}-h5>${getText('login.legend', 'register')}</h2>`,
   classes: [prefix + '-mb-0'],
   elements: elements
 };

--- a/src/page/account/template/ejs/blocks/colored.ejs
+++ b/src/page/account/template/ejs/blocks/colored.ejs
@@ -27,12 +27,12 @@ const col = COLS[block.col] || COLS[6];
 const classes = {
   outer: {
     container: [`${prefix}-container`, `${prefix}-container--fluid`, `${prefix}-mb-md-14v`],
-    grid: [`${prefix}-grid-row`, `${prefix}-grid-row-gutters`, `${prefix}-grid-row--center`],
+    grid: [`${prefix}-grid-row`, `${prefix}-grid-row--gutters`, `${prefix}-grid-row--center`],
     col: [`${prefix}-col-12`, `${prefix}-col-md-${col.outer.md}`, `${prefix}-col-lg-${col.outer.lg}`]
   },
   inner: {
     container: [`${prefix}-container`, `${prefix}-background-alt--${color}`, `${prefix}-px-md-0`, `${prefix}-pt-10v`, `${prefix}-pt-md-14v`, `${prefix}-pb-6v`, `${prefix}-pb-md-10v`],
-    grid: [`${prefix}-grid-row`, `${prefix}-grid-row-gutters`, `${prefix}-grid-row--center`],
+    grid: [`${prefix}-grid-row`, `${prefix}-grid-row--gutters`, `${prefix}-grid-row--center`],
     col: [`${prefix}-col-12`, `${prefix}-col-md-${col.inner.md}`, `${prefix}-col-lg-${col.inner.lg}`]
   }
 }

--- a/src/page/account/template/ejs/blocks/heading.ejs
+++ b/src/page/account/template/ejs/blocks/heading.ejs
@@ -1,13 +1,14 @@
 <%
  const heading = locals.heading || {};
- const markup = heading.markup || 'h2';
+ const markup = heading.markup || 'h1';
+ const classes = heading.classes || [`${prefix}-h2`];
  %>
 
 <div class="<%= prefix %>-container <%= prefix %>-mt-8v <%= prefix %>-mt-md-14v <%= prefix %>-mb-2v <%= prefix %>-mb-md-8v">
   <div class="<%= prefix %>-grid-row <%= prefix %>-grid-row--gutters <%= prefix %>-grid-row--center">
     <div class="<%= prefix %>-col-12 <%= prefix %>-col-md-10 <%= prefix %>-col-lg-8">
       <% if (heading.title) { %>
-        <<%= markup %>><%= heading.title %></<%= markup %>>
+        <<%= markup %> <%- includeClasses(classes); %>><%= heading.title %></<%= markup %>>
       <% } %>
 
       <% if (heading.chapo) { %>

--- a/src/page/account/template/ejs/segments/button.ejs
+++ b/src/page/account/template/ejs/segments/button.ejs
@@ -3,7 +3,7 @@ const segment = locals.segment || {};
 const data = segment.data;
 %>
 <% if (data.title) { %>
-  <h5><%= data.title %></h5>
+  <h2 class="<%= prefix %>-h5"><%= data.title %></h2>
 <% } %>
 <% if (data.buttonsGroup) { %>
   <%- include('../../../../../component/button/template/ejs/buttons-group', { buttonsGroup: data.buttonsGroup })  %>

--- a/src/page/account/template/ejs/segments/connect.ejs
+++ b/src/page/account/template/ejs/segments/connect.ejs
@@ -1,10 +1,11 @@
 <%
 const segment = locals.segment;
 const data = segment.data || {};
+const markup = data.markup || 'h2';
 %>
 <div class="<%= prefix %>-mb-6v">
   <% if (data.title) { %>
-    <h2 class="<%= prefix %>-h5"><%= data.title %></h2>
+    <<%= markup %> class="<%= prefix %>-h5"><%= data.title %></<%= markup %>>
   <% } %>
 
   <% if (data.desc) { %>

--- a/src/page/account/template/ejs/segments/connect.ejs
+++ b/src/page/account/template/ejs/segments/connect.ejs
@@ -4,11 +4,11 @@ const data = segment.data || {};
 %>
 <div class="<%= prefix %>-mb-6v">
   <% if (data.title) { %>
-    <h5><%= data.title %></h5>
+    <h2 class="<%= prefix %>-h5"><%= data.title %></h2>
   <% } %>
 
   <% if (data.desc) { %>
-    <p class="<%= prefix %>-text--sm <%= prefix %>"><%= data.desc %></p>
+    <p class="<%= prefix %>-text--sm"><%= data.desc %></p>
   <% } %>
 
   <%- include('../../../../../component/connect/template/ejs/connect.ejs', { connect: data.connect })  %>

--- a/src/page/account/template/ejs/segments/heading.ejs
+++ b/src/page/account/template/ejs/segments/heading.ejs
@@ -1,6 +1,7 @@
 <%
 const segment = locals.segment || {};
 const data = segment.data || {};
-const markup = data.markup || 'h4';
+const markup = data.markup || 'h1';
+const classes = data.classes || [`${prefix}-h4`];
  %>
-<<%= markup %>><%- data.title %></<%= markup %>>
+<<%= markup %> <%- includeClasses(classes); %>><%- data.title %></<%= markup %>>

--- a/src/page/account/template/ejs/segments/stepper.ejs
+++ b/src/page/account/template/ejs/segments/stepper.ejs
@@ -1,5 +1,5 @@
 <%
   const segment = locals.segment || {};
-  const stepper = { ...segment.data, classes: [`${prefix}-h3`] };
+  const stepper = { ...segment.data };
  %>
 <%- include('../../../../../component/stepper/template/ejs/stepper.ejs', { stepper: stepper })  %>

--- a/src/page/account/template/ejs/segments/stepper.ejs
+++ b/src/page/account/template/ejs/segments/stepper.ejs
@@ -1,5 +1,5 @@
 <%
   const segment = locals.segment || {};
-  const stepper = { ...segment.data, markup: 'h3' };
+  const stepper = { ...segment.data, classes: [`${prefix}-h3`] };
  %>
 <%- include('../../../../../component/stepper/template/ejs/stepper.ejs', { stepper: stepper })  %>


### PR DESCRIPTION
- Mise en place d'une hiérarchie sans saut de niveau de titre, plus cohérente
- Correctif typo sur la classe `fr-grid-row--gutters`