### PR TITLE
🐛 fix(follow): corrige affichage [DS-3529, DS-3531, DS-3532]

### DIFF
--- a/src/component/consent/example/sample/modal/body.ejs
+++ b/src/component/consent/example/sample/modal/body.ejs
@@ -45,12 +45,14 @@ function getRadios (id, itemId, type) {
   let elementAccept = type === 'all' ? {label: 'Tout accepter'} : { label : 'Accepter'};
   let elementRefuse = type === 'all' ? {label: 'Tout refuser'} : { label : 'Refuser'};
   let disabled = type === 'mandatory';
+  let checked = type === 'mandatory';
 
   return [
     {
       name: id + '-' + name,
       ...elementAccept,
       id: id + '-' + name + '-accept',
+      checked: checked
     },
     {
       name: id + '-' + name,

--- a/src/component/follow/example/data/socials.json.ejs
+++ b/src/component/follow/example/data/socials.json.ejs
@@ -15,15 +15,15 @@ data.socials = {
       title: contentPlaceholder("Intitulé du lien") + " - nouvelle fenêtre",
     },
     {
-      label: "instagram",
-      type: "instagram",
-      url: contentPlaceholder("Lien vers l'instagram de l'organisation"),
-      title: contentPlaceholder("Intitulé du lien") + " - nouvelle fenêtre",
-    },
-    {
       label: "linkedin",
       type: "linkedin",
       url: contentPlaceholder("Lien vers le linkedin de l'organisation"),
+      title: contentPlaceholder("Intitulé du lien") + " - nouvelle fenêtre",
+    },
+    {
+      label: "instagram",
+      type: "instagram",
+      url: contentPlaceholder("Lien vers l'instagram de l'organisation"),
       title: contentPlaceholder("Intitulé du lien") + " - nouvelle fenêtre",
     },
     {

--- a/src/component/follow/style/_module.scss
+++ b/src/component/follow/style/_module.scss
@@ -69,7 +69,7 @@
 
     #{ns-group(btns)} {
       @include horizontal-btns-group;
-      @include margin(0 -4v -4v -4v);
+      @include margin-bottom(-4v);
       @include width(auto);
 
       #{ns(btn)} {

--- a/src/component/follow/template/ejs/newsletter.ejs
+++ b/src/component/follow/template/ejs/newsletter.ejs
@@ -41,7 +41,7 @@ let newsletterClasses = [prefix + '-follow__newsletter'];
         </form>
       <% } %>
     <% } else if (newsletter.type === 'button') { %>
-      <%- include('../../../button/template/ejs/button.ejs', {button: newsletter.button}); %>
+      <%- include('../../../button/template/ejs/buttons-group.ejs', {buttonsGroup: {inline: 'md', buttons: [newsletter.button]}}); %>
     <% } else if (newsletter.type === 'alert') { %>
       <%- include('../../../alert/template/ejs/alert.ejs', {alert: newsletter.alert}); %>
     <% } %>


### PR DESCRIPTION
- inverse l'ordre des boutons "Instagram" et "LinkedIn"
- supprimer les margin left et right du groupe de boutons
- place le bouton d'action dans un groupe de bouton `fr-btns-group--inline-md` sur les exemples "Lettre d'info seule" et "Réseaux sociaux et Lettre d'info mise en avant" pour que le bouton prenne l’ensemble de la largeur en vue mobile.

