### PR TITLE
🐛 fix(card): alignement du détail & erreur js sur safari <14 [DS-3191]

### DIFF
--- a/src/component/card/style/module/_default.scss
+++ b/src/component/card/style/module/_default.scss
@@ -35,6 +35,7 @@
 
   @include body() {
     @include display-flex(column);
+    @include height(100%);
     flex: 1 1 auto;
     order: 2;
   }

--- a/src/scheme/script/scheme/scheme.js
+++ b/src/scheme/script/scheme/scheme.js
@@ -135,7 +135,7 @@ class Scheme extends api.core.Instance {
     if (this.isListening) return;
     this.isListening = true;
     this.mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-    this.mediaQuery.addEventListener('change', this.changing);
+    if (this.mediaQuery.addEventListener) this.mediaQuery.addEventListener('change', this.changing);
     this.change();
   }
 


### PR DESCRIPTION
Sur les anciennes version de safari macOS (inférieure à 14.0)
- corrige l'alignement du détail de la carte dans une grille de carte
- corrige une erreur de javascript sur `scheme.js` 