### PR TITLE
🐛 fix(footer): ajustements [DS-3552, DS-3384, DS-3560, DS-3381]

### DIFF
--- a/src/component/footer/example/index.ejs
+++ b/src/component/footer/example/index.ejs
@@ -6,6 +6,10 @@
 
 <%- sample('Pied de page avec logo opérateur', './sample/footer-operator.ejs', {}, true); %>
 
-<%- sample('Pied de page avec logos partenaires', './sample/footer-partners.ejs', {}, true); %>
+<%- sample('Pied de page avec logos partenaires', './sample/footer-partners.ejs', {footer: {partners: {mainPartner: true, subPartners: true}}}, true); %>
 
-<%- sample('Pied de page complet', './sample/footer.ejs', {footer: {brand: true, operator: true, bottom: true, content: true, partners: true, top: true}}, true); %>
+<%- sample('Pied de page avec logo partenaire primaire uniquement', './sample/footer-partners.ejs', {footer: {partners: {mainPartner: true}}}, true); %>
+
+<%- sample('Pied de page avec logos partenaires secondaires uniquement', './sample/footer-partners.ejs', {footer: {partners: {subPartners: true}}}, true); %>
+
+<%- sample('Pied de page complet', './sample/footer.ejs', {footer: {brand: true, operator: true, bottom: true, content: true, partners: {mainPartner: true, subPartners: true}, top: true}}, true); %>

--- a/src/component/footer/example/sample/footer-partners.ejs
+++ b/src/component/footer/example/sample/footer-partners.ejs
@@ -2,6 +2,7 @@
 let footer = locals.footer || {};
 let data = {};
 if (footer.logo) data.logo = footer.logo;
+if (footer.partners) data.partners = footer.partners;
 %>
 
 <%- include('footer.ejs', {footer: {brand: true, partners: true, content: true, bottom: true, ...data}}); %>

