### PR TITLE
🩹 fix(style): make media comments not important

### DIFF
--- a/module/shame/media-query/mixin/_order.scss
+++ b/module/shame/media-query/mixin/_order.scss
@@ -5,7 +5,7 @@
   @each $bp, $limits in breakpoints.$values {
     @if $bp != xs {
       @include media-query.respond-from($bp) {
-        /*! media #{$bp} */
+        /* media #{$bp} */
       }
     }
   }


### PR DESCRIPTION
Bonjour, 
Je propose une petite participation pour fermer l'issue https://github.com/GouvernementFR/dsfr/issues/839 concernant les fichier min qui contiennent énormément de commentaires.

Je propose un retrait de tous les commentaires "/*! media sm */" des fichiers css minifiés en passant le commentaire en non important.
Peut-être que ce n'est pas la bonne manière de procéder, dans ce cas serait la raison pour que les commentaires de media query soient en important ?

--- 
TLDR
Remove all "/*! media sm */" from minified css files by modifying the comment so that it is not important.
Fix https://github.com/GouvernementFR/dsfr/issues/839

---
### Certificat de garantie d’origine du développeur
En contribuant à ce projet :

(a) je certifie être le seul développeur de ma contribution et/ou avoir le droit, sans restriction ni réserve, de soumettre ma contribution au Système de Design de l’Etat ;

(b) je certifie que ma contribution ne s’appuie pas sur des travaux antérieurs qui pourraient en restreindre l’usage dans le cadre du Système de Design de l’Etat ;

(c) je garantis la jouissance paisible de ma contribution, dans le cadre du Système de Design de l’Etat ;

(d) Je reconnais et j'accepte que ma contribution fasse l’objet d’un usage public dans le cadre du Système de Design de l’Etat et que les droits d’exploitation y afférents soient selon le contexte (i) cédés à l’État ou (ii) soumis aux dispositions de la licence open source en vigueur pour les Composants de la Plateforme du Système de Design de l’État.

Signature : Arthaud Proust