### PR TITLE
🐛 fix(footer, header, connect): retrait de l'icone target blank [DS-3715]

### DIFF
--- a/src/component/connect/style/module/_default.scss
+++ b/src/component/connect/style/module/_default.scss
@@ -23,6 +23,10 @@
     background-size: 2.5em 3em;
   }
 
+  @include target-blank(true) {
+    @include after(none);
+  }
+
   &__login,
   &__brand {
     line-height: 1;

--- a/src/component/connect/style/module/_default.scss
+++ b/src/component/connect/style/module/_default.scss
@@ -23,9 +23,7 @@
     background-size: 2.5em 3em;
   }
 
-  @include target-blank(true) {
-    @include after(none);
-  }
+  @include disable-external();
 
   &__login,
   &__brand {

--- a/src/component/footer/style/module/_default.scss
+++ b/src/component/footer/style/module/_default.scss
@@ -33,9 +33,7 @@
 
     &-link {
       @include display-flex;
-      @include target-blank(true) {
-        @include after(none);
-      }
+      @include disable-external();
     }
 
     /**

--- a/src/component/footer/style/module/_default.scss
+++ b/src/component/footer/style/module/_default.scss
@@ -33,6 +33,9 @@
 
     &-link {
       @include display-flex;
+      @include target-blank(true) {
+        @include after(none);
+      }
     }
 
     /**

--- a/src/component/footer/style/module/_partners.scss
+++ b/src/component/footer/style/module/_partners.scss
@@ -40,6 +40,12 @@
     }
   }
 
+  &__partners-link {
+    @include target-blank(true) {
+      @include after(none);
+    }
+  }
+
   /**
   * Container des logos partenaires (principaux et secondaires)
   */

--- a/src/component/footer/style/module/_partners.scss
+++ b/src/component/footer/style/module/_partners.scss
@@ -41,9 +41,7 @@
   }
 
   &__partners-link {
-    @include target-blank(true) {
-      @include after(none);
-    }
+    @include disable-external();
   }
 
   /**

--- a/src/component/header/style/module/_brand.scss
+++ b/src/component/header/style/module/_brand.scss
@@ -72,6 +72,10 @@
     @include margin-x(0, lg);
     @include size(100%);
 
+    @include target-blank {
+      @include after(none);
+    }
+
     @include media-query.respond-from(lg) {
       width: auto;
     }

--- a/src/component/header/style/module/_brand.scss
+++ b/src/component/header/style/module/_brand.scss
@@ -72,9 +72,7 @@
     @include margin-x(0, lg);
     @include size(100%);
 
-    @include target-blank {
-      @include after(none);
-    }
+    @include disable-external();
 
     @include media-query.respond-from(lg) {
       width: auto;


### PR DESCRIPTION
- retrait de l'icone "external link" sur les liens en target blank du :
  - lien des logos du footer
  - lien sur le nom de service du header
  - bouton franceConnect s'il est sous forme de lien