### PR TITLE
🐛 fix(header): corrige le focus sur le champ de recherche [DS-3499]

### DIFF
--- a/src/component/header/style/module/_modal.scss
+++ b/src/component/header/style/module/_modal.scss
@@ -37,6 +37,7 @@
       @include padding-top(4v);
       @include padding-bottom(18v);
       @include height(100%);
+      overflow: initial;
 
       @include respond-from(lg) {
         @include padding-y(0);

--- a/src/component/header/style/module/_modal.scss
+++ b/src/component/header/style/module/_modal.scss
@@ -37,7 +37,7 @@
       @include padding-top(4v);
       @include padding-bottom(18v);
       @include height(100%);
-      overflow: initial;
+      overflow: inherit;
 
       @include respond-from(lg) {
         @include padding-y(0);


### PR DESCRIPTION
- retire le `overflow: hidden;` sur le `fr-container` du champ de recherche