### PR TITLE
✨ feat(navigation, header, sidemenu): homogénéisation des espacements et indentation [DS-3356]

### DIFF
--- a/src/component/accordion/style/_module.scss
+++ b/src/component/accordion/style/_module.scss
@@ -35,9 +35,6 @@
       @include margin-right(0);
       @include margin-left(auto);
     }
-
-    @include padding(3v 0);
-    @include padding(3v 4v, md);
   }
 
   #{ns(collapse)} {

--- a/src/component/header/style/module/_links.scss
+++ b/src/component/header/style/module/_links.scss
@@ -43,7 +43,7 @@
 
   & &__menu-links {
     @include after('', block) {
-      @include margin(3v -4v);
+      @include margin(3v -4v 0);
       @include size(calc(100% + 8v), 1px);
     }
 

--- a/src/component/header/style/module/_links.scss
+++ b/src/component/header/style/module/_links.scss
@@ -43,7 +43,7 @@
 
   & &__menu-links {
     @include after('', block) {
-      @include margin(3v -4v 0);
+      @include margin(3v -4v);
       @include size(calc(100% + 8v), 1px);
     }
 

--- a/src/component/header/style/module/_nav.scss
+++ b/src/component/header/style/module/_nav.scss
@@ -5,12 +5,12 @@
 
 #{ns(header)} {
   #{ns(nav)} {
-    &__list {
-      @include margin(0 -4v);
-    }
-
     @include respond-from(lg) {
       justify-content: flex-start;
+
+      &__list {
+        @include margin(0 -4v);
+      }
     }
   }
 }

--- a/src/component/header/style/module/_nav.scss
+++ b/src/component/header/style/module/_nav.scss
@@ -11,10 +11,6 @@
 
     @include respond-from(lg) {
       justify-content: flex-start;
-
-      &__list {
-        max-width: calc(100% + #{space(4v)});
-      }
     }
   }
 }

--- a/src/component/header/style/module/_nav.scss
+++ b/src/component/header/style/module/_nav.scss
@@ -5,12 +5,15 @@
 
 #{ns(header)} {
   #{ns(nav)} {
+    &__list {
+      @include margin(0 -4v);
+    }
+
     @include respond-from(lg) {
       justify-content: flex-start;
 
       &__list {
         max-width: calc(100% + #{space(4v)});
-        @include margin(0 -4v);
       }
     }
   }

--- a/src/component/navigation/style/module/_default.scss
+++ b/src/component/navigation/style/module/_default.scss
@@ -84,7 +84,7 @@
   &__link,
   &__btn {
     @include size(100%);
-    @include padding(3v 0);
+    @include padding(3v 4v);
     @include text-style(md);
     text-align: left;
 
@@ -97,7 +97,7 @@
     &[aria-current] {
       position: relative;
       @include before('', block) {
-        @include absolute(50%, null, null, -4v, 2px, 6v);
+        @include absolute(50%, null, null, 0, 2px, 6v);
         @include margin-top(-3v);
       }
     }

--- a/src/component/navigation/style/module/_mega-menu.scss
+++ b/src/component/navigation/style/module/_mega-menu.scss
@@ -4,8 +4,6 @@
 ////
 
 #{ns(mega-menu)} {
-  @include margin(0 -4v 1px);
-
   @include respond-from(lg) {
     @include absolute(100%, 0, null, 0);
     @include margin(0);
@@ -48,10 +46,8 @@
 
   &__leader {
     @include enable-underline;
-    @include padding-x(4v);
     @include padding-top(2v);
     @include padding-top(0, lg);
-    @include padding-x(0, lg);
     @include set-text-margin(0 0 2v);
     @include set-title-margin(0 0 2v);
   }
@@ -61,7 +57,7 @@
   }
 
   &__list {
-    @include padding-bottom(6v);
+    @include padding-bottom(4v);
 
     @include relative;
     @include before('', block) {

--- a/src/component/navigation/style/module/_menu.scss
+++ b/src/component/navigation/style/module/_menu.scss
@@ -20,7 +20,7 @@
 
   @include list {
     @include margin(0);
-    @include padding(2v 0 6v);
+    @include padding(0 4v 4v);
 
     @include respond-from(lg) {
       @include width(80v);

--- a/src/component/navigation/style/scheme/_default.scss
+++ b/src/component/navigation/style/scheme/_default.scss
@@ -21,10 +21,8 @@
 
     &__btn {
       &[aria-expanded="true"]:not(:disabled) {
-        @include respond-from(lg) {
-          @include color.text(active blue-france, (legacy: $legacy));
-          @include color.background(open blue-france, (legacy: $legacy));
-        }
+        @include color.background(open blue-france, (legacy: $legacy));
+        @include color.text(active blue-france, (legacy: $legacy));
       }
     }
 

--- a/src/component/sidemenu/style/module/_action.scss
+++ b/src/component/sidemenu/style/module/_action.scss
@@ -11,7 +11,7 @@
   @include relative;
   @include display-flex(row, center);
   @include size(100%);
-  @include padding(3v 2v);
+  @include padding(3v 4v);
   @include margin(0, md);
   @include text-style(md);
   text-align: left;
@@ -42,7 +42,7 @@
 #{ns(sidemenu__btn)} {
   &[aria-expanded] {
     @include display-flex(row, center);
-    @include padding(3v 8v 3v 2v, md);
+    @include padding(3v 10v 3v 4v, md);
 
     @include icon(arrow-down-s-line, sm, after) {
       @include margin-left(auto);

--- a/src/component/sidemenu/style/module/_inner.scss
+++ b/src/component/sidemenu/style/module/_inner.scss
@@ -13,7 +13,7 @@
     */
     > #{ns(collapse)} {
       @include margin(-1v 3v 0);
-      @include padding(1v 1v 0);
+      @include padding(1v 3v 0);
       @include padding(0, md);
       @include margin(0, md);
 

--- a/src/component/sidemenu/style/module/_list.scss
+++ b/src/component/sidemenu/style/module/_list.scss
@@ -8,7 +8,7 @@
     font-weight: font-weight('bold');
 
     #{ns(sidemenu__list)} {
-      @include margin(0 2v 4v);
+      @include margin(0 4v 4v);
       @include margin(0 4v 4v, md);
       font-weight: font-weight();
 
@@ -22,7 +22,6 @@
         #{ns(sidemenu__link)},
         #{ns(sidemenu__btn)} {
           @include text-style(sm);
-          @include padding(3v 2v, md);
         }
       }
     }


### PR DESCRIPTION
- Uniformisation du menu latéral, navigation, et accordéon
  - ajout d'un fond open-blue-france et du texte en blue-france sur les boutons d'ouverture en état ouvert
  - ajout de marge pour indenter les sous menus
  - ajustement des espacements
- Ajustement de la navigation du header en mobile
- Ajustement de la taille max de la navigation dans le header en desktop