### PR TITLE
:bug: fix(password): retrait du bouton natif sur edge [DS-3378]

### DIFF
--- a/src/component/password/style/_module.scss
+++ b/src/component/password/style/_module.scss
@@ -30,6 +30,10 @@
     &::-webkit-caps-lock-indicator {
       content: none;
     }
+    
+    &::-ms-reveal {
+      display: none
+    }
   }
 
   &__label {


### PR DESCRIPTION
- Sur edge une icône oeil apparaît au focus d'un champ de type "password"
- Retrait de l'icone native