### PR TITLE
:sparkles: feat(colors): ajout des utilitaires de couleur flat [DS-3484]

### DIFF
--- a/module/color/variable/_decisions.scss
+++ b/module/color/variable/_decisions.scss
@@ -19,8 +19,8 @@ $values: (
     ),
     flat: (
       neutral: strongest,
-      /* primary: strong,
-      accent: strong,*/
+      primary: strong,
+      accent: strong,
       system: strong,
     ),
     action-high: (


### PR DESCRIPTION
- Ajout des classes utilitaires pour le token background flat avec les variations de couleur d'accent