### PR TITLE
🐛 fix(footer): correctifs logo partenaires [DS-3384, DS-3560]

### DIFF
--- a/src/component/footer/example/index.ejs
+++ b/src/component/footer/example/index.ejs
@@ -8,6 +8,8 @@
 
 <%- sample('Pied de page avec logos partenaires', './sample/footer-partners.ejs', {footer: {partners: {mainPartner: true, subPartners: true}}}, true); %>
 
+<%- sample('Pied de page avec logo partenaire primaire uniquement', './sample/footer-partners.ejs', {footer: {partners: {mainPartner: true}}}, true); %>
+
 <%- sample('Pied de page avec logos partenaires secondaires uniquement', './sample/footer-partners.ejs', {footer: {partners: {subPartners: true}}}, true); %>
 
 <%- sample('Pied de page complet', './sample/footer.ejs', {footer: {brand: true, operator: true, bottom: true, content: true, partners: {mainPartner: true, subPartners: true}, top: true}}, true); %>

--- a/src/component/footer/example/index.ejs
+++ b/src/component/footer/example/index.ejs
@@ -6,6 +6,8 @@
 
 <%- sample('Pied de page avec logo opérateur', './sample/footer-operator.ejs', {}, true); %>
 
-<%- sample('Pied de page avec logos partenaires', './sample/footer-partners.ejs', {}, true); %>
+<%- sample('Pied de page avec logos partenaires', './sample/footer-partners.ejs', {footer: {partners: {mainPartner: true, subPartners: true}}}, true); %>
 
-<%- sample('Pied de page complet', './sample/footer.ejs', {footer: {brand: true, operator: true, bottom: true, content: true, partners: true, top: true}}, true); %>
+<%- sample('Pied de page avec logos partenaires secondaires uniquement', './sample/footer-partners.ejs', {footer: {partners: {subPartners: true}}}, true); %>
+
+<%- sample('Pied de page complet', './sample/footer.ejs', {footer: {brand: true, operator: true, bottom: true, content: true, partners: {mainPartner: true, subPartners: true}, top: true}}, true); %>

--- a/src/component/footer/example/sample/footer-partners.ejs
+++ b/src/component/footer/example/sample/footer-partners.ejs
@@ -2,6 +2,7 @@
 let footer = locals.footer || {};
 let data = {};
 if (footer.logo) data.logo = footer.logo;
+if (footer.partners) data.partners = footer.partners;
 %>
 
 <%- include('footer.ejs', {footer: {brand: true, partners: true, content: true, bottom: true, ...data}}); %>

