### PR TITLE
🐛 fix(range): dépendance à scheme [DS-3641]

### DIFF
--- a/src/component/range/.package.yml
+++ b/src/component/range/.package.yml
@@ -8,3 +8,4 @@ styles:
   - form
 script:
   - core
+  - scheme

--- a/src/component/range/script/range/range.js
+++ b/src/component/range/script/range/range.js
@@ -26,7 +26,7 @@ class Range extends api.core.Instance {
       this._observer = new ResizeObserver(this._retrieveWidth.bind(this));
       this._observer.observe(this.node);
       this._retrieveWidth();
-      this.addDescent(api.scheme.SchemeEmission.SCHEME, this._model.update.bind(this._model));
+      if (api.scheme) this.addDescent(api.scheme.SchemeEmission.SCHEME, this._model.update.bind(this._model));
     }
 
     this.addAscent(RangeEmission.CONSTRAINTS, this.setConstraints.bind(this));


### PR DESCRIPTION
- Le composant `range`utilise des fonctionnalités de `scheme` pour pouvoir passer en dark mode
- Ajout de la dépendance dans la configuration du package `range`
- Vérification de l'implémentation (optionnelle) de `scheme` avant d'en utiliser les fonctionnalités