### PR TITLE
🐛 fix(name): a11y - gestion du focus [DS-3325]

### DIFF
--- a/src/pattern/name/example/index.ejs
+++ b/src/pattern/name/example/index.ejs
@@ -3,6 +3,7 @@ const sample = getSample(include);
 %>
 <script type="module">
   <%- include('./js/add-firstname.js'); %>
+  <%- include('./js/remove-firstname.js'); %>
   <%- include('./js/toggle-disabled.js'); %>
 </script>
 

--- a/src/pattern/name/example/js/add-firstname.js
+++ b/src/pattern/name/example/js/add-firstname.js
@@ -27,7 +27,7 @@ window.addFirstname = (button, id) => {
   removeButton.innerHTML = labelRemoveButton;
   removeButton.title = labelRemoveButton;
 
-  removeButton.setAttribute('onclick', 'this.copy.remove()');
+  removeButton.setAttribute('onclick', 'removeFirstname(this.copy)');
   removeButton.copy = copy;
 
   wrapper.appendChild(copy.getElementsByTagName('input')[0]);

--- a/src/pattern/name/example/js/remove-firstname.js
+++ b/src/pattern/name/example/js/remove-firstname.js
@@ -1,9 +1,12 @@
 window.removeFirstname = (copy) => {
   const attrGivenName = '[name=given-name]';
-  const givens = copy.parentNode.querySelectorAll(attrGivenName);
-  copy.remove();
-  if (givens.length) {
-    const lastGiven = givens[givens.length - 1] !== copy.querySelector(attrGivenName) ? givens[givens.length - 1] : givens[givens.length - 2];
-    lastGiven.focus();
+  const fieldsetElements = copy.parentNode.querySelectorAll('.fr-fieldset__element');
+  if (copy.nextSibling.querySelector(attrGivenName)) {
+    copy.nextSibling.querySelector(attrGivenName).focus();
+  } else {
+    if (fieldsetElements.length) {
+      fieldsetElements[fieldsetElements.length - 1].querySelector('button').focus();
+    }
   }
+  copy.remove();
 };

--- a/src/pattern/name/example/js/remove-firstname.js
+++ b/src/pattern/name/example/js/remove-firstname.js
@@ -1,12 +1,4 @@
 window.removeFirstname = (copy) => {
-  const attrGivenName = '[name=given-name]';
-  const fieldsetElements = copy.parentNode.querySelectorAll('.fr-fieldset__element');
-  if (copy.nextSibling.querySelector(attrGivenName)) {
-    copy.nextSibling.querySelector(attrGivenName).focus();
-  } else {
-    if (fieldsetElements.length) {
-      fieldsetElements[fieldsetElements.length - 1].querySelector('button').focus();
-    }
-  }
+  copy.nextSibling.querySelector('input,button').focus();
   copy.remove();
 };

--- a/src/pattern/name/example/js/remove-firstname.js
+++ b/src/pattern/name/example/js/remove-firstname.js
@@ -1,0 +1,9 @@
+window.removeFirstname = (copy) => {
+  const attrGivenName = '[name=given-name]';
+  const givens = copy.parentNode.querySelectorAll(attrGivenName);
+  copy.remove();
+  if (givens.length) {
+    const lastGiven = givens[givens.length - 1] !== copy.querySelector(attrGivenName) ? givens[givens.length - 1] : givens[givens.length - 2];
+    lastGiven.focus();
+  }
+};

--- a/src/pattern/name/example/js/toggle-disabled.js
+++ b/src/pattern/name/example/js/toggle-disabled.js
@@ -1,5 +1,8 @@
 window.toggleDisabled = (checkbox, id) => {
   const fieldset = document.getElementById(id);
   if (checkbox.checked) fieldset.setAttribute('disabled', '');
-  else fieldset.removeAttribute('disabled');
+  else {
+    fieldset.removeAttribute('disabled');
+    fieldset.querySelector('[name=given-name]').focus();
+  }
 };

--- a/src/pattern/name/example/js/toggle-disabled.js
+++ b/src/pattern/name/example/js/toggle-disabled.js
@@ -3,6 +3,6 @@ window.toggleDisabled = (checkbox, id) => {
   if (checkbox.checked) fieldset.setAttribute('disabled', '');
   else {
     fieldset.removeAttribute('disabled');
-    fieldset.querySelector('[name=given-name]').focus();
+    fieldset.querySelector('input, button').focus();
   }
 };


### PR DESCRIPTION
Ajoute dans la page d’exemple le déplacement du focus : 
- au click sur la checkbox de désactivation pour activer, le premier champ ou bouton prend le focus
- au click sur l’ajout d’un prénom, le champs ajouté prend le focus
- au click sur la suppression, le champ ou bouton suivant prend le focus