### PR TITLE
:sparkles: feat(select, input): ajout de la bordure en état erreur / succés / info [DS-3308]

### DIFF
--- a/src/component/input/input-base/style/_module.scss
+++ b/src/component/input/input-base/style/_module.scss
@@ -96,9 +96,23 @@
 }
 
 #{ns(input-group)} {
+  @include relative;
+
   #{ns(message)} {
     &:first-child {
       @include margin-top(2v);
+    }
+  }
+
+  &--valid,
+  &--error,
+  &--info {
+    @include before('', block) {
+      pointer-events: none;
+      @include absolute(0, -3v, 0, -3v);
+      background-repeat: no-repeat;
+      background-position: 0 0;
+      background-size: spacing.space(0.5v 100%);
     }
   }
 }

--- a/src/component/input/input-base/style/_scheme.scss
+++ b/src/component/input/input-base/style/_scheme.scss
@@ -48,6 +48,24 @@
     &-group--error & {
       @include color.box-shadow(plain error, (legacy:$legacy), bottom-2-in);
     }
+
+    &-group--error {
+      @include before {
+        @include color.background-image(border plain error, (legacy:$legacy));
+      }
+    }
+
+    &-group--valid {
+      @include before {
+        @include color.background-image(border plain success, (legacy:$legacy));
+      }
+    }
+
+    &-group--info {
+      @include before {
+        @include color.background-image(border plain info, (legacy:$legacy));
+      }
+    }
   }
 
   #{ns(input-wrap)} {

--- a/src/component/select/style/_module.scss
+++ b/src/component/select/style/_module.scss
@@ -20,9 +20,23 @@
 }
 
 #{ns(select-group)} {
+  @include relative;
+
   #{ns(message)} {
     &:first-child {
       @include margin-top(2v);
+    }
+  }
+
+  &--valid,
+  &--error,
+  &--info {
+    @include before('', block) {
+      pointer-events: none;
+      @include absolute(0, -3v, 0, -3v);
+      background-repeat: no-repeat;
+      background-position: 0 0;
+      background-size: spacing.space(0.5v 100%);
     }
   }
 }

--- a/src/component/select/style/_scheme.scss
+++ b/src/component/select/style/_scheme.scss
@@ -24,6 +24,24 @@
       @include color.box-shadow(plain error, (legacy:$legacy), bottom-2-in);
     }
 
+    &-group--error {
+      @include before {
+        @include color.background-image(border plain error, (legacy:$legacy));
+      }
+    }
+
+    &-group--valid {
+      @include before {
+        @include color.background-image(border plain success, (legacy:$legacy));
+      }
+    }
+
+    &-group--info {
+      @include before {
+        @include color.background-image(border plain info, (legacy:$legacy));
+      }
+    }
+
     /**
     * Mixin pour gérer l'état disabled
     */


### PR DESCRIPTION
Actuellement la bordure gauche montrant l'état d'erreur/succès/info n'est appliqué que dans le cas d'un groupe de champ en erreur via les modificateur .fr-fieldset--error, .fr-fieldset--valid, .fr-fieldset--info

Afin d'être ISO avec l'UI nous rajoutons cet élément visuel sur : 
- les champs seuls (.fr-input-group) : 
  - `.fr-input-group--error`
  - `.fr-input-group--valid`
  - `.fr-input-group--info`
- les selects (.fr-select-group)
  - `.fr-select-group--error`
  - `.fr-select-group--valid`
  - `.fr-select-group--info`