### PR TITLE
🐛  fix(toggle): retrait tap-highlight-color iOS [DS-3502]

### DIFF
--- a/src/component/toggle/style/module/_default.scss
+++ b/src/component/toggle/style/module/_default.scss
@@ -38,6 +38,7 @@
     width: spacing.space(calc(100% - 10v));
     min-height: spacing.space(6v);
     @include text-style(md);
+    -webkit-tap-highlight-color: transparent;
 
     &#{ns-attr(unchecked-label)}#{ns-attr(checked-label)} {
       @include padding-left(0);

--- a/src/component/toggle/style/module/_default.scss
+++ b/src/component/toggle/style/module/_default.scss
@@ -17,6 +17,7 @@
     @include size(10v, 6v);
     @include absolute;
     opacity: 0;
+    -webkit-tap-highlight-color: transparent;
 
     &:checked {
       ~ #{ns(toggle__label)} {
@@ -63,6 +64,7 @@
       min-width: spacing.space(10v);
       max-width: spacing.space(10v);
       background-repeat: no-repeat;
+      -webkit-tap-highlight-color: transparent;
     }
 
     @include after('') {
@@ -72,6 +74,7 @@
       background-repeat: no-repeat;
       background-size: spacing.space(4v);
       background-position: center;
+      -webkit-tap-highlight-color: transparent;
     }
   }
 

--- a/src/component/toggle/style/module/_default.scss
+++ b/src/component/toggle/style/module/_default.scss
@@ -64,7 +64,6 @@
       min-width: spacing.space(10v);
       max-width: spacing.space(10v);
       background-repeat: no-repeat;
-      -webkit-tap-highlight-color: transparent;
     }
 
     @include after('') {
@@ -74,7 +73,6 @@
       background-repeat: no-repeat;
       background-size: spacing.space(4v);
       background-position: center;
-      -webkit-tap-highlight-color: transparent;
     }
   }
 


### PR DESCRIPTION
- Au clic sur le toggle sur iOS, l'effet de highlight est présent
- Retrait de cet effet avec la propriété [-webkit-tap-highlight-color](https://developer.mozilla.org/fr/docs/Web/CSS/-webkit-tap-highlight-color)