### PR TITLE
:bug: fix(pagination): correctif régression href des exemples [DS-3380]

### DIFF
--- a/src/component/pagination/example/sample/pagination.ejs
+++ b/src/component/pagination/example/sample/pagination.ejs
@@ -9,6 +9,7 @@ const getData = (label, displayedLg = false, hasLgLabel = false, title = null) =
     id: uniqueId('pagination'),
     label: label,
     title: title,
+    href: href,
     displayedLg: displayedLg === true,
     hasLgLabel: hasLgLabel === true
   };


### PR DESCRIPTION
- Corrige la régression qui a supprimé les liens des éléments de pagination