### PR TITLE
✨ feat(core): ajout d'un retour à la ligne des mots trop long [DS-3737]

### DIFF
--- a/src/core/style/reset/module/_body.scss
+++ b/src/core/style/reset/module/_body.scss
@@ -10,5 +10,6 @@
     @include margin(0);
     @include padding(0);
     @include text-style(md);
+    overflow-wrap: break-word;
   }
 }


### PR DESCRIPTION
- Ajout de la propriété `overflow-wrap: world-break` sur body permettant le passage à la ligne des mots plus grand que leur conteneur.