### PR TITLE
🐛 fix(consent): ajoute un niveau de titre sur la bannière de consentement [DS-2257]

### DIFF
--- a/src/component/consent/template/ejs/placeholder.ejs
+++ b/src/component/consent/template/ejs/placeholder.ejs
@@ -24,7 +24,7 @@ button.markup = 'button';
 %>
 
 <div <%- includeClasses(classes); %> <%- includeAttrs(attributes) %>>
-  <% if (consent.title) { %><p class="<%= prefix %>-h6"><%= consent.title %></p> <% } %>
+  <% if (consent.title) { %><h4 class="<%= prefix %>-h6"><%= consent.title %></h4> <% } %>
   <% if (consent.body) { %><p><%- consent.body %></p><% } %>
   <%- include('../../../button/template/ejs/button.ejs', {button: button}); %>
 </div>


### PR DESCRIPTION
- le titre est passé de `<p>` à `<h4>` dans la structure HTML du composant