### PR TITLE
🐛 fix(tag): token de couleur du tag selectionnable [DS-3556]

### DIFF
--- a/src/component/tag/style/_scheme.scss
+++ b/src/component/tag/style/_scheme.scss
@@ -17,7 +17,7 @@
     }
 
     &#{ns(tag)}--dismiss {
-      @include color.text(inverted grey, (legacy: $legacy));
+      @include color.text(inverted blue-france, (legacy: $legacy));
       @include color.background(action-high blue-france, (legacy: $legacy, hover: true));
     }
   }
@@ -59,7 +59,7 @@
         }
 
         &#{ns(tag)}--sm {
-          @include tag-punched-background(background action-high blue-france, sm, $legacy);
+          @include tag-punched-background(background active blue-france, sm, $legacy);
 
           @include disabled.selector {
             @include tag-punched-background(background disabled grey, sm, $legacy, false);
@@ -77,7 +77,7 @@
       input[type=button] {
         &#{ns(tag)} {
           @include pressed-selector(true) {
-            @include tag-punched-background(background action-high blue-france, sm, $legacy);
+            @include tag-punched-background(background active blue-france, sm, $legacy);
 
             @include disabled.selector {
               @include tag-punched-background(background disabled grey, sm, $legacy, false);

--- a/src/component/tag/style/_scheme.scss
+++ b/src/component/tag/style/_scheme.scss
@@ -42,8 +42,8 @@
       @include pressed-selector(true) {
         &:not(:disabled) {
           @include color.transparent-background((legacy:$legacy));
-          @include color.text(inverted grey, (legacy: $legacy));
-          @include tag-punched-background(background action-high blue-france, md, $legacy);
+          @include color.text(inverted blue-france, (legacy: $legacy));
+          @include tag-punched-background(background active blue-france, md, $legacy);
         }
 
         @include after {


### PR DESCRIPTION
- Utilisation du token $text-inverted-blue-france sur la couleur du texte des tag selectionnable et supprimable à la place de $text-inverted-grey

- Remplacement du token de couleur de fond des tag selectionnable par $background-active-blue-france au lieu de $background-action-high-blue-france