### PR TITLE
🐛 fix(toggle): largeur max du label & libellé [DS-3647]

### DIFF
--- a/src/component/toggle/example/sample/toggle-default.ejs
+++ b/src/component/toggle/example/sample/toggle-default.ejs
@@ -2,10 +2,10 @@
 const toggle = locals.toggle || {};
 
 const data = {
-  label: 'Label action interrupteur',
+  label: 'Label de l\'interrupteur',
   id: uniqueId('toggle'),
   ...toggle,
-  hint: toggle.hint === true ? 'Texte d’aide pour clarifier l’action' : toggle.hint
+  hint: toggle.hint === true ? 'Texte de description additionnel' : toggle.hint
 }
 
 %>

--- a/src/component/toggle/example/sample/toggle-group.ejs
+++ b/src/component/toggle/example/sample/toggle-group.ejs
@@ -3,9 +3,9 @@ const toggles = locals.toggles || {};
 const toggle = locals.toggle || {};
 
 let data = {
-  label: 'Label action interrupteur',
+  label: 'Label de l\'interrupteur',
   ...toggle || {},
-  hint: toggle.hint === true ? 'Texte d’aide pour clarifier l’action' : toggle.hint,
+  hint: toggle.hint === true ? 'Texte de description additionnel' : toggle.hint,
 }
 
 const elements = [];

--- a/src/component/toggle/style/module/_default.scss
+++ b/src/component/toggle/style/module/_default.scss
@@ -36,7 +36,7 @@
   label {
     --toggle-status-width: auto;
     display: inline-flex;
-    width: spacing.space(calc(100% - 10v));
+    width: spacing.space(calc(100% - 8v));
     min-height: spacing.space(6v);
     @include text-style(md);
     -webkit-tap-highlight-color: transparent;

--- a/src/component/toggle/style/module/_variants.scss
+++ b/src/component/toggle/style/module/_variants.scss
@@ -21,7 +21,7 @@
   #{ns(toggle__label)} {
     justify-content: space-between;
     @include padding-left(0);
-    width: calc(100% - #{space(10v)});
+    width: calc(100% - #{space(8v)});
     flex: 1;
 
     @include before {


### PR DESCRIPTION
- augmentation de la largeur max du label, la marge de 10v passe à 8v
- changement du libellé du label et du texte additionnel