### PR TITLE
✨ feat(doc): ajout d'infos sur la configuration dans la doc analytics [DS-3741]

### DIFF
--- a/src/analytics/doc/analytics/installation/configuration.md
+++ b/src/analytics/doc/analytics/installation/configuration.md
@@ -25,7 +25,5 @@ La configuration doit être placée **avant** les fichiers `patch.module.js`, `d
 </script>
 ```
 
-Utiliser le DSFR mode verbose permet d’afficher dans la console le résultat de la fonction collect(), montrant les
-informations envoyées à Eulerian.
-Si le mode production est activé dans la config, ou que le mode verbose est désactivé, les logs n'apparaissent pas dans la console.
-Il est alors possible de surcharger la configuration via des paramètres dans l'url : `?production=false&verbose=true`
+Les résultats de la fonction collect(), montrant les informations envoyées à Eulerian, sont affichés dans la console.
+En mode production, les logs n'apparaissent pas dans la console. Il est alors possible de surcharger la configuration via le paramètre dans l'url : `?production=false`

--- a/src/analytics/doc/analytics/installation/configuration.md
+++ b/src/analytics/doc/analytics/installation/configuration.md
@@ -27,3 +27,5 @@ La configuration doit être placée **avant** les fichiers `patch.module.js`, `d
 
 Utiliser le DSFR mode verbose permet d’afficher dans la console le résultat de la fonction collect(), montrant les
 informations envoyées à Eulerian.
+Si le mode production est activé dans la config, ou que le mode verbose est désactivé, les logs n'apparaissent pas dans la console.
+Il est alors possible de surcharger la configuration via des paramètres dans l'url : `?production=false&verbose=true`


### PR DESCRIPTION
- Ajoute dans la doc de configuration des analytics, la possibilité de surcharger la configuration du mode production via le paramètre dans l'url : `?production=false`