### PR TITLE
♻️ refactor(highlight, callout): background image à la place de box shadow [DS-3361]

### DIFF
--- a/src/component/callout/style/_module.scss
+++ b/src/component/callout/style/_module.scss
@@ -3,6 +3,8 @@
 /// @group callout
 ////
 
+@use 'module/spacing';
+
 #{ns(callout)} {
   @include relative();
   @include padding(6v);
@@ -10,6 +12,9 @@
   @include set-title-margin(0 0 2v);
   @include set-text-margin(0);
   @include margin(map-get($text-spacing, text));
+  background-size: spacing.space(1v 100%);
+  background-position: 0 0;
+  background-repeat: no-repeat;
 
   /**
    * Inclusion de l'icône (optionnel)

--- a/src/component/callout/style/_scheme.scss
+++ b/src/component/callout/style/_scheme.scss
@@ -8,7 +8,7 @@
 @mixin _callout-scheme($legacy: false) {
   #{ns(callout)} {
     @include color.background(contrast grey, (legacy:$legacy));
-    @include color.box-shadow(default blue-france, (legacy:$legacy), left-1v-in);
+    @include color.background-image(border default blue-france, (legacy:$legacy));
 
     @include before {
       @include color.text(title grey, (legacy:$legacy));
@@ -19,7 +19,7 @@
     }
 
     @include color.accentuate {
-      @include color.box-shadow(default accent, (legacy:$legacy), left-1v-in);
+      @include color.background-image(border default accent, (legacy:$legacy));
       @include color.background(contrast accent, (legacy:$legacy));
     }
   }

--- a/src/component/highlight/style/_module.scss
+++ b/src/component/highlight/style/_module.scss
@@ -3,9 +3,14 @@
 /// @group Highlight
 ////
 
+@use 'module/spacing';
+
 #{ns(highlight)} {
   @include padding-left(6v);
   @include text-style(md);
   @include padding-left(8v, md);
   @include margin-left(8v, md);
+  background-size: spacing.space(1v 100%);
+  background-position: 0 0;
+  background-repeat: no-repeat;
 }

--- a/src/component/highlight/style/_scheme.scss
+++ b/src/component/highlight/style/_scheme.scss
@@ -7,10 +7,10 @@
 
 @mixin _highlight-scheme($legacy: false) {
   #{ns(highlight)} {
-    @include color.box-shadow(default blue-france, (legacy:$legacy), left-1v-in);
+    @include color.background-image(border default blue-france, (legacy:$legacy));
 
     @include color.accentuate {
-      @include color.box-shadow(default accent, (legacy:$legacy), left-1v-in);
+      @include color.background-image(border default accent, (legacy:$legacy));
     }
   }
 }


### PR DESCRIPTION
Les bordures de la mise en avant et mise en exergue sont actuellement en box-shadow, les passer en background-image