### PR TITLE
🐛 fix(password): couleur du texte de la checkbox afficher [DS-3567]

### DIFF
--- a/src/component/password/style/_scheme.scss
+++ b/src/component/password/style/_scheme.scss
@@ -21,7 +21,7 @@
     & &__checkbox {
       input[type="checkbox"] {
         + label {
-          @include color.text(default grey, (legacy: $legacy));
+          @include color.text(label grey, (legacy: $legacy));
           @include before {
             @include color.background-image(border action-high blue-france, (), checkbox-background-image());
           }


### PR DESCRIPTION
- utilisation du token de couleur : text-label-grey