### PR TITLE
🐛 fix(analytics): Erreur sur IE selecteur translate [DS-3749]

### DIFF
--- a/src/analytics/script/integration/component/translate/translate-selector.js
+++ b/src/analytics/script/integration/component/translate/translate-selector.js
@@ -5,6 +5,6 @@ const COLLAPSE = api.internals.ns.selector('collapse');
 
 export const TranslateSelector = {
   BUTTON: `${TRANSLATE}__btn`,
-  COLLAPSE: `${TRANSLATE} > ${COLLAPSE}, ${TRANSLATE} > *:not(${TRANSLATE}):not(${COLLAPSE}) > ${COLLAPSE}, ${TRANSLATE} > *:not(${TRANSLATE}, ${COLLAPSE}) > *:not(${TRANSLATE}, ${COLLAPSE}) > ${COLLAPSE}`,
+  COLLAPSE: `${TRANSLATE} > ${COLLAPSE}, ${TRANSLATE} > *:not(${TRANSLATE}):not(${COLLAPSE}) > ${COLLAPSE}, ${TRANSLATE} > *:not(${TRANSLATE}):not(${COLLAPSE}) > *:not(${TRANSLATE}):not(${COLLAPSE}) > ${COLLAPSE}`,
   COLLAPSE_LEGACY: `${TRANSLATE} ${COLLAPSE}`
 };


### PR DESCRIPTION
- modifie le selecteur du translate pour utiliser 2 `:not()` à la suite au lieu d'un `not(1, 2)`