### PR TITLE
🐛 fix(checkbox): met a jour le token de la coche [DS-3472]

### DIFF
--- a/src/component/checkbox/style/_scheme.scss
+++ b/src/component/checkbox/style/_scheme.scss
@@ -20,7 +20,7 @@
         + label {
           @include before {
             @include color.background(active blue-france);
-            @include color.data-uri-svg(inverted grey, (), $checkbox-svg, false);
+            @include color.data-uri-svg(text inverted blue-france, (), $checkbox-svg, false);
           }
         }
       }

--- a/src/component/consent/example/sample/modal/body.ejs
+++ b/src/component/consent/example/sample/modal/body.ejs
@@ -45,12 +45,14 @@ function getRadios (id, itemId, type) {
   let elementAccept = type === 'all' ? {label: 'Tout accepter'} : { label : 'Accepter'};
   let elementRefuse = type === 'all' ? {label: 'Tout refuser'} : { label : 'Refuser'};
   let disabled = type === 'mandatory';
+  let checked = type === 'mandatory';
 
   return [
     {
       name: id + '-' + name,
       ...elementAccept,
       id: id + '-' + name + '-accept',
+      checked: checked
     },
     {
       name: id + '-' + name,


### PR DESCRIPTION
- passe la couleur de la coche en `$text-inverted-blue-france`