### PR TITLE
🐛 fix(legacy): bugs IE divers [DS-3641]

### DIFF
--- a/src/component/breadcrumb/style/_module.scss
+++ b/src/component/breadcrumb/style/_module.scss
@@ -45,7 +45,7 @@ un padding de 4px et une marge négative en compensation sont mis en place afin 
       transform: none;
       visibility: inherit;
       overflow: visible;
-      max-height: initial;
+      max-height: none;
       @include before(none);
     }
   }

--- a/src/component/button/style/_legacy.scss
+++ b/src/component/button/style/_legacy.scss
@@ -9,6 +9,10 @@
   #{ns(btn)} {
     @include icon-legacy(null, sm);
 
+    &[href] {
+      text-decoration: none;
+    }
+
     @include class-not-start-with(#{ns(btn--icon-, '')}) {
       @include has-icon {
         @include icon-legacy(null, md);
@@ -50,6 +54,18 @@
 
   #{ns(btn--display)} {
     @include icon-legacy(theme-fill, sm);
+  }
+
+  #{ns(btn--briefcase)} {
+    @include icon-legacy(briefcase-fill, sm);
+  }
+
+  #{ns(btn--account)} {
+    @include icon-legacy(account-circle-fill, sm);
+  }
+
+  #{ns(btn--team)} {
+    @include icon-legacy(team-line, sm);
   }
 
   #{ns-group(btns)} {

--- a/src/component/card/style/_legacy.scss
+++ b/src/component/card/style/_legacy.scss
@@ -36,6 +36,22 @@
       #{ns(tile__title a)} {
         @include icon-legacy(download-line, null, after);
       }
+
+      #{ns(card__header)} {
+        padding-top: 56.25%;
+
+        @include respond-from(md) {
+          padding-top: 0;
+        }
+
+        #{ns(card__img)} {
+          img {
+            height: auto !important;
+            width: auto;
+            margin: auto;
+          }
+        }
+      }
     }
 
     &#{ns(enlarge-link)} {

--- a/src/component/card/template/ejs/header.ejs
+++ b/src/component/card/template/ejs/header.ejs
@@ -3,7 +3,9 @@
 
 * header.img (object, optional) : paramètres de l'image
 
-* header.taxonomy (object, optional) : Taxonomie
+* header.vid (object, optional) : paramètres de vidéo
+
+* header.badgesGroup (array, optional) : Groupe de badges (voir badge)
 
 %>
 

--- a/src/component/checkbox/deprecated/style/_module.scss
+++ b/src/component/checkbox/deprecated/style/_module.scss
@@ -11,16 +11,14 @@
       &--sm {
         label {
           &::before {
-            @include margin-top(4v);
+            @include margin-top(1v);
           }
         }
       }
-    }
-  }
-}
 
-#{ns-group(checkbox)} {
-  input[type='checkbox'] {
-    margin-top: spacing.space(3v);
+      input[type='checkbox'] {
+        margin-top: spacing.space(3v);
+      }
+    }
   }
 }

--- a/src/component/checkbox/style/_legacy.scss
+++ b/src/component/checkbox/style/_legacy.scss
@@ -5,11 +5,26 @@
 
 @use 'module/selector';
 @use 'module/legacy';
+@use 'module/spacing';
 
 @include legacy.is(ie11) {
   #{selector.ns(checkbox-group)} {
     input[type="checkbox"] {
       opacity: 1;
+      @include margin-top(0);
+    }
+  }
+
+  #{selector.ns(fieldset__content)} {
+    #{selector.ns(checkbox-group)} {
+      input[type="checkbox"] {
+        @include margin-top(6v);
+      }
+    }
+
+    + #{selector.ns(valid-text)},
+    + #{selector.ns(error-text)} {
+      @include margin-top(4v);
     }
   }
 }

--- a/src/component/connect/style/module/_plus.scss
+++ b/src/component/connect/style/module/_plus.scss
@@ -10,11 +10,11 @@
     @include padding-right(3em);
 
     @include after ('+', block) {
-      @include absolute(null, 0.25em);
+      @include absolute(null, 0.25em, 0);
       font-size: 3em;
       font-weight: bold;
       line-height: 1;
-      transform: translate(5%, -10%);
+      transform: translate(5%, -17%);
     }
   }
 }

--- a/src/component/header/style/_legacy.scss
+++ b/src/component/header/style/_legacy.scss
@@ -38,6 +38,12 @@
       }
     }
 
