### PR TITLE
🐛 fix(consent): correctif espacement et couleur [DS-3370, DS-3369]

### DIFF
--- a/src/component/consent/style/_scheme.scss
+++ b/src/component/consent/style/_scheme.scss
@@ -36,5 +36,9 @@
     #{ns(consent-service)} {
       @include color.no-box-shadow((legacy: $legacy));
     }
+
+    #{ns(consent-service__collapse-btn)} {
+      @include color.text(action-high blue-france, (legacy:$legacy));
+    }
   }
 }

--- a/src/component/consent/style/_setting.scss
+++ b/src/component/consent/style/_setting.scss
@@ -11,7 +11,6 @@ $consent-btn-settings:(
     )
   ),
   places: right,
-  underline: true,
   display: flex,
   no-modifier: true
 );

--- a/src/component/consent/style/module/_services.scss
+++ b/src/component/consent/style/module/_services.scss
@@ -45,10 +45,10 @@
 
   &__desc {
     @include text-style(sm);
-    @include set-text-margin(3v 0 3v 0);
+    @include set-text-margin(3v 0 2v 0);
 
     @include respond-from(md) {
-      @include set-text-margin(1v 6v 3v 0);
+      @include set-text-margin(1v 6v 2v 0);
       @include size(60%);
     }
   }


### PR DESCRIPTION
- Corrige description d'une finalité de 3v à 2v en margin-bottom
- Homogénéité avec accordion, nav et sidemenu sur le bouton de la modale de consentement “voir plus de détails” :
   - enlever le soulignement
   - mettre en bleu le lien “voir plus de détail”