### PR TITLE
✨ feat(core, password): boutons spéciaux input Safari [DS-3510]

### DIFF
--- a/src/component/password/style/_module.scss
+++ b/src/component/password/style/_module.scss
@@ -8,22 +8,20 @@
   @include set-text-margin(0 0 2v 0);
 
   #{ns-attr(capslock)} {
+    #{ns(password__input)} {
+      @include padding-right(12v);
+    }
+    
     @include before('', block) {
-      @include absolute(3v, 3v, null, null, 4v, 4v);
+      @include absolute(3v, 4v, null, null, 4v, 4v);
       pointer-events: none;
     }
   }
-
-  :not(#{ns-attr(capslock)}) {
-    #{ns(password__input)} {
-      @include padding-right(4v);
-    }
-  }
-
+  
   &__checkbox {
     @include absolute(0, 0);
   }
-
+  
   &__input {
     @include margin-bottom(3v);
 

--- a/src/component/password/style/_scheme.scss
+++ b/src/component/password/style/_scheme.scss
@@ -14,7 +14,7 @@
 
     #{selector.ns-attr(capslock)} {
       @include before {
-        @include color.data-uri-svg(default grey, (legacy: $legacy), $capslock-svg);
+        @include color.data-uri-svg(label grey, (legacy: $legacy), $capslock-svg);
       }
     }
 

--- a/src/core/style/action/module/_input.scss
+++ b/src/core/style/action/module/_input.scss
@@ -27,3 +27,10 @@ input[type="checkbox"],
 input[type="radio"] {
   @include reset.appearance;
 }
+
+input::-webkit-contacts-auto-fill-button,
+input::-webkit-credentials-auto-fill-button {
+  @include margin-left(4v);
+  @include margin-right(-1px);
+  @include size(5v, 5v);
+}

--- a/src/core/style/action/module/_input.scss
+++ b/src/core/style/action/module/_input.scss
@@ -4,6 +4,7 @@
 ////
 
 @use 'module/reset';
+@use 'module/spacing';
 
 input,
 select,
@@ -33,5 +34,5 @@ input::-webkit-credentials-auto-fill-button {
   @include margin-left(4v);
   @include margin-right(-1px);
   @include size(5v, 5v);
-  mask-size: #{space(5v 5v)};
+  mask-size: #{spacing.space(5v 5v)};
 }

--- a/src/core/style/action/module/_input.scss
+++ b/src/core/style/action/module/_input.scss
@@ -33,4 +33,5 @@ input::-webkit-credentials-auto-fill-button {
   @include margin-left(4v);
   @include margin-right(-1px);
   @include size(5v, 5v);
+  mask-size: #{space(5v 5v)};
 }


### PR DESCRIPTION
- Dans les champs de type password, sur safari Mac, il y a une icône apportant des outils supplémentaire qui se superpose à l’icône des signalant la hauteur de casse
- Déplacement des icônes natives pour qu'elles ne se superposent pas
- Retrait de l'icône capslock native, privilégiant la nôtre