### PR TITLE
🐛 fix(tooltip) : a11y tooltip hover [DS-3461,DS-3462,DS-3463]

### DIFF
--- a/src/component/tooltip/example/sample/tooltip-text.ejs
+++ b/src/component/tooltip/example/sample/tooltip-text.ejs
@@ -9,7 +9,7 @@ let data = {
   ...tooltip
 };
 let triggerText = tooltip.triggerText || getText('sample.example', 'tooltip');
-let tooltipTarget = `<span class="${prefix}-text--bold" aria-describedby="${tooltipId}">${triggerText}</span>`;
+let tooltipTarget = `<span class="${prefix}-text--bold" tabindex="0" aria-describedby="${tooltipId}">${triggerText}</span>`;
 let paragraphInsert = tooltipTarget + include('../sample/tooltip-default', {tooltip: data});
 %>
 

--- a/src/component/tooltip/script/tooltip/tooltip-referent.js
+++ b/src/component/tooltip/script/tooltip/tooltip-referent.js
@@ -22,7 +22,9 @@ class TooltipReferent extends api.core.PlacementReferent {
     this.listen('focusout', this.focusout.bind(this));
     if (!this.matches(TooltipSelector.BUTTON)) {
       this.listen('mouseover', this.mouseover.bind(this));
+      this.placement.listen('mouseover', this.mouseover.bind(this));
       this.listen('mouseout', this.mouseout.bind(this));
+      this.placement.listen('mouseout', this.mouseout.bind(this));
     }
     this.listenKey(api.core.KeyCodes.ESCAPE, this.escape.bind(this), true, true);
   }

--- a/src/component/tooltip/script/tooltip/tooltip.js
+++ b/src/component/tooltip/script/tooltip/tooltip.js
@@ -65,7 +65,7 @@ class Tooltip extends api.core.Placement {
     const limit = this.rect.width * 0.5 - 8;
     if (x < -limit) x = -limit;
     if (x > limit) x = limit;
-    this.setProperty('--arrow-x', x.toFixed(2));
+    this.setProperty('--arrow-x', `${x.toFixed(2)}px`);
   }
 }
 

--- a/src/component/tooltip/script/tooltip/tooltip.js
+++ b/src/component/tooltip/script/tooltip/tooltip.js
@@ -22,6 +22,9 @@ class Tooltip extends api.core.Placement {
 
   init () {
     super.init();
+    if (!this.node.parentNode.querySelector(`[aria-describedby="${this.id}"]`).classList.contains(api.internals.ns.selector('btn--tooltip', ''))) {
+      this.register(`span[id="${this.id}"]`, TooltipReferent);
+    }
     this.register(`[aria-describedby="${this.id}"]`, TooltipReferent);
     this.listen('transitionend', this.transitionEnd.bind(this));
   }
@@ -65,7 +68,7 @@ class Tooltip extends api.core.Placement {
     const limit = this.rect.width * 0.5 - 8;
     if (x < -limit) x = -limit;
     if (x > limit) x = limit;
-    const roundedX = Math.round((x + Number.EPSILON) * 100) / 100; // arrondi a 2 décimal
+    const roundedX = Math.round((x + Number.EPSILON) * 100) / 100; // arrondi à 2 décimal
     this.setProperty('--arrow-x', `${roundedX}px`);
   }
 }

--- a/src/component/tooltip/script/tooltip/tooltip.js
+++ b/src/component/tooltip/script/tooltip/tooltip.js
@@ -65,7 +65,8 @@ class Tooltip extends api.core.Placement {
     const limit = this.rect.width * 0.5 - 8;
     if (x < -limit) x = -limit;
     if (x > limit) x = limit;
-    this.setProperty('--arrow-x', `${x}px`);
+    const roundedX = Math.round((x + Number.EPSILON) * 100) / 100; // arrondi a 2 décimal
+    this.setProperty('--arrow-x', `${roundedX}px`);
   }
 }
 

--- a/src/component/tooltip/script/tooltip/tooltip.js
+++ b/src/component/tooltip/script/tooltip/tooltip.js
@@ -22,9 +22,6 @@ class Tooltip extends api.core.Placement {
 
   init () {
     super.init();
-    if (!this.node.parentNode.querySelector(`[aria-describedby="${this.id}"]`).classList.contains(api.internals.ns.selector('btn--tooltip', ''))) {
-      this.register(`span[id="${this.id}"]`, TooltipReferent);
-    }
     this.register(`[aria-describedby="${this.id}"]`, TooltipReferent);
     this.listen('transitionend', this.transitionEnd.bind(this));
   }
@@ -68,8 +65,7 @@ class Tooltip extends api.core.Placement {
     const limit = this.rect.width * 0.5 - 8;
     if (x < -limit) x = -limit;
     if (x > limit) x = limit;
-    const roundedX = Math.round((x + Number.EPSILON) * 100) / 100; // arrondi à 2 décimal
-    this.setProperty('--arrow-x', `${roundedX}px`);
+    this.setProperty('--arrow-x', x.toFixed(2));
   }
 }
 

--- a/src/component/tooltip/style/_module.scss
+++ b/src/component/tooltip/style/_module.scss
@@ -24,7 +24,7 @@
 
   &:not(&--shown) {
     // transition in/out
-    visibility: hidden;
+    display: none;
     opacity: 0;
   }
 

--- a/src/component/tooltip/style/_module.scss
+++ b/src/component/tooltip/style/_module.scss
@@ -15,7 +15,6 @@
   @include text-style(xs);
   opacity: 1;
   visibility: visible;
-  pointer-events: none;
   transition: opacity 0s 0.15s, visibility 0s 0.15s;
   text-align: left;
   background-repeat: no-repeat;

--- a/src/component/tooltip/template/ejs/tooltip.ejs
+++ b/src/component/tooltip/template/ejs/tooltip.ejs
@@ -13,4 +13,4 @@
 const tooltip = locals.tooltip || {};
 %>
 
-<span class="<%= prefix %>-tooltip <%= prefix %>-placement" id="<%= tooltip.id %>" role="tooltip" aria-hidden="true"><%- tooltip.content %></span>
+<span class="<%= prefix %>-tooltip <%= prefix %>-placement" id="<%= tooltip.id %>" role="tooltip"><%- tooltip.content %></span>

--- a/src/core/script/placement/placement-referent.js
+++ b/src/core/script/placement/placement-referent.js
@@ -12,6 +12,11 @@ class PlacementReferent extends Instance {
 
   init () {
     this.registration.creator.setReferent(this);
+    this._placement = this.registration.creator;
+  }
+
+  get placement () {
+    return this._placement;
   }
 
   get isShown () {


### PR DESCRIPTION
- autorise le survol sur l'information contextuelle
- ajoute un `tabindex="0"` sur l'example dans un texte
- arrondi la valeur de placements de la flèche verticale à 2 décimales
- retire le `aria-hidden="true"` et ajoute `display="none"`