### PR TITLE
🐛 fix(consent): correction espacement des radios accepter [DS-3525]

### DIFF
--- a/src/component/consent/example/sample/modal/body.ejs
+++ b/src/component/consent/example/sample/modal/body.ejs
@@ -45,12 +45,14 @@ function getRadios (id, itemId, type) {
   let elementAccept = type === 'all' ? {label: 'Tout accepter'} : { label : 'Accepter'};
   let elementRefuse = type === 'all' ? {label: 'Tout refuser'} : { label : 'Refuser'};
   let disabled = type === 'mandatory';
+  let checked = type === 'mandatory';
 
   return [
     {
       name: id + '-' + name,
       ...elementAccept,
       id: id + '-' + name + '-accept',
+      checked: checked
     },
     {
       name: id + '-' + name,

--- a/src/component/consent/style/module/_services.scss
+++ b/src/component/consent/style/module/_services.scss
@@ -74,7 +74,7 @@
   #{ns-group(radio)} {
     position: relative;
 
-    &:not(:last-child) input[type="radio"] + label {
+    &:not(:last-child) {
       @include margin-right(12v);
     }
 


### PR DESCRIPTION
- Les sous finalités ont une marge plus importantes à droite sur le radio Accepter