### PR TITLE
🐛 fix(input): combo champ + button en erreur [DS-3583]

### DIFF
--- a/src/component/input/input-base/style/_scheme.scss
+++ b/src/component/input/input-base/style/_scheme.scss
@@ -39,14 +39,26 @@
       }
     }
 
-    #{ns(fieldset--valid)} &,
-    &-group--valid & {
-      @include color.box-shadow(plain success, (legacy:$legacy), bottom-2-in);
+    &-wrap--addon {
+      > #{ns(input)}:not(:last-child) {
+        @include color.box-shadow(action-high blue-france, (legacy:$legacy), bottom-2-in);
+      }
     }
 
-    #{ns(fieldset--error)} &,
-    &-group--error & {
-      @include color.box-shadow(plain error, (legacy:$legacy), bottom-2-in);
+    #{ns(fieldset--valid)},
+    &-group--valid {
+      #{ns(input)}, 
+      #{ns(input-wrap--addon)} > #{ns(input)}:not(:last-child) {
+        @include color.box-shadow(plain success, (legacy:$legacy), bottom-2-in);
+      }
+    }
+
+    #{ns(fieldset--error)},
+    &-group--error {
+      #{ns(input)}, 
+      #{ns(input-wrap--addon)} > #{ns(input)}:not(:last-child) {
+        @include color.box-shadow(plain error, (legacy:$legacy), bottom-2-in);
+      }
     }
 
     &-group--error {
@@ -64,14 +76,6 @@
     &-group--info {
       @include before {
         @include color.background-image(border plain info, (legacy:$legacy));
-      }
-    }
-  }
-
-  #{ns(input-wrap--addon)} {
-    > *:not(:last-child) {
-      &#{ns(input)}:not(#{ns(input--valid)}):not(#{ns(input--error)}) {
-        @include color.box-shadow(action-high blue-france, (legacy:$legacy), bottom-2-in);
       }
     }
   }


### PR DESCRIPTION
- Lorsque le champ newsletter de la lettre d'information est en erreur le champs doit être souligné en rouge et non en bleu