### PR TITLE
✨ feat(alert): ajoute un example de taille md avec description seule [DS-3685, DS-3688]

### DIFF
--- a/src/component/alert/example/index.ejs
+++ b/src/component/alert/example/index.ejs
@@ -14,6 +14,8 @@ const sample = getSample(include);
 
 <%- sample('Alerte attention', './sample/alert-default', {alert: {type: "warning", title: "Attention"}}, true); %>
 
+<%- sample('Alerte avec description seule', './sample/alert-default', {alert: {title:false, text: "Information : titre de l'information"}}, true); %>
+
 <%- sample('Alerte avec bouton fermer', './sample/alert-dismissable', {alert: {type: "info", title: "Information Covid"}}, true); %>
 
 <%- sample('Alerte taille SM', './sample/alert-default', {alert: {title:false, size: "sm", type: "info", text: "Information : titre de l'information"}}, true); %>

--- a/src/component/alert/example/index.ejs
+++ b/src/component/alert/example/index.ejs
@@ -14,11 +14,13 @@ const sample = getSample(include);
 
 <%- sample('Alerte attention', './sample/alert-default', {alert: {type: "warning", title: "Attention"}}, true); %>
 
-<%- sample('Alerte avec description seule', './sample/alert-default', {alert: {title:false, text: "Information : titre de l'information"}}, true); %>
+<%- sample('Alerte sans titre', './sample/alert-default', {alert: {type: "info", title:false, text: "Information : titre de l'information"}}, true); %>
 
 <%- sample('Alerte avec bouton fermer', './sample/alert-dismissable', {alert: {type: "info", title: "Information Covid"}}, true); %>
 
-<%- sample('Alerte taille SM', './sample/alert-default', {alert: {title:false, size: "sm", type: "info", text: "Information : titre de l'information"}}, true); %>
+<%- sample('Alerte taille SM', './sample/alert-default', {alert: {size: "sm", type: "info"}}, true); %>
+
+<%- sample('Alerte taille SM sans titre', './sample/alert-default', {alert: {title:false, size: "sm", type: "info", text: "Information : titre de l'information"}}, true); %>
 
 <%- sample('Alerte taille SM refermable', './sample/alert-dismissable', {alert: {title:false, size: "sm", type: "info", text: "Information : cliquer sur la croix pour fermer l'alerte"}}, true); %>
 


### PR DESCRIPTION
- Ajout d’exemples d’alerte MD sans titre, et d’alerte SM avec titre