### PR TITLE
🐛 fix(select): corrige l'affichage du optgroup sur firefox windows [DS-3712]

### DIFF
--- a/src/core/style/reset/_module.scss
+++ b/src/core/style/reset/_module.scss
@@ -5,3 +5,4 @@
 
 @import 'module/box-sizing';
 @import 'module/body';
+@import 'module/select';

--- a/src/core/style/reset/module/_select.scss
+++ b/src/core/style/reset/module/_select.scss
@@ -1,0 +1,10 @@
+////
+/// Core Module : Reset select
+/// @group core
+////
+
+select {
+  optgroup {
+    font-style: normal;
+  }
+}


### PR DESCRIPTION
- ajoute un `font-style: normal` sur `optgroup` dans le reset