### PR TITLE
fix(core): apparence du champ de recherche iOS

### DIFF
--- a/src/core/style/action/module/_input.scss
+++ b/src/core/style/action/module/_input.scss
@@ -6,9 +6,7 @@
 input,
 select,
 textarea {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
+  @include appearance(none);
   @include font-family;
   @include text-adjustments;
   border-radius: 0;
@@ -17,10 +15,13 @@ textarea {
   margin: 0; // Address margins set differently in Firefox 4+, Safari, and Chrome.
 }
 
+// Fix for normalize.css
+input[type=search] {
+  @include appearance(none);
+}
+
 // Fix for NVDA
 input[type="checkbox"],
 input[type="radio"] {
-  -webkit-appearance: auto;
-  -moz-appearance: auto;
-  appearance: auto;
+  @include appearance;
 }

--- a/src/core/style/action/tool/_input.scss
+++ b/src/core/style/action/tool/_input.scss
@@ -1,0 +1,10 @@
+////
+/// Core Tool : input
+/// @group core
+////
+
+@mixin appearance($appearance: auto) {
+  -webkit-appearance: $appearance;
+  -moz-appearance: $appearance;
+  appearance: $appearance;
+}


### PR DESCRIPTION
En utilisant des librairies tierces (telles que normalize.css), le champ de recherche reprend son aspect natif arrondi en mobile IOS.
Spécificité renforcée sur le sélecteur afin de conserver le appearance: none