### PR TITLE
🐛 fix(core): correctif bug proxy Toggle [DS-3351]

### DIFF
--- a/src/core/script/action/toggle/toggle.js
+++ b/src/core/script/action/toggle/toggle.js
@@ -13,6 +13,10 @@ class Toggle extends Instance {
   }
 
   handleClick () {
+    this.toggle();
+  }
+
+  toggle () {
     this.pressed = this.pressed !== 'true';
   }
 


### PR DESCRIPTION
- Dans la class Toggle, le proxy appelle la fonction toggle qui a été remplacée par la fonction générique handleClick : 
- Ce correctif restaure la fonction toggle et implémente son appel dans handleClick