### PR TITLE
✨ feat(*): Ajout d'un meta tag iOS [DS-3507]

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,7 @@ Consulter la [documentation des paramètres d’affichage](https://www.systeme-d
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <link rel="stylesheet" href="dsfr.min.css">
-    <link rel="stylesheet" href="utility/utility.min.css">
+    <meta name="format-detection" content="telephone=no">
 
     <meta name="theme-color" content="#000091"><!-- Défini la couleur de thème du navigateur (Safari/Android) -->
     <link rel="apple-touch-icon" href="favicon/apple-touch-icon.png"><!-- 180×180 -->
@@ -104,6 +103,9 @@ Consulter la [documentation des paramètres d’affichage](https://www.systeme-d
     <link rel="manifest" href="favicon/manifest.webmanifest" crossorigin="use-credentials">
     <!-- Modifier les chemins relatifs des favicons en fonction de la structure du projet -->
     <!-- Dans le fichier manifest.webmanifest aussi, modifier les chemins vers les images -->
+    
+    <link rel="stylesheet" href="dsfr.min.css">
+    <link rel="stylesheet" href="utility/utility.min.css">
 
     <title>Titre de la page - Nom du site</title>
   </head>

--- a/tool/example/example.ejs
+++ b/tool/example/example.ejs
@@ -4,7 +4,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <title><%= title %> - Design System</title>
+  <meta name="format-detection" content="telephone=no">
+  <title><%= title %> - Système de design</title>
 
   <%- include('../../src/core/template/ejs/favicon/favicon.ejs', {favicon: {path: `${relativeRoot}dist/favicon/`}}); %>
 


### PR DESCRIPTION
- Sur iOS, les numéros de téléphone sont automatiquement transformés en lien
- Entraîne un mauvais rendu dans le bloc fonctionnel de numéro de téléphone
- Correction par l'ajout général du meta tag `<meta name="format-detection" content="telephone=no">`