### PR TITLE
🐛 fix(skiplink): espacements des liens d'évitement [DS-3533]

### DIFF
--- a/src/component/skiplink/style/_module.scss
+++ b/src/component/skiplink/style/_module.scss
@@ -7,6 +7,7 @@
   @include disable-list-style;
   @include absolute(0);
   @include padding(4v 0);
+  @include padding(3v 0, md);
   transform: translateY(-100%);
 
   &:focus-within {
@@ -16,15 +17,18 @@
 
   @include list {
     @include display-flex(column);
-    @include margin(0 -4v -6v);
 
     > li {
-      @include margin(0 4v 6v);
-      @include margin(0 4v, md);
+      @include margin-bottom(4v);
+      @include margin(0 2v, md);
 
       @include before(none);
 
       @include nest-link(md, null, null, null, true);
+
+      &:last-child {
+        @include margin-bottom(0);
+      }
     }
 
     @include respond-from(md) {


### PR DESCRIPTION
- L'ecart entre les liens d'évitement passe à 16px (4v)
- En desktop la marge en haut et en bas du composant passe à 12px (3v)