### PR TITLE
🐛 fix(login): corrige espacements [DS-3400]

### DIFF
--- a/src/page/account/login/example/data/login.json.ejs
+++ b/src/page/account/login/example/data/login.json.ejs
@@ -3,6 +3,7 @@ const login = locals.login || {};
 
 const alert = {
   id: uniqueId('alert'),
+  classes: ['fr-mb-2v'],
   size: 'sm',
   text: getText('login.error', 'login'),
   type: 'error'
@@ -66,6 +67,7 @@ elements.push({
   type: 'fieldset',
   data: {
     id: 'credentials',
+    classes: ['fr-mb-n4v'],
     legend: {
       label: getText('login.credentials', 'login'),
       sr: true

--- a/src/page/account/login/example/sample/default.ejs
+++ b/src/page/account/login/example/sample/default.ejs
@@ -4,7 +4,6 @@ const login = locals.login || {};
 const connect = JSON.parse(include('../../../../../component/connect/example/data/connect.json.ejs'));
 const form = JSON.parse(include('../data/login.json.ejs', { login: login }));
 
-
 const segments = [
   {
     type: 'heading',


### PR DESCRIPTION
- corrige l'espace en trop entre le lien "Mot de passe oublié ?" et la checkbox "Se souvenir de moi",
- ajoute une marge supplémentaire sous l’alerte d’erreur