### PR TITLE
🐛 fix(transcription): a11y retour audit [DS-3457]

### DIFF
--- a/src/component/header/script/header/header-modal.js
+++ b/src/component/header/script/header/header-modal.js
@@ -20,7 +20,6 @@ class HeaderModal extends api.core.Instance {
   }
 
   activateModal () {
-    this.setAttribute('role', 'dialog');
     const modal = this.element.getInstance('Modal');
     if (!modal) return;
     modal.isEnabled = true;
@@ -39,7 +38,6 @@ class HeaderModal extends api.core.Instance {
     if (!modal) return;
     modal.conceal();
     modal.isEnabled = false;
-    this.removeAttribute('role');
     this.removeAttribute('aria-labelledby');
     this.unlisten('click', this._clickHandling, { capture: true });
   }

--- a/src/component/modal/script/modal/modal-selector.js
+++ b/src/component/modal/script/modal/modal-selector.js
@@ -3,5 +3,6 @@ import api from '../../api.js';
 export const ModalSelector = {
   MODAL: api.internals.ns.selector('modal'),
   SCROLL_DIVIDER: api.internals.ns.selector('scroll-divider'),
-  BODY: api.internals.ns.selector('modal__body')
+  BODY: api.internals.ns.selector('modal__body'),
+  TITLE: api.internals.ns.selector('modal__title')
 };

--- a/src/component/modal/script/modal/modal.js
+++ b/src/component/modal/script/modal/modal.js
@@ -6,6 +6,7 @@ import { ModalAttribute } from './modal-attribute';
 class Modal extends api.core.Disclosure {
   constructor () {
     super(api.core.DisclosureType.OPENED, ModalSelector.MODAL, ModalButton, 'ModalsGroup');
+    this._isDialog = true;
     this.scrolling = this.resize.bind(this, false);
     this.resizing = this.resize.bind(this, true);
   }
@@ -16,6 +17,10 @@ class Modal extends api.core.Disclosure {
 
   init () {
     super.init();
+    this._isDialog = this.node.tagName === 'DIALOG';
+    this.modalTitle = this.node.querySelector(ModalSelector.TITLE);
+    if (this._isDialog) this.setTitleId();
+    this.isScrolling = false;
     this.listenClick();
     this.listenKey(api.core.KeyCodes.ESCAPE, this.conceal.bind(this, false, false), true, true);
   }
@@ -34,6 +39,9 @@ class Modal extends api.core.Disclosure {
     this.isScrollLocked = true;
     this.setAttribute('aria-modal', 'true');
     this.setAttribute('open', 'true');
+    if (!this._isDialog) {
+      this.activateModal();
+    }
     return true;
   }
 
@@ -43,7 +51,38 @@ class Modal extends api.core.Disclosure {
     this.removeAttribute('aria-modal');
     this.removeAttribute('open');
     if (this.body) this.body.deactivate();
+    if (!this._isDialog) {
+      this.deactivateModal();
+    }
     return true;
+  }
+
+  get isDialog () {
+    return this._isDialog;
+  }
+
+  set isDialog (value) {
+    this._isDialog = value;
+  }
+
+  activateModal () {
+    this.setAttribute('role', 'dialog');
+    if (this.modalTitle) this.setAttribute('aria-labelledby', this.modalTitle.id);
+  }
+
+  deactivateModal () {
+    this.removeAttribute('role');
+    this.removeAttribute('aria-labelledby');
+  }
+
+  setTitleId () {
+    if (this.modalTitle) {
+      if (!this.modalTitle.id && this.id) {
+        this.modalTitle.setAttribute('id', `${this.id}-title`);
+      }
+    } else {
+      console.warn('modal component requires a title with class .modal__title');
+    }
   }
 
   _electPrimary (candidates) {

--- a/src/component/modal/template/ejs/modal.ejs
+++ b/src/component/modal/template/ejs/modal.ejs
@@ -3,6 +3,8 @@
 
 * modal.id (string, required) : id de la modale
 
+* modal.tag (string, required) : balise de la modale (dialog, div>)
+
 * modal.label (string, required) : label du bouton de la modale
 
 * modal.title (string, required) : titre de la modale
@@ -35,6 +37,8 @@
 
 <%
 let modal = locals.modal || {};
+let modalTag = modal.tag || 'dialog';
+const isDialog = modalTag === 'dialog';
 let modalClasses = modal.classes || [];
 modalClasses.push(`${prefix}-modal`);
 
@@ -81,7 +85,7 @@ const titleId = modal.id + '-title';
 
 modalAttrs.role = 'dialog';
 
-if (modal.title) modalAttrs['aria-labelledby'] = titleId;
+if (isDialog && modal.title) modalAttrs['aria-labelledby'] = titleId;
 
 if (modal.top) modalClasses.push(`${prefix}-modal--top`);
 
@@ -89,7 +93,7 @@ if (modal.concealingBackdrop !== undefined) modalAttrs[`data-${prefix}-concealin
 
 %>
 
-<dialog id="<%= modal.id %>" <%- includeClasses(modalClasses) %> <%- includeAttrs(modalAttrs); %>>
+<<%= modalTag %> id="<%= modal.id %>" <%- includeClasses(modalClasses) %> <%- includeAttrs(modalAttrs); %>>
   <div class="<%= prefix %>-container <%= prefix %>-container--fluid <%= prefix %>-container-md">
     <div class="<%= prefix %>-grid-row <%= prefix %>-grid-row--center">
       <div <%- includeClasses(gridClasses); %>>
@@ -120,4 +124,4 @@ if (modal.concealingBackdrop !== undefined) modalAttrs[`data-${prefix}-concealin
       </div>
     </div>
   </div>
-</dialog>
+</<%= modalTag %>>

--- a/src/component/transcription/example/sample/transcription-default.ejs
+++ b/src/component/transcription/example/sample/transcription-default.ejs
@@ -5,6 +5,7 @@ let data = {
   title: getText('modal.title', 'transcription'),
   content: transcription.content || randomContent(['text', 'list']),
   fullscreen: getText('button.fullscreen', 'transcription'),
+  fullscreenAriaLabel: getText('button.fullscreenAriaLabel', 'transcription'),
   ...transcription
 }
 %>

--- a/src/component/transcription/i18n/fr.yml
+++ b/src/component/transcription/i18n/fr.yml
@@ -9,6 +9,7 @@ modal:
 button:
   close: Fermer
   fullscreen: Agrandir
+  fullscreenAriaLabel: Agrandir la transcription
 link:
   download: Télécharger
 sample:

--- a/src/component/transcription/style/_module.scss
+++ b/src/component/transcription/style/_module.scss
@@ -70,6 +70,8 @@
   }
 
   #{ns(collapse)} {
+    @include display-flex(column-reverse);
+
     &--expanded {
       @include margin(0 0.25v);
     }

--- a/src/component/transcription/template/ejs/transcription.ejs
+++ b/src/component/transcription/template/ejs/transcription.ejs
@@ -26,6 +26,7 @@ const title = getText('collapse.title', 'transcription');
 if (transcription.id) attributes.id = transcription.id;
 
 let modal = {
+  tag: 'div',
   title: transcription.title,
   body: transcription.content,
   id: transcription.modalId || uniqueId('modal-transcription'),
@@ -38,11 +39,11 @@ let collapseId = prefix + '-transcription-collapse-' + transcription.id;
 <div class="<%= prefix %>-transcription" <%- includeAttrs(attributes) %>>
   <button class="<%= prefix %>-transcription__btn" aria-expanded="<%= isExpanded %>" aria-controls="<%= collapseId %>"><%= title %></button>
   <div class="<%= prefix %>-collapse" id="<%= collapseId %>">
-    <%- include('../../../modal/template/ejs/modal.ejs', {modal: { ...modal, id: modalId }}) %>
     <div class="<%= prefix %>-transcription__footer">
       <div class="<%= prefix %>-transcription__actions-group">
-        <%- include('../../../button/template/ejs/button.ejs', { button: {label: transcription.fullscreen, title: transcription.fullscreen, classes: [prefix + '-btn--fullscreen'], attributes: {'aria-controls': modalId, 'data-fr-opened': false} } } ); %>
+        <%- include('../../../button/template/ejs/button.ejs', { button: {label: transcription.fullscreen, title: transcription.fullscreen, classes: [prefix + '-btn--fullscreen'], attributes: {'aria-controls': modalId, 'aria-label': transcription.fullscreenAriaLabel, 'data-fr-opened': false} } } ); %>
       </div>
     </div>
+    <%- include('../../../modal/template/ejs/modal.ejs', {modal: { ...modal, id: modalId }}) %>
   </div>
 </div>


### PR DESCRIPTION
- place le bouton d’agrandissement avant la modale et inverse les elements via css
- ajoute `aria-label=”Agrandir la transcription”` sur le bouton d’agrandissement
- remplace la balise dialog par une balise div et retire le `aria-labelledby`
- ajoute un console.warn si absence de `fr-modal__title`