### PR TITLE
:bug: fix(footer): retrait de CSS obsolète [DS-3404]

### DIFF
--- a/src/component/footer/style/module/_bottom.scss
+++ b/src/component/footer/style/module/_bottom.scss
@@ -19,8 +19,6 @@
   * Liste de liens avec séparateur
   */
   &__bottom-list {
-    flex-wrap: wrap;
-    align-items: center;
     @include size(100%);
     @include padding(2v 0 4v);
     @include size(100%);


### PR DESCRIPTION
- retrait de CSS résiduel de précédentes versions dans le footer-bottom__list