--- a/src/component/footer/example/sample/footer.ejs
+++ b/src/component/footer/example/sample/footer.ejs
@@ -12,7 +12,7 @@ if (footer.brand === true) {
 }
 
 if (footer.content === true) data.content = {
-  desc: lorem(),
+  desc: lorem('', 240),
   links: [
     {label: 'legifrance.gouv.fr'},
     {label: 'gouvernement.fr'},

--- a/src/component/footer/example/sample/footer.ejs
+++ b/src/component/footer/example/sample/footer.ejs
@@ -21,16 +21,26 @@ if (footer.content === true) data.content = {
   ]
 };
 
-if (footer.partners === true) data.partners = {
-  title: 'Nos partenaires',
-  href: footer.href,
-  mainPartner: imgData('img/placeholder.16x9.png', 'rendered', null, null, 'height: 5.625rem'),
-  subPartners: [
-      imgData('img/placeholder.16x9.png', 'rendered', null, null, 'height: 5.625rem'),
-      imgData('img/placeholder.1x1.png', 'rendered', null, null, 'height: 5.625rem'),
-      imgData('img/placeholder.9x16.png', 'rendered', null, null, 'height: 5.625rem')
-  ]
-};
+if (footer.partners !== undefined) {
+  data.partners = {
+    title: footer.partners.subPartners ? 'Nos partenaires' : 'Notre partenaire',
+    href: footer.href
+  }
+
+  if (footer.partners.mainPartner === true) {
+    data.partners.mainPartner = imgData('img/placeholder.16x9.png', 'rendered', null, null, 'height: 5.625rem');
+  }
+
+  if (footer.partners.subPartners === true) {
+    data.partners.subPartners = [
+        imgData('img/placeholder.16x9.png', 'rendered', null, null, 'height: 5.625rem'),
+        imgData('img/placeholder.1x1.png', 'rendered', null, null, 'height: 5.625rem'),
+        imgData('img/placeholder.9x16.png', 'rendered', null, null, 'height: 5.625rem')
+    ]
+  }
+}
+
+
 
 if (footer.bottom === true) data.bottom = {
   links: [

--- a/src/component/footer/style/_scheme.scss
+++ b/src/component/footer/style/_scheme.scss
@@ -9,7 +9,10 @@
   #{ns(footer)} {
     @include color.box-shadow((plain blue-france) (default grey), (legacy:$legacy), top-2-in bottom-1-in);
 
-    &__content-link,
+    &__content-link {
+      @include color.text(default grey, (legacy:$legacy));
+    }
+
     &__top-cat {
       @include color.text(title grey, (legacy:$legacy));
     }
@@ -41,6 +44,15 @@
 
     &__partners {
       @include color.box-shadow(default grey, (legacy:$legacy), top-1-in);
+
+      &-title {
+        @include color.text(default grey, (legacy:$legacy));
+      }
+
+      #{ns(footer__logo)} {
+        @include color.background(default grey, (legacy:$legacy));
+        @include color.box-shadow(default grey, (legacy:$legacy));
+      }
 
       @if not $legacy {
         #{ns(footer__partners-link)} {

--- a/src/component/footer/style/module/_bottom.scss
+++ b/src/component/footer/style/module/_bottom.scss
@@ -14,7 +14,7 @@
 
     @include nest-footer-bottom-btn(xs, left) {
       display: inline;
-    };
+    }
   }
 
   /**
@@ -22,7 +22,7 @@
   */
   &__bottom-list {
     @include size(100%);
-    @include padding(4v 0 4v);
+    @include padding(2v 0);
     @include size(100%);
     @include margin(0);
   }
@@ -39,10 +39,8 @@
       @include size(1px, 4v);
       @include margin-right(1v);
       @include margin-right(3v, md);
-      @include margin-bottom(2v);
-      @include margin-bottom(1v, md);
-      @include margin-top(2v);
-      @include margin-top(1v, md);
+      @include margin-bottom(2.5v);
+      @include margin-top(2.5v);
     }
 
     &:first-child {

--- a/src/component/footer/style/module/_bottom.scss
+++ b/src/component/footer/style/module/_bottom.scss
@@ -12,7 +12,9 @@
     @include display-flex(row, center, null, wrap);
     @include margin-top(10v);
 
-    @include nest-footer-bottom-btn(xs, left);
+    @include nest-footer-bottom-btn(xs, left) {
+      display: inline;
+    };
   }
 
   /**

--- a/src/component/footer/style/module/_bottom.scss
+++ b/src/component/footer/style/module/_bottom.scss
@@ -20,7 +20,7 @@
   */
   &__bottom-list {
     @include size(100%);
-    @include padding(2v 0 4v);
+    @include padding(4v 0 4v);
     @include size(100%);
     @include margin(0);
   }

--- a/src/component/footer/style/module/_content.scss
+++ b/src/component/footer/style/module/_content.scss
@@ -29,7 +29,7 @@
   */
   &__content-desc {
     @include enable-underline;
-    @include set-text-margin(0 0 2v 0);
+    @include set-text-margin(0 0 0 0);
     @include size(100%);
     @include text-style(sm);
   }
@@ -41,6 +41,8 @@
     @include display-flex(row);
     align-self: center;
     @include margin-bottom(-2v);
+    @include margin-top(4v);
+    @include margin-top(2v, md);
     flex-wrap: wrap;
 
     > li {

--- a/src/component/footer/style/module/_content.scss
+++ b/src/component/footer/style/module/_content.scss
@@ -39,8 +39,7 @@
   &__content-list {
     @include display-flex(row);
     align-self: center;
-    // @include margin-bottom(-4v);
-    // @include margin-bottom(4v, md);
+    @include margin-bottom(-2v);
     flex-wrap: wrap;
 
     > li {

--- a/src/component/footer/style/module/_content.scss
+++ b/src/component/footer/style/module/_content.scss
@@ -20,6 +20,7 @@
     @include respond-from(lg) {
       @include margin-top(0);
       flex-basis: calc(100% - (100% / 2));
+      @include max-width(147v);
     }
   }
 
@@ -43,7 +44,7 @@
     flex-wrap: wrap;
 
     > li {
-      @include margin-right(4v);
+      @include margin-right(5v);
       @include margin-right(6v, sm);
       @include margin-top(2v);
       @include margin-bottom(2v);

--- a/src/component/footer/style/module/_default.scss
+++ b/src/component/footer/style/module/_default.scss
@@ -6,7 +6,7 @@
 #{ns(footer)} {
   @include disable-list-style;
   @include size(100%);
-  @include padding-top(10v);
+  @include padding-top(8v);
 
   @include body {
     @include display-flex(row, center, null, wrap);

--- a/src/component/footer/style/module/_default.scss
+++ b/src/component/footer/style/module/_default.scss
@@ -42,7 +42,7 @@
      */
     #{ns(logo)} + #{ns(footer__brand-link)} {
       @include margin-left(6v);
-      @include margin-left(12v, md);
+      @include margin-left(8v, md);
     }
 
     @include respond-from(md) {

--- a/src/component/footer/style/module/_partners.scss
+++ b/src/component/footer/style/module/_partners.scss
@@ -21,7 +21,6 @@
     */
     #{ns(footer__logo)} {
       @include size(auto, auto);
-      @include padding(1v);
     }
 
     + #{ns(footer__bottom)} {
@@ -30,8 +29,9 @@
   }
 
   &__partners-title {
-    @include set-title-margin(0 0 2v 0);
+    @include set-title-margin(0 0 3v 0);
     @include text-style(sm);
+    @include font-weight(regular);
     flex-basis: 100%;
     text-align: center;
 
@@ -110,7 +110,8 @@
     * On surcharge le style du lien pour les logos secondaires
     */
     #{ns(footer)}__partners-link {
-      @include margin-bottom(2v);
+      @include margin-bottom(4v);
+      @include margin-bottom(2v, md);
     }
 
     @include respond-from(sm) {

--- a/src/component/footer/style/module/_partners.scss
+++ b/src/component/footer/style/module/_partners.scss
@@ -48,12 +48,8 @@
     @include margin(0 0 -2v 0);
 
     @include respond-from(sm) {
-      @include display-flex(row, flex-start, flex-start);
+      @include display-flex(row, flex-start, space-between);
       @include margin-right(-2v);
-      @include before('', block) {
-        order: 2;
-        flex: 1;
-      }
     }
 
     @include respond-from(md) {
@@ -67,27 +63,13 @@
   */
   &__partners-main {
     @include display-flex(row,null,center);
-    @include margin-x(auto);
     @include margin-bottom(8v);
     @include margin-bottom(4v, sm);
 
     + #{ns(footer__partners-sub)} {
-      & > ul > li {
-        @include margin(0 2v 0 2v, sm);
-        @include margin(0 4v 0 4v, md);
-      }
-
       @include respond-from(md) {
-        & > ul {
-          justify-content: flex-end;
-        }
         @include padding-left(4v);
-        @include padding-top(0);
       }
-    }
-
-    @include respond-from(sm) {
-      order: 1;
     }
   }
 
@@ -100,9 +82,26 @@
     &,
     & > ul {
       @include display-flex(column, center, null, wrap);
+
       @include respond-from(sm) {
         flex-direction: row;
         align-items: flex-start;
+      }
+
+      @include respond-from(md) {
+        & > ul {
+          justify-content: flex-end;
+        }
+        @include padding-top(0);
+      }
+      
+      & > li {
+        @include margin(0 2v 0 2v, sm);
+        @include margin(0 4v 0 4v, md);
+
+        &:first-child {
+          @include margin-left(0);
+        }
       }
     }
 

--- a/src/component/footer/style/module/_top.scss
+++ b/src/component/footer/style/module/_top.scss
@@ -11,7 +11,7 @@
   &__top {
     @include display-flex(null);
     @include margin(-9.5v 0 4v);
-    @include margin(-9.5v 0 10v, md);
+    @include margin(-9.5v 0 8v, md);
     @include padding(8v 0 4v);
   }
 

--- a/src/component/footer/style/module/_top.scss
+++ b/src/component/footer/style/module/_top.scss
@@ -10,9 +10,9 @@
 #{ns(footer)} {
   &__top {
     @include display-flex(null);
-    @include margin(-9.5v 0 4v);
+    @include margin(-9.5v 0 6v);
     @include margin(-9.5v 0 8v, md);
-    @include padding(8v 0 4v);
+    @include padding(8v 0 5v);
   }
 
   /**

--- a/src/component/footer/style/module/_top.scss
+++ b/src/component/footer/style/module/_top.scss
@@ -10,8 +10,8 @@
 #{ns(footer)} {
   &__top {
     @include display-flex(null);
-    @include margin(-9.5v 0 6v);
-    @include margin(-9.5v 0 8v, md);
+    @include margin(-7.5v 0 6v);
+    @include margin(-7.5v 0 8v, md);
     @include padding(8v 0 5v);
   }
 
@@ -30,6 +30,7 @@
   * Style de la liste
   */
   &__top-list {
+    @include text-style(xs);
     @include margin(0);
 
     li {

--- a/src/component/footer/template/ejs/partners.ejs
+++ b/src/component/footer/template/ejs/partners.ejs
@@ -13,26 +13,31 @@
   attributes.id = attributes.id || uniqueId('footer__partners-link');
 %>
 
-<h4 class="<%= prefix %>-footer__partners-title"><%- partners.title %></h4>
+<h2 class="<%= prefix %>-footer__partners-title"><%- partners.title %></h2>
 <div class="<%= prefix %>-footer__partners-logos">
-  <div class="<%= prefix %>-footer__partners-main">
-    <a <%- includeAttrs(attributes) %> class="<%= prefix %>-footer__partners-link" href="<%- partners.href %>">
-      <%- include('../../../../core/template/ejs/media/img.ejs',  {media: {...partners.mainPartner, classes: [prefix + '-footer__logo']}}); %>
-    </a>
-  </div>
-  <div class="<%= prefix %>-footer__partners-sub">
-    <ul>
-      <%
-        for (let i = 0; i < partners.subPartners.length; i++) {
-          const attributes = {};
-      	  attributes.id = uniqueId('footer__subpartners-link');
-      %>
-      <li>
-        <a <%- includeAttrs(attributes) %> class="<%= prefix %>-footer__partners-link" href="<%- partners.href %>">
-          <%- include('../../../../core/template/ejs/media/img.ejs', {media: {...partners.subPartners[i], classes: [prefix + '-footer__logo']}}); %>
-        </a>
-      </li>
-    <% } %>
-    </ul>
-  </div>
+  <% if (partners.mainPartner) { %>
+    <div class="<%= prefix %>-footer__partners-main">
+      <a <%- includeAttrs(attributes) %> class="<%= prefix %>-footer__partners-link" href="<%- partners.href %>">
+        <%- include('../../../../core/template/ejs/media/img.ejs',  {media: {...partners.mainPartner, classes: [prefix + '-footer__logo']}}); %>
+      </a>
+    </div>
+  <% } %>
+
+  <% if (partners.subPartners && partners.subPartners.length) { %>
+    <div class="<%= prefix %>-footer__partners-sub">
+      <ul>
+        <%
+          for (let i = 0; i < partners.subPartners.length; i++) {
+            const attributes = {};
+            attributes.id = uniqueId('footer__subpartners-link');
+        %>
+          <li>
+            <a <%- includeAttrs(attributes) %> class="<%= prefix %>-footer__partners-link" href="<%- partners.href %>">
+              <%- include('../../../../core/template/ejs/media/img.ejs', {media: {...partners.subPartners[i], classes: [prefix + '-footer__logo']}}); %>
+            </a>
+          </li>
+        <% } %>
+      </ul>
+    </div>
+  <% } %>
 </div>


### PR DESCRIPTION
- le texte filler de footer__content-desc doit faire maximum 3 lignes en desktop
- passe les liens .fr-footer__content-link en $text-default-grey
- passe le padding top de .fr-footer__bottom-list à 4v
- correction des espacements autour de fr-footer-body :  en mobile et en desktop (32px en haut et 24px en bas)
- titre “nos partenaire“ → fr-footer__partners-title passe en graisse régular, couleur text-default-grey
- ecart de 12px sous “Nos partenaire” en mobile/desktop
- enleve le padding sur .fr-footer__partners .fr-footer__logo, ajoute une border 1px en $border-default-grey + un background en background-default-grey
- en desktop l’ecart entre logo et bloc mark passe à 32px
- passe le logo opérateur en 16x9
- ajoute un margin bottom négatif de 8px sur le groupe de lien pour garder 24px en dessous
- retire le padding sur les images des logos partenaire
- passe à 16px entre les logos partenaires secondaires
- corrige le niveau de titre des partenaires
- rend les partenaires secondaires facultatifs
- corrige alignement des liens en bas du footer
