### PR TITLE
fix(form): icone message erreur/succès alignée en haut [DS-3378]

### DIFF
--- a/src/component/form/style/module/_message.scss
+++ b/src/component/form/style/module/_message.scss
@@ -1,5 +1,5 @@
 #{ns(message)} {
-  @include display-flex(row, center);
+  @include display-flex(row, flex-start);
   @include text-style(xs);
   @include margin(0 0 1v 0);
 
@@ -13,6 +13,7 @@
     @include icon(null, sm, before) {
       display: inline-block;
       @include margin-right(1v);
+      @include margin-top(0.5v);
     }
   }
 


### PR DESCRIPTION
- l'icone à gauche des messages d'erreur/succès sur plusieurs lignes doit être alignée en haut et non pas centrée