### PR TITLE
🐛 fix(tag): corrige le hover des tags cliquables [DS-3724]

### DIFF
--- a/src/component/tag/style/_scheme.scss
+++ b/src/component/tag/style/_scheme.scss
@@ -22,7 +22,7 @@
     }
   }
 
-  a[href],
+  a,
   button,
   input[type=button] {
     &#{ns(tag)} {


### PR DESCRIPTION
- Le hover des tags cliquables avait disparu