### PR TITLE
🐛 fix(form): token de couleur de la legend [DS-3550]

### DIFF
--- a/src/component/form/style/_scheme.scss
+++ b/src/component/form/style/_scheme.scss
@@ -96,7 +96,7 @@
     }
 
     &__legend {
-      @include color.text(title grey, (legacy:$legacy));
+      @include color.text(label grey, (legacy:$legacy));
     }
 
     &--error,


### PR DESCRIPTION
- la légende d'un fieldset passe en $text-label-grey à la place de $text-title-grey