### PR TITLE
:bug: fix(modal): retour de focus fermeture clavier [DS-3513]

### DIFF
--- a/src/component/modal/script/modal/modal.js
+++ b/src/component/modal/script/modal/modal.js
@@ -45,7 +45,10 @@ class Modal extends api.core.Disclosure {
         break;
 
       default:
-        this.conceal();
+        if (this.isDisclosed) {
+          this.conceal();
+          this.focus();
+        }
     }
   }
 


### PR DESCRIPTION
- Mise en place du retour du focus à la fermeture en pressant la touche ESC