### PR TITLE
🐛 fix(modal): a11y retire la liste dans la zone d'actions [DS-1257]

### DIFF
--- a/src/component/button/style/tool/_group.scss
+++ b/src/component/button/style/tool/_group.scss
@@ -10,7 +10,8 @@
     @include margin-x(2v);
   }
 
-  > li {
+  > li,
+  > div {
     display: inline-flex;
     max-width: 100%;
     width: auto;
@@ -18,7 +19,8 @@
 }
 
 @mixin vertical-btns-group() {
-  > li {
+  > li,
+  > div {
     width: 100%;
     max-width: 100%;
   }

--- a/src/component/button/style/tool/_group.scss
+++ b/src/component/button/style/tool/_group.scss
@@ -10,8 +10,7 @@
     @include margin-x(2v);
   }
 
-  > li,
-  > div {
+  > li {
     display: inline-flex;
     max-width: 100%;
     width: auto;

--- a/src/component/button/template/ejs/buttons-group.ejs
+++ b/src/component/button/template/ejs/buttons-group.ejs
@@ -3,6 +3,8 @@
 
 * buttonsGroup.buttons (array, required): paramètres spécifique de chaque bouton du groupe
 
+* buttonsGroup.markup (string) : si non défini, ul
+
 * buttonsGroup.inline (string|boolean, optional) : aligne les boutons horizontalement (dans la mesure du possible)
 valeurs :
   * true : toujours en ligne
@@ -43,6 +45,8 @@ valeurs :
 
 <%
  const buttonsGroup = locals.buttonsGroup || {};
+ const groupMarkup = buttonsGroup.markup || 'ul';
+ const itemMarkup = buttonsGroup.markup || 'li';
  let groupClasses = buttonsGroup.classes || [];
  let groupAttrs = buttonsGroup.attributes || {};
  let buttons = buttonsGroup.buttons || [];
@@ -91,9 +95,9 @@ valeurs :
  }
  %>
 
-<ul <%- includeClasses(groupClasses) %> <%- includeAttrs(groupAttrs) %>>
+<<%= groupMarkup %> <%- includeClasses(groupClasses) %> <%- includeAttrs(groupAttrs) %>>
   <% for (let i = 0; i < buttons.length; i++) { %>
-  <li>
+  <<%= itemMarkup %>>
       <%
           const button = buttons[i];
           let path;
@@ -111,6 +115,6 @@ valeurs :
           }
         %>
     <%- include(path, {button:button}); %>
-  </li>
+  </<%= itemMarkup %>>
   <% } %>
-</ul>
+</<%= groupMarkup %>>

--- a/src/component/button/template/ejs/buttons-group.ejs
+++ b/src/component/button/template/ejs/buttons-group.ejs
@@ -3,7 +3,7 @@
 
 * buttonsGroup.buttons (array, required): paramètres spécifique de chaque bouton du groupe
 
-* buttonsGroup.markup (string) : si non défini, ul
+* buttonsGroup.groupMarkup (string) : si non défini, ul
 
 * buttonsGroup.inline (string|boolean, optional) : aligne les boutons horizontalement (dans la mesure du possible)
 valeurs :
@@ -45,8 +45,8 @@ valeurs :
 
 <%
  const buttonsGroup = locals.buttonsGroup || {};
- const groupMarkup = buttonsGroup.markup || 'ul';
- const itemMarkup = buttonsGroup.markup || 'li';
+ const groupMarkup = buttonsGroup.groupMarkup || 'ul';
+ const itemMarkup = buttonsGroup.groupMarkup || 'li';
  let groupClasses = buttonsGroup.classes || [];
  let groupAttrs = buttonsGroup.attributes || {};
  let buttons = buttonsGroup.buttons || [];

--- a/src/component/button/template/ejs/buttons-group.ejs
+++ b/src/component/button/template/ejs/buttons-group.ejs
@@ -46,7 +46,7 @@ valeurs :
 <%
  const buttonsGroup = locals.buttonsGroup || {};
  const groupMarkup = buttonsGroup.groupMarkup || 'ul';
- const itemMarkup = buttonsGroup.groupMarkup || 'li';
+ const isList = groupMarkup === 'ul';
  let groupClasses = buttonsGroup.classes || [];
  let groupAttrs = buttonsGroup.attributes || {};
  let buttons = buttonsGroup.buttons || [];
@@ -97,24 +97,28 @@ valeurs :
 
 <<%= groupMarkup %> <%- includeClasses(groupClasses) %> <%- includeAttrs(groupAttrs) %>>
   <% for (let i = 0; i < buttons.length; i++) { %>
-  <<%= itemMarkup %>>
-      <%
-          const button = buttons[i];
-          let path;
-          switch(button.template) {
-              case 'display':
-                path = './button-display.ejs';
-                break;
+    <% if (isList) { %>
+      <li>
+    <% } %>
+    <%
+      const button = buttons[i];
+      let path;
+      switch(button.template) {
+        case 'display':
+          path = './button-display.ejs';
+          break;
 
-              case 'close':
-                path = './button-close.ejs';
-                break;
+        case 'close':
+          path = './button-close.ejs';
+          break;
 
-              default:
-                path = './button.ejs';
-          }
-        %>
+        default:
+          path = './button.ejs';
+      }
+    %>
     <%- include(path, {button:button}); %>
-  </<%= itemMarkup %>>
+    <% if (isList) { %>
+      </li>
+    <% } %>
   <% } %>
 </<%= groupMarkup %>>

--- a/src/component/modal/example/sample/footer/buttons.ejs
+++ b/src/component/modal/example/sample/footer/buttons.ejs
@@ -1,1 +1,1 @@
-<%- include('../../../../button/example/sample/buttons-group', {buttonsGroup: {sizes:{md : {size:'md'}}, hierarchy: true, label: 'Label bouton', iconPlace:'left', align:'right', reverse: true, inline:'lg', icon :'checkbox-circle-line', group: true, groupCount: 2}}) %>
+<%- include('../../../../button/example/sample/buttons-group', {buttonsGroup: {markup: 'div', sizes:{md : {size:'md'}}, hierarchy: true, label: 'Label bouton', iconPlace:'left', align:'right', reverse: true, inline:'lg', icon :'checkbox-circle-line', group: true, groupCount: 2}}) %>

--- a/src/component/modal/example/sample/footer/buttons.ejs
+++ b/src/component/modal/example/sample/footer/buttons.ejs
@@ -1,1 +1,1 @@
-<%- include('../../../../button/example/sample/buttons-group', {buttonsGroup: {markup: 'div', sizes:{md : {size:'md'}}, hierarchy: true, label: 'Label bouton', iconPlace:'left', align:'right', reverse: true, inline:'lg', icon :'checkbox-circle-line', group: true, groupCount: 2}}) %>
+<%- include('../../../../button/example/sample/buttons-group', {buttonsGroup: {groupMarkup: 'div', sizes:{md : {size:'md'}}, hierarchy: true, label: 'Label bouton', iconPlace:'left', align:'right', reverse: true, inline:'lg', icon :'checkbox-circle-line', group: true, groupCount: 2}}) %>


### PR DESCRIPTION
- retrait de la liste `<ul><li>` dans la structure HTML de la zone d'action qui devient : 
```
                    <div class="fr-modal__footer">
                        <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
                            <button class="fr-btn fr-icon-checkbox-circle-line fr-btn--icon-left" id="button-5462">
                                Label bouton
                            </button>
                            <button class="fr-btn fr-icon-checkbox-circle-line fr-btn--icon-left fr-btn--secondary" id="button-5463">
                                Label bouton
                            </button>
                        </div>
                    </div>
```