### PR TITLE
🐛 fix(radio): correctif couleur manquante [DS-3558]

### DIFF
--- a/src/component/radio/style/scheme/_sm.scss
+++ b/src/component/radio/style/scheme/_sm.scss
@@ -26,7 +26,7 @@
 
         @include disabled.selector {
           + label {
-            @include color.background-image((disabled grey), (legacy:$legacy), radio-background-image(true, sm));
+            @include color.background-image((disabled grey) (disabled grey), (legacy:$legacy), radio-background-image(true, sm));
           }
         }
       }


### PR DESCRIPTION
- Erreur dans le build du CSS suite au manque d'une couleur 