### PR TITLE
🐛 fix(sidemenu): correction marge interne [DS-3537]

### DIFF
--- a/src/component/sidemenu/style/module/_inner.scss
+++ b/src/component/sidemenu/style/module/_inner.scss
@@ -5,7 +5,8 @@
 
 #{ns(sidemenu)} {
   &__inner {
-    @include padding(0 8v 0 1v, md);
+    @include padding(0 6v 0 0, md);
+    
 
     /**
     * Ce wrapper ne sert que pour la version mobile


### PR DESCRIPTION
- retire 1v de padding gauche et droite sur `fr-sidemenu__inner` en desktop