### PR TITLE
🐛 fix(navigation): correctifs de style mega-menu [DS-3549, DS-3548]

### DIFF
--- a/src/component/consent/example/sample/modal/body.ejs
+++ b/src/component/consent/example/sample/modal/body.ejs
@@ -45,12 +45,14 @@ function getRadios (id, itemId, type) {
   let elementAccept = type === 'all' ? {label: 'Tout accepter'} : { label : 'Accepter'};
   let elementRefuse = type === 'all' ? {label: 'Tout refuser'} : { label : 'Refuser'};
   let disabled = type === 'mandatory';
+  let checked = type === 'mandatory';
 
   return [
     {
       name: id + '-' + name,
       ...elementAccept,
       id: id + '-' + name + '-accept',
+      checked: checked
     },
     {
       name: id + '-' + name,

--- a/src/component/navigation/index.scss
+++ b/src/component/navigation/index.scss
@@ -3,4 +3,6 @@
 /// @group navigation
 ////
 
+@import '../link/index';
+
 @import '../../core/index';

--- a/src/component/navigation/style/module/_mega-menu.scss
+++ b/src/component/navigation/style/module/_mega-menu.scss
@@ -52,7 +52,8 @@
     @include set-text-margin(0 0 2v);
     @include set-title-margin(0 0 2v);
 
-    & > p {
+    p,
+    #{ns(link)} {
       @include text-style(sm);
     }
   }

--- a/src/component/navigation/style/module/_mega-menu.scss
+++ b/src/component/navigation/style/module/_mega-menu.scss
@@ -51,9 +51,9 @@
     @include padding-top(0, lg);
     @include set-text-margin(0 0 2v);
     @include set-title-margin(0 0 2v);
+    @include nest-link(sm, null);
 
-    p,
-    #{ns(link)} {
+    p {
       @include text-style(sm);
     }
   }

--- a/src/component/navigation/style/module/_mega-menu.scss
+++ b/src/component/navigation/style/module/_mega-menu.scss
@@ -46,10 +46,15 @@
 
   &__leader {
     @include enable-underline;
+    @include margin-top(-5v, lg);
     @include padding-top(2v);
     @include padding-top(0, lg);
     @include set-text-margin(0 0 2v);
     @include set-title-margin(0 0 2v);
+
+    & > p {
+      @include text-style(sm);
+    }
   }
 
   &__category {

--- a/src/component/navigation/style/scheme/_default.scss
+++ b/src/component/navigation/style/scheme/_default.scss
@@ -22,7 +22,7 @@
     &__btn {
       &[aria-expanded="true"]:not(:disabled) {
         @include color.background(open blue-france, (legacy: $legacy));
-        @include color.text(active blue-france, (legacy: $legacy));
+        @include color.text(action-high blue-france, (legacy: $legacy));
       }
     }
 

--- a/src/component/navigation/template/ejs/leader.ejs
+++ b/src/component/navigation/template/ejs/leader.ejs
@@ -12,7 +12,7 @@
 <% let menu = locals.menu || {}; %>
 <% let leader = menu.leader || {}; %>
 
-<div class="<%= prefix %>-col-12 <%= prefix %>-col-lg-8 <%= prefix %>-col-offset-lg-4--right <%= prefix %>-mb-4v" >
+<div class="<%= prefix %>-col-12 <%= prefix %>-col-lg-8 <%= prefix %>-col-offset-lg-4--right" >
   <div class="<%= prefix %>-mega-menu__leader" >
     <%
     if (leader.title !== undefined) {


### PR DESCRIPTION
- ajoute un `margin-top: -1.25rem` (-20px) sur le `fr-mega-menu__leader`
- passe le texte de description et le lien du `fr-mega-menu__leader` en taille `sm`
- supprime la classe `fr-mb-4v `de la colonne entourant le `fr-mega-menu__leader`
- le texte du bouton de navigation passe en $text-action-high-blue-france à l'ouverture