### PR TITLE
🐛 fix(civility): correctif taille des boutons radio [DS-3389]

### DIFF
--- a/src/pattern/civility/example/data/honorific-radio.json.ejs
+++ b/src/pattern/civility/example/data/honorific-radio.json.ejs
@@ -11,7 +11,8 @@ const data = {
       data: {
         name: 'honorific',
         id: uniqueId('honorific'),
-        label: getText(`option.${key}`, key === 'no-answer' ? 'radio' : 'civility')
+        label: getText(`option.${key}`, key === 'no-answer' ? 'radio' : 'civility'),
+        size: 'sm'
       }
     };
   })


### PR DESCRIPTION
- Corrige la taille des boutons radio du titre d'appel en sm au lieu de md