### PR TITLE
🐛 fix(summary): alignement du titre du sommaire [DS-3555]

### DIFF
--- a/src/component/summary/style/_module.scss
+++ b/src/component/summary/style/_module.scss
@@ -23,6 +23,7 @@
 
   @include title {
     @include text-style(xs);
+    @include padding-left(2v);
     font-weight: font-weight(bold);
     text-transform: uppercase;
   }


### PR DESCRIPTION
- Ajout d'un padding-left de 8px pour aligner le titre avec le premier élément de la liste