+    &__operator {
+      img {
+        height: auto !important;
+      }
+    }
+
     #{ns(modal)} {
       @include respond-from(lg) {
         position: static;

--- a/src/component/pagination/style/_legacy.scss
+++ b/src/component/pagination/style/_legacy.scss
@@ -17,19 +17,19 @@
     &__link {
       @include color.transparent-background((legacy: true, hover: true));
 
-      &--first {
+      #{ns(pagination)} &--first {
         @include icon-legacy(arrow-left-s-first-line, md);
       }
 
-      &--prev {
+      #{ns(pagination)} &--prev {
         @include icon-legacy(arrow-left-s-line, md);
       }
 
-      &--next {
+      #{ns(pagination)} &--next {
         @include icon-legacy(arrow-right-s-line, md);
       }
 
-      &--last {
+      #{ns(pagination)} &--last {
         @include icon-legacy(arrow-right-s-last-line, md);
       }
     }

--- a/src/component/quote/style/_legacy.scss
+++ b/src/component/quote/style/_legacy.scss
@@ -12,6 +12,10 @@
   #{ns(quote)} {
     @include icon-legacy(quote-line,lg);
 
+    &__source {
+      @include disable-list-style-legacy(true);
+    }
+
     blockquote {
       max-width: 100%;
     }

--- a/src/component/range/style/_legacy.scss
+++ b/src/component/range/style/_legacy.scss
@@ -11,7 +11,7 @@
 @include legacy.is(ie11) {
   #{selector.ns-group(range)} {
     output {
-      min-width: spacing.space(12v);
+      min-width: spacing.space(4v);
     }
 
     input[type=range] {
@@ -27,8 +27,15 @@
     }
 
     &#{selector.ns-attr(js-range)} {
+      #{selector.ns(label)} {
+        &::before,
+        &::after {
+          top: calc(100% + #{spacing.space(12v)});
+        }
+      }
+
       input[type=range] {
-        @include margin-bottom(1v);
+        @include margin-bottom(4v);
 
         @include selector.range-ms-fill-lower {
           @include height(1v);
@@ -62,6 +69,13 @@
 
     &--sm {
       &#{selector.ns-attr(js-range)} {
+        #{selector.ns(label)} {
+          &::before,
+          &::after {
+            top: calc(100% + #{spacing.space(10v)});
+          }
+        }
+
         input[type=range] {
           @include selector.range-ms-track {
             @include height(0.5v);

--- a/src/component/segmented/style/_legacy.scss
+++ b/src/component/segmented/style/_legacy.scss
@@ -27,7 +27,12 @@
     input + label {
       @include icon-size-legacy(sm, before) {
         vertical-align: -2px;
-        outline-width: 0;
+      }
+    }
+
+    input:focus + label {
+      @include before {
+        outline: none;
       }
     }
   }

--- a/src/component/tag/style/_legacy.scss
+++ b/src/component/tag/style/_legacy.scss
@@ -10,6 +10,7 @@
 @include legacy.is(ie11) {
   #{ns(tag)} {
     @include icon-legacy(null, sm);
+    text-decoration: none;
 
     #{ns(tag)}--sm {
       @include icon-legacy(null, xs, before);

--- a/src/component/tag/style/_scheme.scss
+++ b/src/component/tag/style/_scheme.scss
@@ -22,7 +22,7 @@
     }
   }
 
-  a,
+  a[href],
   button,
   input[type=button] {
     &#{ns(tag)} {

--- a/src/core/style/action/legacy/_link.scss
+++ b/src/core/style/action/legacy/_link.scss
@@ -4,20 +4,12 @@
 ////
 
 @use 'module/legacy';
+@use 'module/spacing';
 
 @include legacy.is(ie11) {
-  [href],
-  #{ns(reset-link)} {
-    &[href],
-    [href] {
-      text-decoration: underline;
-    }
-  }
-
   #{ns(raw-link)} {
     &[href],
     [href] {
-      text-decoration: none;
       @include after(none);
     }
   }
@@ -25,6 +17,7 @@
   [target="_blank"] {
     @include icon-legacy(external-link-line, sm, after) {
       content: "";
+      vertical-align: sub;
     }
   }
 }

--- a/src/core/style/typography/_legacy.scss
+++ b/src/core/style/typography/_legacy.scss
@@ -16,4 +16,8 @@
   h6 {
     @include margin(0 0 6v);
   }
+
+  p {
+    @include margin(0 0 4v);
+  }
 }


### PR DESCRIPTION
- Retrait du soulignement sur les bouton et tags en `a` sur IE
- Retrait de la marge top des paragraphes `p` sur IE
- Changement du placement du '+' de franceConnect+
- Correction du ratio d'image sur les cartes de téléchargement sur IE
- Réglage de l'alignement de l'icône des liens en target blank sur IE
- Correction de l'alignement de la case des cases à cocher sur IE
- Correction des min/max/valeur du curseur sur IE
- Retrait du focus autour de l'icône des controles segmentés sur IE
- Correction de la hauteur du composant fil d'arianne sur IE
- Ajout des modifiers de bouton pour les accès rapide du header sur IE
- Correction des icones prev/next de la pagination sur IE
- Correction des couleurs du tag désactivé sur IE
- Retrait du soulignement dans le reset des liens `a`