### PR TITLE
🐛 fix(header): correctif erreur itérable null [DS-3747]

### DIFF
--- a/src/component/header/script/header/header-links.js
+++ b/src/component/header/script/header/header-links.js
@@ -15,12 +15,12 @@ class HeaderLinks extends api.core.Instance {
     const toolsHtml = this.toolsLinks.innerHTML.replace(/  +/g, ' ');
     const menuHtml = this.menuLinks.innerHTML.replace(/  +/g, ' ');
     // Pour éviter de dupliquer des id, on ajoute un suffixe aux id et aria-controls duppliqués.
-    let toolsHtmlIdList = toolsHtml.match(/id="(.*?)"/gm);
-    if (toolsHtmlIdList) {
-      // on a besoin d'échapper les backslash dans la chaine de caractère
-      // eslint-disable-next-line no-useless-escape
-      toolsHtmlIdList = toolsHtmlIdList.map(element => element.replace('id=\"', '').replace('\"', ''));
-    }
+    let toolsHtmlIdList = toolsHtml.match(/id="(.*?)"/gm) || [];
+
+    // on a besoin d'échapper les backslash dans la chaine de caractère
+    // eslint-disable-next-line no-useless-escape
+    toolsHtmlIdList = toolsHtmlIdList.map(element => element.replace('id=\"', '').replace('\"', ''));
+
     const toolsHtmlAriaControlList = toolsHtml.match(/aria-controls="(.*?)"/gm);
     let toolsHtmlDuplicateId = toolsHtml.replace(/id="(.*?)"/gm, 'id="$1' + copySuffix + '"');
     if (toolsHtmlAriaControlList) {


### PR DESCRIPTION
- la valeur null renvoyée par la fonction match est remplacée par un array vide pour permettre son itération
- Corrige #890 
