### PR TITLE
🐛 fix(build): liens doc sur core & utility [DS-3652]

### DIFF
--- a/tool/example/heading.ejs
+++ b/tool/example/heading.ejs
@@ -17,7 +17,7 @@
     <%
     for (const d of doc) {
     %>
-      <li><a href="<%= d.url %>" <%- includeAttrs(targetBlankData()) %> <%= d.title %></a></li>
+      <li><a href="<%= d.url %>" <%- includeAttrs(targetBlankData()) %>> <%= d.title %></a></li>
     <%
     }
     %>


### PR DESCRIPTION
- correction des liens de la documentation qui ne s'affichent plus dans les exemples