### PR TITLE
🐛 fix(link): correctif téléchargement multiligne [DS-3509]

### DIFF
--- a/src/component/link/style/module/_download.scss
+++ b/src/component/link/style/module/_download.scss
@@ -13,15 +13,12 @@
   }
 
   #{ns(link__detail)} {
-    @include absolute(7v, null, null, 0);
+    @include absolute(calc(100% + 1v), null, null, 0);
     @include text-style(xs);
     @include font-weight(regular);
-    max-width: 100%;
     white-space: nowrap;
     pointer-events: none;
     cursor: text;
-    overflow: hidden;
-    text-overflow: ellipsis;
 
     abbr {
       text-decoration: none;


### PR DESCRIPTION
- les liens de téléchargement étaient limités à une seul ligne avec une ellipse sur le text dépassant
- correctif prenant en compte le retour à la ligne