### PR TITLE
:bug: fix(example): retire les attributs file des <link> [DS-3307]

### DIFF
--- a/tool/example/style.ejs
+++ b/tool/example/style.ejs
@@ -4,6 +4,6 @@ for (const file of Object.keys(files.style)) {
   const dependencies = files.style[file];
   for (const dependency of dependencies) {
 %>
-  <link href="<%= relativeRoot %><%= dependency %>" rel="stylesheet" file="<%= file %>">
+  <link href="<%= relativeRoot %><%= dependency %>" rel="stylesheet">
 <% }
 } %>


### PR DESCRIPTION
- l'attribut file n'est pas un attribut possible pour les éléments <link>