### PR TITLE
🐛 fix(accordion): corrige le focus dans un groupe [DS-3486]

### DIFF
--- a/src/component/accordion/style/_module.scss
+++ b/src/component/accordion/style/_module.scss
@@ -8,6 +8,8 @@
 #{ns(accordion)} {
   position: relative;
 
+
+
   @include before('', block) {
     @include absolute(0, 0, 0 , 0, 100%, 100%);
     pointer-events: none;
@@ -19,6 +21,10 @@
     display: block;
     font-size: unset;
     line-height: unset;
+  }
+
+  &:focus-within {
+    z-index: 1;
   }
 
   &__btn {


### PR DESCRIPTION
- corrige le focus croppé si on remonte sur un accordion précédent dans un groupe d'accordéon.