### PR TITLE
:bug: fix(search): hauteur du champ trop grande de 1px sur ios [DS-3312]

### DIFF
--- a/src/component/search/style/_module.scss
+++ b/src/component/search/style/_module.scss
@@ -15,7 +15,7 @@
   #{ns(input)} {
     @include margin(0);
     border-radius: spacing.space(1v) 0 0;
-    max-height: none;
+    @include max-height(10v);
 
     /* TODO: intégrer la croix en background pour effacer la search bar
     &::-webkit-search-cancel-button {
@@ -35,5 +35,9 @@
 
   &--lg {
     @include nest-btn(lg, left, null, md);
+
+    #{ns(input)} {
+      @include max-height(12v, md);
+    }
   }
 }


### PR DESCRIPTION
Sur ios le champ dépasse de 1px par rapport au bouton.

-> Correction du max-height