### PR TITLE
✨ feat(header): retire aria attribut haspopup du burger menu en mobile [DS-3679]

### DIFF
--- a/src/analytics/example/spa/agnostic/index.ejs
+++ b/src/analytics/example/spa/agnostic/index.ejs
@@ -23,7 +23,7 @@
                 Rechercher
               </button>
               <button class="<%= prefix %>-btn--menu <%= prefix %>-btn" data-<%= prefix %>-opened="false"
-                aria-controls="modal-124" aria-haspopup="menu" id="button-125" title="Menu">
+                aria-controls="modal-124" id="button-125" title="Menu">
                 Menu
               </button>
             </div>

--- a/src/analytics/example/spa/angular/_index.ejs
+++ b/src/analytics/example/spa/angular/_index.ejs
@@ -34,7 +34,7 @@ app.config(function($routeProvider) {
                             <button class="fr-btn--search fr-btn" data-fr-opened="false" aria-controls="modal-122" id="button-123" title="Rechercher" >
                                 Rechercher
                             </button>
-                            <button class="fr-btn--menu fr-btn" data-fr-opened="false" aria-controls="modal-124" aria-haspopup="menu" id="button-125" title="Menu">
+                            <button class="fr-btn--menu fr-btn" data-fr-opened="false" aria-controls="modal-124" id="button-125" title="Menu">
                                 Menu
                             </button>
                         </div>

--- a/src/analytics/example/spa/react/index.ejs
+++ b/src/analytics/example/spa/react/index.ejs
@@ -34,7 +34,7 @@
                                 <button class="fr-btn--search fr-btn" data-fr-opened="false" aria-controls="modal-122" id="button-123" title="Rechercher" >
                                     Rechercher
                                 </button>
-                                <button class="fr-btn--menu fr-btn" data-fr-opened="false" aria-controls="modal-124" aria-haspopup="menu" id="button-125" title="Menu">
+                                <button class="fr-btn--menu fr-btn" data-fr-opened="false" aria-controls="modal-124" id="button-125" title="Menu">
                                     Menu
                                 </button>
                             </div>

--- a/src/analytics/example/spa/vue/index.ejs
+++ b/src/analytics/example/spa/vue/index.ejs
@@ -21,7 +21,7 @@
                                 <button class="<%= prefix %>-btn--search <%= prefix %>-btn" data-<%= prefix %>-opened="false" aria-controls="modal-122" id="button-123" title="Rechercher" data-<%= prefix %>-js-modal-button="true" >
                                     Rechercher
                                 </button>
-                                <button class="<%= prefix %>-btn--menu <%= prefix %>-btn" data-<%= prefix %>-opened="false" aria-controls="modal-124" aria-haspopup="menu" id="button-125" title="Menu">
+                                <button class="<%= prefix %>-btn--menu <%= prefix %>-btn" data-<%= prefix %>-opened="false" aria-controls="modal-124" id="button-125" title="Menu">
                                     Menu
                                 </button>
                             </div>

--- a/src/component/header/deprecated/template/ejs/navbar.ejs
+++ b/src/component/header/deprecated/template/ejs/navbar.ejs
@@ -45,8 +45,7 @@ let label;
       title: label,
       attributes: {
           ...attrs,
-          'aria-controls': navbar.menu.modalId,
-          'aria-haspopup': 'menu'
+          'aria-controls': navbar.menu.modalId
       },
       label: label,
       id: navbar.menu.id

--- a/src/component/header/template/ejs/navbar.ejs
+++ b/src/component/header/template/ejs/navbar.ejs
@@ -45,8 +45,7 @@ let label;
       title: label,
       attributes: {
           ...attrs,
-          'aria-controls': navbar.menu.modalId,
-          'aria-haspopup': 'menu'
+          'aria-controls': navbar.menu.modalId
       },
       label: label,
       id: navbar.menu.id


### PR DESCRIPTION
- Retrait de l'attribut `aria-haspopup` du bouton du burger menu en mobile