### PR TITLE
🐛 fix(unexpected): corrige groupe de bouton vide [DS-3324]

### DIFF
--- a/src/page/response/template/ejs/response.ejs
+++ b/src/page/response/template/ejs/response.ejs
@@ -46,22 +46,24 @@
                     </p>
                 <% } %>
 
-                <ul class="fr-btns-group fr-btns-group--inline-md">
-                    <% if(home) { %>
-                        <li>
-                            <a class="<%= prefix %>-btn" href="/">
-                                <%= home %>
-                            </a>
-                        </li>
-                    <% } %>
-                    <% if(contact) { %>
-                        <li>
-                            <a class="<%= prefix %>-btn <%= prefix %>-btn--secondary" href="<%= contact.href %>">
-                                <%= contact.button %>
-                            </a>
-                        </li>
-                    <% } %>
-                </ul>
+                <% if (home || contact) { %>
+                    <ul class="fr-btns-group fr-btns-group--inline-md">
+                        <% if(home) { %>
+                            <li>
+                                <a class="<%= prefix %>-btn" href="/">
+                                    <%= home %>
+                                </a>
+                            </li>
+                        <% } %>
+                        <% if(contact) { %>
+                            <li>
+                                <a class="<%= prefix %>-btn <%= prefix %>-btn--secondary" href="<%= contact.href %>">
+                                    <%= contact.button %>
+                                </a>
+                            </li>
+                        <% } %>
+                    </ul>
+                <% } %>
             </div>
             <div class="<%= prefix %>-col-12 <%= prefix %>-col-md-3 <%= prefix %>-col-offset-md-1 <%= prefix %>-px-6w <%= prefix %>-px-md-0 <%= prefix %>-py-0">
                 <svg xmlns="http://www.w3.org/2000/svg" class="<%= prefix %>-responsive-img fr-artwork" aria-hidden="true" width="160" height="200" viewBox="0 0 160 200">


### PR DESCRIPTION
- ajoute une condition sur l'ajout du wrapper `.fr-btns-group` dans la template `ejs`