### PR TITLE
🐛 fix(highlight): met à jour les espacements [DS-3538]

### DIFF
--- a/src/component/consent/example/sample/modal/body.ejs
+++ b/src/component/consent/example/sample/modal/body.ejs
@@ -45,12 +45,14 @@ function getRadios (id, itemId, type) {
   let elementAccept = type === 'all' ? {label: 'Tout accepter'} : { label : 'Accepter'};
   let elementRefuse = type === 'all' ? {label: 'Tout refuser'} : { label : 'Refuser'};
   let disabled = type === 'mandatory';
+  let checked = type === 'mandatory';
 
   return [
     {
       name: id + '-' + name,
       ...elementAccept,
       id: id + '-' + name + '-accept',
+      checked: checked
     },
     {
       name: id + '-' + name,

--- a/src/component/highlight/style/_module.scss
+++ b/src/component/highlight/style/_module.scss
@@ -4,8 +4,8 @@
 ////
 
 #{ns(highlight)} {
-  @include padding-left(6v);
+  @include padding-left(5v);
   @include text-style(md);
-  @include padding-left(8v, md);
+  @include padding-left(9v, md);
   @include margin-left(8v, md);
 }


### PR DESCRIPTION
- passe le `padding` à `5v` en mobile et `9v` en desktop.