### PR TITLE
🐛 fix(transcription, content): correctif title et label bouton Agrandir [DS-3512, DS-3501]

### DIFF
--- a/src/component/content/example/sample/media-default.ejs
+++ b/src/component/content/example/sample/media-default.ejs
@@ -5,7 +5,9 @@ content.id = content.id || uniqueId('media');
 if (content.transcription === true) content.transcription = {
   id: uniqueId('transcription'),
   title: getText('modal.title', 'transcription'),
-  content: randomContent(['text', 'list'])
+  content: randomContent(['text', 'list']),
+  fullscreen: getText('button.fullscreen', 'transcription'),
+  fullscreenAriaLabel: getText('button.fullscreenAriaLabel', 'transcription'),
 };
 
 %>

--- a/src/component/transcription/template/ejs/transcription.ejs
+++ b/src/component/transcription/template/ejs/transcription.ejs
@@ -41,7 +41,7 @@ let collapseId = prefix + '-transcription-collapse-' + transcription.id;
   <div class="<%= prefix %>-collapse" id="<%= collapseId %>">
     <div class="<%= prefix %>-transcription__footer">
       <div class="<%= prefix %>-transcription__actions-group">
-        <%- include('../../../button/template/ejs/button.ejs', { button: {label: transcription.fullscreen, title: transcription.fullscreen, classes: [prefix + '-btn--fullscreen'], attributes: {'aria-controls': modalId, 'aria-label': transcription.fullscreenAriaLabel, 'data-fr-opened': false} } } ); %>
+        <%- include('../../../button/template/ejs/button.ejs', { button: {label: transcription.fullscreen, classes: [prefix + '-btn--fullscreen'], attributes: {'aria-controls': modalId, 'aria-label': transcription.fullscreenAriaLabel, 'data-fr-opened': false} } } ); %>
       </div>
     </div>
     <%- include('../../../modal/template/ejs/modal.ejs', {modal: { ...modal, id: modalId }}) %>


### PR DESCRIPTION
- Retrait du title sur le bouton agrandir
- Ajout label agrandir dans les exemples de content