### PR TITLE
🐛 fix(link): correction des liens de téléchargement sur firefox et des groupes de liens sur safari [DS-3569]

### DIFF
--- a/src/component/link/style/module/_download.scss
+++ b/src/component/link/style/module/_download.scss
@@ -13,9 +13,10 @@
   }
 
   #{ns(link__detail)} {
-    @include absolute(calc(100% + 1v), null, null, 0);
+    @include absolute(null, null, null, 0);
     @include text-style(xs);
     @include font-weight(regular);
+    @include margin-top(7v);
     white-space: nowrap;
     pointer-events: none;
     cursor: text;

--- a/src/component/link/style/module/_group.scss
+++ b/src/component/link/style/module/_group.scss
@@ -23,12 +23,12 @@
     }
   }
 
-  #{ns(link)} {
-    vertical-align: top;
-  }
-
   &--sm {
     @include nest-link(sm, null);
+
+    #{ns(link)}:not(#{ns(link--download)}) {
+      vertical-align: top;
+    }
   }
 
   &--lg {


### PR DESCRIPTION
- Sur firefox, le détail passe sous le lien de téléchargement lorsque celui-ci est sur plusieurs lignes.
- Sur safari, les liens de téléchargement dans un groupe de lien sont décalés vers le bas.
