### PR TITLE
:bug: fix(sidemenu): correction de la couleur des liens du sidemenu [DS-3493]

### DIFF
--- a/src/component/sidemenu/style/_scheme.scss
+++ b/src/component/sidemenu/style/_scheme.scss
@@ -28,8 +28,8 @@
     }
 
     @include list-item {
-      #{ns(sidemenu)}__link,
-      #{ns(sidemenu)}__btn {
+      #{ns(sidemenu__link)},
+      #{ns(sidemenu__btn)} {
         @include color.text(default grey, (legacy:$legacy));
       }
 

--- a/src/component/sidemenu/style/_scheme.scss
+++ b/src/component/sidemenu/style/_scheme.scss
@@ -28,6 +28,11 @@
     }
 
     @include list-item {
+      #{ns(sidemenu)}__link,
+      #{ns(sidemenu)}__btn {
+        @include color.text(default grey, (legacy:$legacy));
+      }
+
       @include before {
         @include color.box-shadow(default grey, (legacy:$legacy), top-1-out bottom-1-in);
       }


### PR DESCRIPTION
- Effet de bord du passage du bouton mobile en bleu, l'ensemble des boutons du sidemenu est passé en bleu.
- Ce correctif amène la spécificité nécessaire pour avoir les boutons et lien en `text default grey`