### PR TITLE
🐛 fix(connect): adaptabilité de la taille de fonte pour l'accessibilité [DS-3627]

### DIFF
--- a/src/component/connect/i18n/fr.yml
+++ b/src/component/connect/i18n/fr.yml
@@ -9,7 +9,7 @@ default:
   link: Qu’est-ce que FranceConnect ?
   href: https://franceconnect.gouv.fr/
 plus:
-  brand: FranceConnect+
+  brand: FranceConnect
   link: Qu’est-ce que FranceConnect+ ?
   href: https://franceconnect.gouv.fr/france-connect-plus
 agent:

--- a/src/component/connect/standalone/style/_module.scss
+++ b/src/component/connect/standalone/style/_module.scss
@@ -10,4 +10,6 @@
   @include btn-reset(true);
   @include standalone-cursor(get-clickable-elements());
   @include standalone-focus(get-clickable-elements());
+  @include text-style(md);
+  font-size: max(1rem, 16px);
 }

--- a/src/component/connect/style/module/_agent.scss
+++ b/src/component/connect/style/module/_agent.scss
@@ -6,6 +6,5 @@
 #{ns(connect)} {
   &--agent &__brand {
     font-size: map-get($brand-size, agent);
-    height: map-get($brand-size, agent);
   }
 }

--- a/src/component/connect/style/module/_default.scss
+++ b/src/component/connect/style/module/_default.scss
@@ -7,36 +7,35 @@
 
 #{ns(connect)} {
   @include relative;
-  @include padding(2.5v 3v 2.5v 16v);
+  @include padding(0.625em 0.75em 0.625em 4em);
   @include display-flex(column, flex-start, center, null, true);
-  min-height: spacing.space(14v);
   @include margin-bottom(3v);
   @include disable-underline;
   @include enable-tint;
   @include hover-tint;
 
   @include before('', block) {
-    @include absolute(1v, null, 1v, 3v, 10v, 12v);
+    @include absolute(50%, null, 0.25em, 0.75em, 2.5em, 3em);
+    @include margin-top(-1.5em);
     background-image: url(svg-encode($fc-logo-svg, true));
     background-repeat: no-repeat;
     background-position: 50% 50%;
-    background-size: spacing.space(10v 12v);
+    background-size: 2.5em 3em;
   }
 
   &__login,
   &__brand {
     line-height: 1;
     @include z-index(over);
+    white-space: nowrap;
   }
 
   &__login {
     font-size: map-get($login-size, default);
-    height: map-get($login-size, default);
   }
 
   &__brand {
     font-weight: bold;
     font-size: map-get($brand-size, default);
-    height: map-get($brand-size, default);
   }
 }

--- a/src/component/connect/style/module/_default.scss
+++ b/src/component/connect/style/module/_default.scss
@@ -7,9 +7,9 @@
 
 #{ns(connect)} {
   @include relative;
-  @include padding(1v 3v 1v 16v);
+  @include padding(2.5v 3v 2.5v 16v);
   @include display-flex(column, flex-start, center, null, true);
-  height: spacing.space(14v);
+  min-height: spacing.space(14v);
   @include margin-bottom(3v);
   @include disable-underline;
   @include enable-tint;

--- a/src/component/connect/style/module/_plus.scss
+++ b/src/component/connect/style/module/_plus.scss
@@ -3,23 +3,18 @@
 /// @group connect
 ////
 
+@use 'module/spacing';
+
 #{ns(connect)} {
   &--plus {
-    @include padding-right(12v);
+    @include padding-right(3em);
 
     @include after ('+', block) {
-      @include absolute(4v, 3v, 4v, null, 6v, 6v);
-      font-size: 3.6em;
+      @include absolute(null, 0.25em);
+      font-size: 3em;
       font-weight: bold;
-      // background-repeat: repeat-x, repeat-y;
-      // background-position: 50% 50%, 50% 50%;
-      // background-size: 21.5% 21.5%, 21.5% 21.5%;
+      line-height: 1;
+      transform: translate(5%, -10%);
     }
-  }
-
-  &--plus &__brand {
-    @include margin-right(-10px);
-    overflow: hidden;
-    @include width(100%);
   }
 }

--- a/src/component/connect/style/module/_plus.scss
+++ b/src/component/connect/style/module/_plus.scss
@@ -6,11 +6,14 @@
 #{ns(connect)} {
   &--plus {
     @include padding-right(12v);
-    @include after ('', block) {
+
+    @include after ('+', block) {
       @include absolute(4v, 3v, 4v, null, 6v, 6v);
-      background-repeat: repeat-x, repeat-y;
-      background-position: 50% 50%, 50% 50%;
-      background-size: 21.5% 21.5%, 21.5% 21.5%;
+      font-size: 3.6em;
+      font-weight: bold;
+      // background-repeat: repeat-x, repeat-y;
+      // background-position: 50% 50%, 50% 50%;
+      // background-size: 21.5% 21.5%, 21.5% 21.5%;
     }
   }
 

--- a/src/component/connect/style/scheme/_default.scss
+++ b/src/component/connect/style/scheme/_default.scss
@@ -11,17 +11,9 @@
     @include color.background(action-high blue-france, (legacy: $legacy, standalone: $standalone));
     @include color.text(inverted blue-france, (legacy: $legacy, standalone: $standalone));
 
-    @include after {
-      @include color.background-image((text inverted blue-france, text inverted blue-france), (legacy: $legacy, standalone: $standalone));
-    }
-
     @include disabled.selector((can-be-link: true)) {
       @include color.background(disabled grey, (legacy: $legacy, standalone: $standalone));
       @include color.text(disabled grey, (legacy: $legacy, standalone: $standalone));
-
-      @include after {
-        @include color.background-image((text disabled grey, text disabled grey), (legacy: $legacy, standalone: $standalone));
-      }
     }
   }
 }

--- a/src/component/connect/style/setting/_size.scss
+++ b/src/component/connect/style/setting/_size.scss
@@ -4,10 +4,10 @@
 ////
 
 $login-size: (
-  default: 17px
+  default: 1.275em
 );
 
 $brand-size: (
-  default: 18px,
+  default: 1.35em,
   // agent: 19px,
 );

--- a/src/component/connect/style/setting/_size.scss
+++ b/src/component/connect/style/setting/_size.scss
@@ -4,10 +4,10 @@
 ////
 
 $login-size: (
-  default: 1.275em
+  default: 1.0625em
 );
 
 $brand-size: (
-  default: 1.35em,
+  default: 1.125em,
   // agent: 19px,
 );

--- a/src/core/style/action/tool/_button.scss
+++ b/src/core/style/action/tool/_button.scss
@@ -13,5 +13,6 @@
     color: inherit;
     background-color: transparent;
     font-family: inherit;
+    font-size: inherit;
   }
 }


### PR DESCRIPTION
Actuellement, le bouton FranceConnect ne répond pas aux critères d’accessibilité qui redéfinisse le letter-spacing et la taille de fonte.
- Passage des valeurs de tailles et d'espacements en 'em' pour les rendre relatives à la taille de fonte du bouton.
- **Retrait du '+' de 'FranceConnect+' dans l'intitulé de `fr-connect__brand`**. Celui-ci est désormais placé en contenu du pseudo-élément after du bouton