### PR TITLE
🐛 fix(header): augmente le z-index du header [DS-3661]

### DIFF
--- a/module/elevation/variable/_z-indexes.scss
+++ b/module/elevation/variable/_z-indexes.scss
@@ -1,5 +1,6 @@
 $values: (
   raised: 500,
+  raised-over: 750,
   overlap: 1000,
   overlap-over: 1250,
   overlap-above: 1500,

--- a/src/component/header/style/_scheme.scss
+++ b/src/component/header/style/_scheme.scss
@@ -10,7 +10,7 @@
 @mixin _header-scheme($legacy: false) {
   #{ns(header)} {
     &__brand {
-      @include elevation.elevate(raised, (legacy: $legacy));
+      @include elevation.elevate(raised-over, (legacy: $legacy));
     }
 
     &__service {
@@ -19,7 +19,7 @@
     }
 
     @include media-query.respond-from(lg) {
-      @include elevation.elevate(raised, (legacy: $legacy));
+      @include elevation.elevate(raised-over, (legacy: $legacy));
 
       &__brand {
         @include elevation.drop((legacy:$legacy));


### PR DESCRIPTION
- ajout d'un niveau d'élévation `raised-over`
- le header passe en z-index `raised-over`