### PR TITLE
🐛 fix(header): met a jour la taille de la barre de recherche [DS-3521]

### DIFF
--- a/src/component/consent/example/sample/modal/body.ejs
+++ b/src/component/consent/example/sample/modal/body.ejs
@@ -45,12 +45,14 @@ function getRadios (id, itemId, type) {
   let elementAccept = type === 'all' ? {label: 'Tout accepter'} : { label : 'Accepter'};
   let elementRefuse = type === 'all' ? {label: 'Tout refuser'} : { label : 'Refuser'};
   let disabled = type === 'mandatory';
+  let checked = type === 'mandatory';
 
   return [
     {
       name: id + '-' + name,
       ...elementAccept,
       id: id + '-' + name + '-accept',
+      checked: checked
     },
     {
       name: id + '-' + name,

--- a/src/component/header/style/module/_tools.scss
+++ b/src/component/header/style/module/_tools.scss
@@ -20,7 +20,7 @@
 
     #{ns(header__search)} {
       @include respond-from(lg) {
-        @include max-size(100v);
+        @include max-size(96v);
         @include margin-left(auto);
       }
     }


### PR DESCRIPTION
- passe le `max-width` de la barre de recherche à `96v` (`384px`)