### PR TITLE
🐛 fix(link, card, tile): espacement entre libellé et icone [DS-3643]

### DIFF
--- a/src/component/card/style/module/_content.scss
+++ b/src/component/card/style/module/_content.scss
@@ -19,7 +19,9 @@
     @include margin-bottom(0);
 
     a {
-      @include icon(arrow-right-line, sm, after);
+      @include icon(arrow-right-line, sm, after) {
+        @include margin-left(2v);
+      }
     }
 
     @include target-blank {

--- a/src/component/card/template/ejs/content.ejs
+++ b/src/component/card/template/ejs/content.ejs
@@ -77,9 +77,7 @@ switch (true) {
 
 <div class="<%= prefix %>-card__content">
     <<%= markup %> class="<%= prefix %>-card__title">
-        <% if (hasLink) { %><a <%- includeAttrs(attributes) %>><% } %>
-          <%- content.title %>
-        <% if (hasLink) { %></a><% } %>
+        <% if (hasLink) { %><a <%- includeAttrs(attributes) %>><% } %><%- content.title %><% if (hasLink) { %></a><% } %>
     </<%= markup %>>
 
     <% if (content.description !== undefined) { %>

--- a/src/component/link/example/index.ejs
+++ b/src/component/link/example/index.ejs
@@ -12,6 +12,8 @@
 
 <%- sample('Lien seul désactivé', './sample/link-default', {link: {disabled: true}}, true); %>
 
+<%- sample('Lien externe', './sample/link-default', {link: {blank: true}}, true); %>
+
 <%- section('Groupe de liens', 'Lorsque que l\'on a plus d\'un lien, il convient d\'utiliser un groupe de liens. <br>La taille de tous les liens peut être définie au niveau du groupe.') %>
 
 <%- sample('Groupe de liens', './sample/links-group', { linksGroup: { groupCount: 9 } }, true); %>

--- a/src/component/link/template/ejs/link.ejs
+++ b/src/component/link/template/ejs/link.ejs
@@ -122,6 +122,4 @@ if (link.detail) {
 
 %>
 
-<<%= markup %> <%- includeClasses(linkClasses); %> <%- includeAttrs(linkAttrs); %> >
-<%- label %>
-</<%= markup %>>
+<<%= markup %> <%- includeClasses(linkClasses); %> <%- includeAttrs(linkAttrs); %> ><%- label %></<%= markup %>>

--- a/src/component/tile/style/module/_default.scss
+++ b/src/component/tile/style/module/_default.scss
@@ -58,9 +58,12 @@
         }
       }
     }
+  }
 
-    &#{ns(tile--no-icon)} {
-      #{ns(tile__title a)} {
+  &--no-icon,
+  &:not(#{ns(enlarge-link)}):not(#{ns(tile--download)}) {
+    #{ns(tile__title a)} {
+      &:not([target="_blank"]) {
         @include after(none);
       }
     }
@@ -87,11 +90,13 @@
         background-repeat: no-repeat;
       }
 
-      @include icon(arrow-right-line, md, after);
+      @include icon(arrow-right-line, sm, after) {
+        @include margin-left(2v);
+      }
     }
 
     @include target-blank {
-      @include icon(external-link-line, null, after);
+      @include icon(external-link-line, sm, after);
     }
   }
 

--- a/src/component/tile/template/ejs/content.ejs
+++ b/src/component/tile/template/ejs/content.ejs
@@ -59,9 +59,7 @@ if (content.badge) start.badge = content.badge;
 
 <div class="<%= prefix %>-tile__content">
   <<%= markup %> class="<%= prefix %>-tile__title">
-      <% if (hasLink) { %><a <%- includeAttrs(attributes) %>><% } %>
-        <%- content.title %>
-      <% if (hasLink) { %></a><% } %>
+      <% if (hasLink) { %><a <%- includeAttrs(attributes) %>><% } %><%- content.title %><% if (hasLink) { %></a><% } %>
   </<%= markup %>>
 
   <% if (content.description !== undefined) { %>


### PR DESCRIPTION
- retrait du saut de ligne entre la balise `a` et son libellé pour corriger l'écart entre le libellé du lien et l'icone
- ajout d'un exemple "lien externe" dans les exemples de lien
- correction de la taille de l'icone sur les tuiles sans lien étendu
- retrait de l'icone arrow-right sur les tuiles sans lien étendu, pour être iso avec les cartes