### PR TITLE
:bug: fix(tab, core): correctif tab legacy & margin top des headings [DS-3281]

### DIFF
--- a/src/component/tab/style/_legacy.scss
+++ b/src/component/tab/style/_legacy.scss
@@ -13,9 +13,17 @@
       @include absolute(12v, 0, 0, 0);
     }
 
+    #{ns(tabs__list)} {
+      @include padding(1v 3v);
+    }
+
+    &__tab {
+      @include icon-size-legacy(sm);
+    }
+
     &__panel {
       @include padding(0 0.1px);
-      @include margin-top(12v);
+      left: 0;
       @include enable-list-style-legacy;
       @include enable-underline-legacy;
 
@@ -25,8 +33,8 @@
       }
 
       > *:first-child {
-        @include padding-top(4v);
-        @include padding-top(8v, md);
+        @include padding-top(3v);
+        @include padding-top(7v, md);
       }
 
       > *:last-child {

--- a/src/component/tab/style/_legacy.scss
+++ b/src/component/tab/style/_legacy.scss
@@ -13,8 +13,8 @@
     @include disable-list-style-legacy;
 
     &__panel {
-      @include padding(1px);
-      left: 0;
+      @include padding(0 0.1px);
+      @include margin-top(12v);
       @include enable-list-style-legacy;
       @include enable-underline-legacy;
 

--- a/src/component/tab/style/_legacy.scss
+++ b/src/component/tab/style/_legacy.scss
@@ -13,6 +13,7 @@
     @include disable-list-style-legacy;
 
     &__panel {
+      @include absolute(12v, 0, 0, 0);
       @include padding(0 0.1px);
       @include margin-top(12v);
       @include enable-list-style-legacy;

--- a/src/component/tab/style/_legacy.scss
+++ b/src/component/tab/style/_legacy.scss
@@ -6,22 +6,28 @@
 @use 'module/legacy';
 
 @include legacy.is(ie11) {
-  /**
-  * Reset liste à puce
-  */
   #{ns(tabs)} {
     @include disable-list-style-legacy;
 
     &__panel {
       @include absolute(12v, 0, 0, 0);
       @include padding(0 0.1px);
-      @include margin-top(12v);
       @include enable-list-style-legacy;
       @include enable-underline-legacy;
 
-       > * {
-        @include padding(4v);
-        @include padding(8v, md);
+      > * {
+        @include padding-x(4v);
+        @include padding-x(8v, md);
+      }
+
+      > *:first-child {
+        @include padding-top(4v);
+        @include padding-top(8v, md);
+      }
+
+      > *:last-child {
+        @include padding-bottom(4v);
+        @include padding-bottom(8v, md);
       }
     }
   }

--- a/src/component/tab/style/_legacy.scss
+++ b/src/component/tab/style/_legacy.scss
@@ -9,9 +9,13 @@
   #{ns(tabs)} {
     @include disable-list-style-legacy;
 
-    &__panel {
+    @include before {
       @include absolute(12v, 0, 0, 0);
+    }
+
+    &__panel {
       @include padding(0 0.1px);
+      @include margin-top(12v);
       @include enable-list-style-legacy;
       @include enable-underline-legacy;
 

--- a/src/component/tab/style/_legacy.scss
+++ b/src/component/tab/style/_legacy.scss
@@ -13,6 +13,8 @@
     @include disable-list-style-legacy;
 
     &__panel {
+      @include padding(1px);
+      left: 0;
       @include enable-list-style-legacy;
       @include enable-underline-legacy;
     }

--- a/src/component/tab/style/_legacy.scss
+++ b/src/component/tab/style/_legacy.scss
@@ -17,6 +17,11 @@
       left: 0;
       @include enable-list-style-legacy;
       @include enable-underline-legacy;
+
+       > * {
+        @include padding(4v);
+        @include padding(8v, md);
+      }
     }
   }
 }

--- a/src/component/tab/style/module/_default.scss
+++ b/src/component/tab/style/module/_default.scss
@@ -29,7 +29,7 @@
   }
 
   @include before('', block) {
-    @include absolute(12v, 0, 0, 0, 100%, 100%);
+    @include size(100%, 100%);
     @include margin-top(-1px);
     order: 2;
   }

--- a/src/component/tab/style/module/_default.scss
+++ b/src/component/tab/style/module/_default.scss
@@ -29,7 +29,7 @@
   }
 
   @include before('', block) {
-    @include size(100%, 100%);
+    @include absolute(12v, 0, 0, 0, 100%, 100%);
     @include margin-top(-1px);
     order: 2;
   }

--- a/src/core/style/typography/_legacy.scss
+++ b/src/core/style/typography/_legacy.scss
@@ -7,4 +7,8 @@
 
 @include legacy.is(ie11) {
   @include enable-list-style-legacy;
+
+  h1, h2, h3, h4, h5, h6 {
+    @include margin(0 0 6v);
+  }
 }


### PR DESCRIPTION
- Corrige la taille de l'icône
- Corrige l'alignement du contenu du tab_panel
- Ajustement du padding de la tab__list
- Retire les margin-top des headings (h1 -> h6)