### PR TITLE
🐛 fix(toggle): couleur label & espacement activer/desactiver [DS-3526, DS-3527]

### DIFF
--- a/src/component/toggle/style/_scheme.scss
+++ b/src/component/toggle/style/_scheme.scss
@@ -9,6 +9,8 @@
 @mixin _toggle-scheme($legacy: false) {
   #{ns(toggle)} {
     label {
+      @include color.text(label grey, (legacy:$legacy));
+
       @include before {
         @include color.text(active blue-france, (legacy:$legacy));
         @include color.data-uri-svg(action-high blue-france, (legacy: $legacy), $toggle-unchecked-svg);

--- a/src/component/toggle/style/module/_default.scss
+++ b/src/component/toggle/style/module/_default.scss
@@ -57,7 +57,7 @@
     @include before('', block) {
       flex-shrink: 0;
       height: spacing.space(calc(5v + 1px));
-      @include padding-top(6v);
+      @include padding-top(7v);
       @include text-style(xs);
       border-radius: spacing.space(3v);
       @include margin-right(8v);


### PR DESCRIPTION
- utilisation du token de couleur $text-label-grey sur le label de l'interrupteur 
- ajout de 4px de marge entre la coche et le texte activer/desactiver