### PR TITLE
🐛 fix(modal): préviens décalage mobile [DS-3495]

### DIFF
--- a/src/component/modal/style/_module.scss
+++ b/src/component/modal/style/_module.scss
@@ -21,7 +21,7 @@
   @include margin(0);
   @include display-flex(column, stretch, space-between);
   @include fixed(0, 0, 0, 0, 100%, 100%);
-  @include padding-right(var(--scrollbar-width));
+  @include padding-right(var(--scrollbar-width), md);
   // transition in/out
   transition: opacity 0.3s, visibility 0.3s;
 


### PR DESCRIPTION
- l'ajout d'un padding à l'ouverture permet de se substituer au décalage créé potentiellement par la disparition de la scrollbar en desktop
- En mobile, la modale occupe 100% de la largeur, ce padding créé un espacement incorrect
- ajout d'un media query sur le breakpoint MD pour corriger le problème