### PR TITLE
🐛 fix(password): correctif accessibilité des messages [DS-3327]

### DIFF
--- a/src/analytics/example/spa/agnostic/route.js.ejs
+++ b/src/analytics/example/spa/agnostic/route.js.ejs
@@ -41,8 +41,6 @@
   const urlLocationHandler = async () => {
     let location = window.location.href.replace(HREF, ''); // get the url route
 
-    console.log('route', location);
-
     // get the route object from the urlRoutes object
     const route = urlRoutes[location] || urlRoutes['404'];
     // get the html from the template

--- a/src/component/form/style/module/_message.scss
+++ b/src/component/form/style/module/_message.scss
@@ -1,5 +1,5 @@
 #{ns(message)} {
-  --comma: ",";
+  --comma: ", ";
   --content: var(--comma);
   @include display-flex(row, flex-start);
   @include text-style(xs);
@@ -11,7 +11,7 @@
 
   &:last-child {
     @include margin-bottom(0);
-    --comma: "";
+    --comma: " ";
   }
 
   &--error,

--- a/src/component/form/style/module/_message.scss
+++ b/src/component/form/style/module/_message.scss
@@ -11,7 +11,7 @@
 
   &:last-child {
     @include margin-bottom(0);
-    --comma: " ";
+    --comma: "";
   }
 
   &--error,

--- a/src/component/form/style/module/_message.scss
+++ b/src/component/form/style/module/_message.scss
@@ -11,6 +11,7 @@
 
   &:last-child {
     @include margin-bottom(0);
+    --comma: ". ";
   }
 
   &--error,

--- a/src/component/form/style/module/_message.scss
+++ b/src/component/form/style/module/_message.scss
@@ -11,7 +11,6 @@
 
   &:last-child {
     @include margin-bottom(0);
-    --comma: "";
   }
 
   &--error,

--- a/src/component/form/style/module/_message.scss
+++ b/src/component/form/style/module/_message.scss
@@ -1,10 +1,17 @@
 #{ns(message)} {
+  --comma: ",";
+  --content: var(--comma);
   @include display-flex(row, flex-start);
   @include text-style(xs);
   @include margin(0 0 1v 0);
 
+  @include after(var(--content)) {
+    @include sr-only();
+  }
+
   &:last-child {
     @include margin-bottom(0);
+    --comma: "";
   }
 
   &--error,

--- a/src/component/form/template/ejs/fieldset/fieldset.ejs
+++ b/src/component/form/template/ejs/fieldset/fieldset.ejs
@@ -87,7 +87,7 @@ if (fieldset.valid) {
 }
 
 if (fieldset.messages) {
-  fieldset.messages.forEach(message => builder.add(message.type, message.text));
+  fieldset.messages.forEach(message => builder.add(message.type, message.text, message.attributes));
 }
 
 if (builder.isIncluded) labelledBy.push(...builder.ids);

--- a/src/component/form/template/ejs/message/builder.js.ejs
+++ b/src/component/form/template/ejs/message/builder.js.ejs
@@ -34,7 +34,7 @@ class MessageBuilder {
     return this._ids;
   }
 
-  add (type, data) {
+  add (type, data, attributes) {
     this.appends[type]++;
     const append = this.appends[type] > 0 ? '-' + this.appends[type] : '';
     const typedId = type ? `-${type}` : '';
@@ -42,7 +42,7 @@ class MessageBuilder {
     switch (typeof data) {
       case 'string':
         // this._ids.push(id);
-        this.messages.push({ type: type, id: id, text: data });
+        this.messages.push({ type: type, id: id, text: data, attributes: attributes });
         break;
 
       case 'object':

--- a/src/component/input/input-base/template/ejs/input.ejs
+++ b/src/component/input/input-base/template/ejs/input.ejs
@@ -76,7 +76,7 @@ if (input.error) {
 }
 
 if (input.messages) {
-  input.messages.forEach(message => builder.add(message.type, message.text));
+  input.messages.forEach(message => builder.add(message.type, message.text, message.attributes));
 }
 
 if (builder.isIncluded) describedby.push(...builder.ids);

--- a/src/component/password/example/sample/password-register.ejs
+++ b/src/component/password/example/sample/password-register.ejs
@@ -1,7 +1,20 @@
 <%
-let password = locals.password || {};
+const password = locals.password || {};
 
-let data = {
+const messages = password.messages || [
+  { text: getText('format.label', 'password') },
+  { text: getText('format.characters', 'password'), type: 'info' },
+  { text: getText('format.special', 'password'), type: 'info' },
+  { text: getText('format.digit', 'password'), type: 'info' }
+];
+
+const msgAttributes = {};
+msgAttributes[`data-${prefix}-valid`] = getText('format.valid', 'password');
+msgAttributes[`data-${prefix}-error`] = getText('format.error', 'password');
+
+messages.filter(message => message.type !== undefined).forEach(message => { message.attributes = msgAttributes; });
+
+const data = {
   id: uniqueId('password'),
   ...password,
   input: {
@@ -11,12 +24,7 @@ let data = {
   },
   checkbox: password.checkbox || {},
   link: false,
-  messages: password.messages || [
-    { text: getText('format.label', 'password') },
-    { text: getText('format.characters', 'password'), type: 'info'},
-    { text: getText('format.special', 'password'), type: 'info'},
-    { text: getText('format.digit', 'password'), type: 'info'}
-  ],
+  messages: messages
 }
 %>
 

--- a/src/component/password/i18n/fr.yml
+++ b/src/component/password/i18n/fr.yml
@@ -17,6 +17,8 @@ format:
   digit: 1 chiffre minimum
   special: 1 caractère spécial minimum
   characters: 12 caractères minimum
+  valid: validé
+  error: en erreur
 link:
   label: Mot de passe oublié ?
   href: url de la page de récupération

--- a/src/component/password/style/_module.scss
+++ b/src/component/password/style/_module.scss
@@ -39,4 +39,21 @@
   &__label {
     @include padding-right(24v);
   }
+
+  #{ns(message--valid)}#{ns-attr(valid)} {
+    @include after('\00a0-\00a0' attr(#{ns-attr(valid, null, true)}));
+  }
+
+  #{ns(message--error)}#{ns-attr(error)} {
+    @include after('\00a0-\00a0' attr(#{ns-attr(error, null, true)}));
+  }
+
+  #{ns(message)} {
+    @include after {
+      position: absolute;
+      overflow: hidden;
+      width: 0;
+      height: 0;
+    }
+  }
 }

--- a/src/component/password/style/_module.scss
+++ b/src/component/password/style/_module.scss
@@ -50,10 +50,7 @@
 
   #{ns(message)} {
     @include after {
-      position: absolute;
-      overflow: hidden;
-      width: 0;
-      height: 0;
+      @include sr-only();
     }
   }
 }

--- a/src/component/password/style/_module.scss
+++ b/src/component/password/style/_module.scss
@@ -40,17 +40,17 @@
     @include padding-right(24v);
   }
 
+  #{ns(message)} {
+    &:first-child {
+      --comma: "";
+    }
+  }
+
   #{ns(message--valid)}#{ns-attr(valid)} {
-    @include after('\00a0,\00a0' attr(#{ns-attr(valid, null, true)}));
+    --content: "\00a0-\00a0" attr(#{ns-attr(valid, null, true)}) var(--comma);
   }
 
   #{ns(message--error)}#{ns-attr(error)} {
-    @include after('\00a0,\00a0' attr(#{ns-attr(error, null, true)}));
-  }
-
-  #{ns(message)} {
-    @include after {
-      @include sr-only();
-    }
+    --content: "\00a0-\00a0" attr(#{ns-attr(error, null, true)}) var(--comma);
   }
 }

--- a/src/component/password/style/_module.scss
+++ b/src/component/password/style/_module.scss
@@ -42,7 +42,7 @@
 
   #{ns(message)} {
     &:first-child {
-      --comma: "";
+      --comma: " ";
     }
   }
 

--- a/src/component/password/style/_module.scss
+++ b/src/component/password/style/_module.scss
@@ -41,11 +41,11 @@
   }
 
   #{ns(message--valid)}#{ns-attr(valid)} {
-    @include after('\00a0-\00a0' attr(#{ns-attr(valid, null, true)}));
+    @include after('\00a0,\00a0' attr(#{ns-attr(valid, null, true)}));
   }
 
   #{ns(message--error)}#{ns-attr(error)} {
-    @include after('\00a0-\00a0' attr(#{ns-attr(error, null, true)}));
+    @include after('\00a0,\00a0' attr(#{ns-attr(error, null, true)}));
   }
 
   #{ns(message)} {


### PR DESCRIPTION
- ajout sur les messages de validation et d'erreur de la composition du mot de passe d'un statut en after uniquement pour les lecteurs d'écrans
- BREAKING CHANGE : il est nécessaire d'ajouter les attributs `data-fr-valid`et `data-fr-error` avec les textes correspondants à l'état (respectivement, en français, "validé" et "en erreur"