--- a/src/component/footer/example/sample/footer.ejs
+++ b/src/component/footer/example/sample/footer.ejs
@@ -23,13 +23,8 @@ if (footer.content === true) data.content = {
 
 if (footer.partners !== undefined) {
   data.partners = {
-    title: 'Nos partenaires',
-    href: footer.href,
-    subPartners: [
-        imgData('img/placeholder.16x9.png', 'rendered', null, null, 'height: 5.625rem'),
-        imgData('img/placeholder.1x1.png', 'rendered', null, null, 'height: 5.625rem'),
-        imgData('img/placeholder.9x16.png', 'rendered', null, null, 'height: 5.625rem')
-    ]
+    title: footer.partners.subPartners ? 'Nos partenaires' : 'Notre partenaire',
+    href: footer.href
   }
 
   if (footer.partners.mainPartner === true) {

--- a/src/component/footer/example/sample/footer.ejs
+++ b/src/component/footer/example/sample/footer.ejs
@@ -21,16 +21,31 @@ if (footer.content === true) data.content = {
   ]
 };
 
-if (footer.partners === true) data.partners = {
-  title: 'Nos partenaires',
-  href: footer.href,
-  mainPartner: imgData('img/placeholder.16x9.png', 'rendered', null, null, 'height: 5.625rem'),
-  subPartners: [
-      imgData('img/placeholder.16x9.png', 'rendered', null, null, 'height: 5.625rem'),
-      imgData('img/placeholder.1x1.png', 'rendered', null, null, 'height: 5.625rem'),
-      imgData('img/placeholder.9x16.png', 'rendered', null, null, 'height: 5.625rem')
-  ]
-};
+if (footer.partners !== undefined) {
+  data.partners = {
+    title: 'Nos partenaires',
+    href: footer.href,
+    subPartners: [
+        imgData('img/placeholder.16x9.png', 'rendered', null, null, 'height: 5.625rem'),
+        imgData('img/placeholder.1x1.png', 'rendered', null, null, 'height: 5.625rem'),
+        imgData('img/placeholder.9x16.png', 'rendered', null, null, 'height: 5.625rem')
+    ]
+  }
+
+  if (footer.partners.mainPartner === true) {
+    data.partners.mainPartner = imgData('img/placeholder.16x9.png', 'rendered', null, null, 'height: 5.625rem');
+  }
+
+  if (footer.partners.subPartners === true) {
+    data.partners.subPartners = [
+        imgData('img/placeholder.16x9.png', 'rendered', null, null, 'height: 5.625rem'),
+        imgData('img/placeholder.1x1.png', 'rendered', null, null, 'height: 5.625rem'),
+        imgData('img/placeholder.9x16.png', 'rendered', null, null, 'height: 5.625rem')
+    ]
+  }
+}
+
+
 
 if (footer.bottom === true) data.bottom = {
   links: [

--- a/src/component/footer/style/module/_partners.scss
+++ b/src/component/footer/style/module/_partners.scss
@@ -48,12 +48,8 @@
     @include margin(0 0 -2v 0);
 
     @include respond-from(sm) {
-      @include display-flex(row, flex-start, flex-start);
+      @include display-flex(row, flex-start, space-between);
       @include margin-right(-2v);
-      @include before('', block) {
-        order: 2;
-        flex: 1;
-      }
     }
 
     @include respond-from(md) {
@@ -67,27 +63,13 @@
   */
   &__partners-main {
     @include display-flex(row,null,center);
-    @include margin-x(auto);
     @include margin-bottom(8v);
     @include margin-bottom(4v, sm);
 
     + #{ns(footer__partners-sub)} {
-      & > ul > li {
-        @include margin(0 2v 0 2v, sm);
-        @include margin(0 4v 0 4v, md);
-      }
-
       @include respond-from(md) {
-        & > ul {
-          justify-content: flex-end;
-        }
         @include padding-left(4v);
-        @include padding-top(0);
       }
-    }
-
-    @include respond-from(sm) {
-      order: 1;
     }
   }
 
@@ -100,9 +82,26 @@
     &,
     & > ul {
       @include display-flex(column, center, null, wrap);
+
       @include respond-from(sm) {
         flex-direction: row;
         align-items: flex-start;
+      }
+
+      @include respond-from(md) {
+        & > ul {
+          justify-content: flex-end;
+        }
+        @include padding-top(0);
+      }
+      
+      & > li {
+        @include margin(0 2v 0 2v, sm);
+        @include margin(0 4v 0 4v, md);
+
+        &:first-child {
+          @include margin-left(0);
+        }
       }
     }
 

--- a/src/component/footer/template/ejs/partners.ejs
+++ b/src/component/footer/template/ejs/partners.ejs
@@ -15,11 +15,14 @@
 
 <h4 class="<%= prefix %>-footer__partners-title"><%- partners.title %></h4>
 <div class="<%= prefix %>-footer__partners-logos">
-  <div class="<%= prefix %>-footer__partners-main">
-    <a <%- includeAttrs(attributes) %> class="<%= prefix %>-footer__partners-link" href="<%- partners.href %>">
-      <%- include('../../../../core/template/ejs/media/img.ejs',  {media: {...partners.mainPartner, classes: [prefix + '-footer__logo']}}); %>
-    </a>
-  </div>
+  <% if (partners.mainPartner) { %>
+    <div class="<%= prefix %>-footer__partners-main">
+      <a <%- includeAttrs(attributes) %> class="<%= prefix %>-footer__partners-link" href="<%- partners.href %>">
+        <%- include('../../../../core/template/ejs/media/img.ejs',  {media: {...partners.mainPartner, classes: [prefix + '-footer__logo']}}); %>
+      </a>
+    </div>
+  <% } %>
+
   <div class="<%= prefix %>-footer__partners-sub">
     <ul>
       <%

--- a/src/component/footer/template/ejs/partners.ejs
+++ b/src/component/footer/template/ejs/partners.ejs
@@ -13,7 +13,7 @@
   attributes.id = attributes.id || uniqueId('footer__partners-link');
 %>
 
-<h4 class="<%= prefix %>-footer__partners-title"><%- partners.title %></h4>
+<h2 class="<%= prefix %>-footer__partners-title"><%- partners.title %></h2>
 <div class="<%= prefix %>-footer__partners-logos">
   <% if (partners.mainPartner) { %>
     <div class="<%= prefix %>-footer__partners-main">

--- a/src/component/footer/template/ejs/partners.ejs
+++ b/src/component/footer/template/ejs/partners.ejs
@@ -23,19 +23,21 @@
     </div>
   <% } %>
 
-  <div class="<%= prefix %>-footer__partners-sub">
-    <ul>
-      <%
-        for (let i = 0; i < partners.subPartners.length; i++) {
-          const attributes = {};
-      	  attributes.id = uniqueId('footer__subpartners-link');
-      %>
-      <li>
-        <a <%- includeAttrs(attributes) %> class="<%= prefix %>-footer__partners-link" href="<%- partners.href %>">
-          <%- include('../../../../core/template/ejs/media/img.ejs', {media: {...partners.subPartners[i], classes: [prefix + '-footer__logo']}}); %>
-        </a>
-      </li>
-    <% } %>
-    </ul>
-  </div>
+  <% if (partners.subPartners && partners.subPartners.length) { %>
+    <div class="<%= prefix %>-footer__partners-sub">
+      <ul>
+        <%
+          for (let i = 0; i < partners.subPartners.length; i++) {
+            const attributes = {};
+            attributes.id = uniqueId('footer__subpartners-link');
+        %>
+          <li>
+            <a <%- includeAttrs(attributes) %> class="<%= prefix %>-footer__partners-link" href="<%- partners.href %>">
+              <%- include('../../../../core/template/ejs/media/img.ejs', {media: {...partners.subPartners[i], classes: [prefix + '-footer__logo']}}); %>
+            </a>
+          </li>
+        <% } %>
+      </ul>
+    </div>
+  <% } %>
 </div>


### PR DESCRIPTION
- ajoute un exemple avec logos partenaires secondaires uniquement
- a11y : corrige le niveau de titre des partenaires