### PR TITLE
:bug: fix(search): apparence du champ de recherche iOS

### DIFF
--- a/src/component/search/style/_module.scss
+++ b/src/component/search/style/_module.scss
@@ -23,11 +23,6 @@
     }
     */
 
-    &[type=search] {
-      -webkit-appearance: none;
-      appearance: none;
-    }
-
     &::placeholder {
       font-style: italic;
     }

--- a/src/component/search/style/_module.scss
+++ b/src/component/search/style/_module.scss
@@ -17,6 +17,12 @@
     border-radius: spacing.space(1v) 0 0;
     max-height: none;
 
+    /* TODO: intégrer la croix en background pour effacer la search bar
+    &::-webkit-search-cancel-button {
+      -webkit-appearance: none;
+    }
+    */
+
     &[type=search] {
       -webkit-appearance: none;
       appearance: none;

--- a/src/component/search/style/_module.scss
+++ b/src/component/search/style/_module.scss
@@ -17,11 +17,10 @@
     border-radius: spacing.space(1v) 0 0;
     max-height: none;
 
-    /* TODO: intégrer la croix en background pour effacer la search bar
-    &::-webkit-search-cancel-button {
+    &[type=search] {
       -webkit-appearance: none;
+      appearance: none;
     }
-    */
 
     &::placeholder {
       font-style: italic;

--- a/src/core/style/action/module/_input.scss
+++ b/src/core/style/action/module/_input.scss
@@ -4,6 +4,7 @@
 ////
 
 input,
+input[type="search"],
 select,
 textarea {
   -webkit-appearance: none;


### PR DESCRIPTION
- En utilisant des librairies tierces (telles que normalize.css), le champ de recherche reprend son aspect natif arrondi en mobile IOS. 
- Spécificité renforcée sur le sélecteur afin de conserver le `appearance: none`