### PR TITLE
🐛 fix(share): texte cookies désactivés en couleur mention [DS-3551]

### DIFF
--- a/src/component/share/style/_scheme.scss
+++ b/src/component/share/style/_scheme.scss
@@ -3,10 +3,16 @@
 /// @group share
 ////
 
+@use 'module/color';
+
 @mixin _share-scheme($legacy: false) {
   #{ns(share)} {
     #{ns(btn)} {
       @include btn-kind-scheme(3, $legacy);
+    }
+
+    &__text {
+      @include color.text(mention grey, (legacy: $legacy));
     }
   }
 }


### PR DESCRIPTION
- Le texte pour indiqué que les cookies sont désactivés doit être en $text-mention-grey 