### PR TITLE
🐛 fix(header): Token de couleur du texte de service en title grey [DS-3520]

### DIFF
--- a/src/component/header/style/_scheme.scss
+++ b/src/component/header/style/_scheme.scss
@@ -14,6 +14,7 @@
     }
 
     &__service {
+      @include color.text(title grey, (legacy:$legacy));
       @include color.box-shadow(default grey, (legacy:$legacy), top-1-in);
     }
 


### PR DESCRIPTION
- Le titre de service doit passer en text title default