### PR TITLE
🐛 feat(company): accessibilité lien externe [DS-3326]

### DIFF
--- a/src/component/tile/template/ejs/content.ejs
+++ b/src/component/tile/template/ejs/content.ejs
@@ -13,7 +13,7 @@
 
 * content.markup (string, optional) : (défaut : h3) niveau de titre
 
-* content.blank (boolean, optional) : Ajoute l'attribut target="_blank" pour ouvrir le lien dans un nouvel onglet
+* content.blank (boolean, optional) : Ajoute l'attribut target="_blank" pour ouvrir le lien dans une nouvelle fenêtre
 
 * content.downloadable (boolean, optional) : Ajoute l'attribut download au lien
 

--- a/src/pattern/company/example/data/siret.json.ejs
+++ b/src/pattern/company/example/data/siret.json.ejs
@@ -22,6 +22,7 @@ const data = {
         label: getText('directory.label', 'company'),
         href: getText('directory.href', 'company'),
         attributes: {
+          title: `${getText('directory.label', 'company')} - nouvelle fenêtre`,
           target: '_blank',
           rel: 'noopener'
         },


### PR DESCRIPTION
- corrige l'accessibilité du lien en `target="_blank"` par l'ajout d'un attribut `title`  :  "Annuaire des entreprises – nouvelle fenêtre"