### PR TITLE
🐛 fix(form, input): met a jour les espacements des icônes [DS-3474, DS-3504]

### DIFF
--- a/src/component/consent/example/sample/modal/body.ejs
+++ b/src/component/consent/example/sample/modal/body.ejs
@@ -45,12 +45,14 @@ function getRadios (id, itemId, type) {
   let elementAccept = type === 'all' ? {label: 'Tout accepter'} : { label : 'Accepter'};
   let elementRefuse = type === 'all' ? {label: 'Tout refuser'} : { label : 'Refuser'};
   let disabled = type === 'mandatory';
+  let checked = type === 'mandatory';
 
   return [
     {
       name: id + '-' + name,
       ...elementAccept,
       id: id + '-' + name + '-accept',
+      checked: checked
     },
     {
       name: id + '-' + name,

--- a/src/component/form/deprecated/style/_module.scss
+++ b/src/component/form/deprecated/style/_module.scss
@@ -19,7 +19,7 @@
   &--inline {
     #{ns(fieldset__content)} {
       @include display-flex(null, baseline, flex-start, wrap);
-      @include margin(-3v 0 0 2v);
+      @include margin(-3v 2v 0 2v);
     }
 
     #{ns-group(checkbox)} {
@@ -58,7 +58,7 @@
 
   &__content {
     @include relative;
-    @include margin-left(2v);
+    @include margin(0 2v);
     width: 100%;
 
     #{ns-group(radio)},

--- a/src/component/input/input-base/style/_module.scss
+++ b/src/component/input/input-base/style/_module.scss
@@ -30,9 +30,9 @@
 
     @supports selector(::-webkit-calendar-picker-indicator) {
       background-repeat: no-repeat;
-      background-position: spacing.space(calc(100% - 3v) 50%);
+      background-position: spacing.space(calc(100% - 4v) 50%);
       background-size: spacing.space(4v) spacing.space(4v);
-      @include padding-right(9v);
+      @include padding-right(11v);
 
       &::-webkit-calendar-picker-indicator {
         display: block;
@@ -50,11 +50,11 @@
 
   @include has-icon {
     #{ns(input)} {
-      @include padding-right(10v);
+      @include padding-right(11v);
     }
 
     @include icon-size(sm, before) {
-      @include absolute(3v, 3v, 3v);
+      @include absolute(3v, 4v, 3v);
       @include margin(auto);
       pointer-events: none;
     }

--- a/src/component/input/input-base/style/_module.scss
+++ b/src/component/input/input-base/style/_module.scss
@@ -32,7 +32,7 @@
       background-repeat: no-repeat;
       background-position: spacing.space(calc(100% - 4v) 50%);
       background-size: spacing.space(4v) spacing.space(4v);
-      @include padding-right(11v);
+      @include padding-right(12v);
 
       &::-webkit-calendar-picker-indicator {
         display: block;
@@ -50,7 +50,7 @@
 
   @include has-icon {
     #{ns(input)} {
-      @include padding-right(11v);
+      @include padding-right(12v);
     }
 
     @include icon-size(sm, before) {


### PR DESCRIPTION
- place l’icône à 16px du bord droit des champs de saisie
- ajuste le `padding-right` à 44px sur les champs de saisie avec icône
- corrige la largeur des class `fr-fieldset__content` pour la version dépréciée