### PR TITLE
🐛 fix(close-btn): retire le `margin-left` négatif [DS-3522]

### DIFF
--- a/src/component/alert/style/_module.scss
+++ b/src/component/alert/style/_module.scss
@@ -19,7 +19,7 @@
   }
 
   #{ns(btn--close)} {
-    @include absolute(1v,5v);
+    @include absolute(1v,1v);
     @include nest-btn(sm, only, close-line, null, false);
   }
 

--- a/src/component/button/style/module/_close.scss
+++ b/src/component/button/style/module/_close.scss
@@ -7,5 +7,4 @@
   @include nest-btn(sm, right, close-line, null, false);
   display: flex;
   @include margin-left(auto);
-  @include margin-right(-4v);
 }

--- a/src/component/consent/example/sample/modal/body.ejs
+++ b/src/component/consent/example/sample/modal/body.ejs
@@ -45,12 +45,14 @@ function getRadios (id, itemId, type) {
   let elementAccept = type === 'all' ? {label: 'Tout accepter'} : { label : 'Accepter'};
   let elementRefuse = type === 'all' ? {label: 'Tout refuser'} : { label : 'Refuser'};
   let disabled = type === 'mandatory';
+  let checked = type === 'mandatory';
 
   return [
     {
       name: id + '-' + name,
       ...elementAccept,
       id: id + '-' + name + '-accept',
+      checked: checked
     },
     {
       name: id + '-' + name,

--- a/src/component/navigation/style/module/_mega-menu.scss
+++ b/src/component/navigation/style/module/_mega-menu.scss
@@ -32,7 +32,6 @@
     display: none;
     @include respond-from(lg) {
       display: flex;
-      @include margin-right(0);
     }
   }
 

--- a/src/component/notice/style/_module.scss
+++ b/src/component/notice/style/_module.scss
@@ -27,7 +27,7 @@
 
   #{ns(btn--close)} {
     @include nest-btn(sm, only, close-line, null, false);
-    @include absolute(-1v, 4v);
+    @include absolute(-1v, 0);
   }
 
   &--info {


### PR DESCRIPTION
- retire le `margin-right: -1rem` sur le modifier `.fr-btn--close` et corrige l'impact sur les composants `fr-alert`, `fr-navigation`, et `fr-notice`