### PR TITLE
Discussion sur attributs `title` - remplacement par `aria-label`

### DIFF
--- a/src/analytics/example/spa/agnostic/index.ejs
+++ b/src/analytics/example/spa/agnostic/index.ejs
@@ -30,7 +30,7 @@
           </div>
           <div class="<%= prefix %>-header__service">
             <a href="/"
-              title="Accueil - [À MODIFIER - Nom du site / service] - [À MODIFIER - texte alternatif de l’image : nom de l'opérateur ou du site serviciel] - République Française">
+              aria-label="Accueil - [À MODIFIER - Nom du site / service] - [À MODIFIER - texte alternatif de l’image : nom de l'opérateur ou du site serviciel] - République Française">
               <p class="<%= prefix %>-header__service-title">
                 Nom du site / service
               </p>

--- a/src/analytics/example/spa/agnostic/index.ejs
+++ b/src/analytics/example/spa/agnostic/index.ejs
@@ -18,12 +18,12 @@
             </div>
             <div class="<%= prefix %>-header__navbar">
               <button class="<%= prefix %>-btn--search <%= prefix %>-btn" data-<%= prefix %>-opened="false"
-                aria-controls="modal-122" id="button-123" title="Rechercher"
+                aria-controls="modal-122" id="button-123"
                 data-<%= prefix %>-js-modal-button="true">
                 Rechercher
               </button>
               <button class="<%= prefix %>-btn--menu <%= prefix %>-btn" data-<%= prefix %>-opened="false"
-                aria-controls="modal-124" id="button-125" title="Menu">
+                aria-controls="modal-124" id="button-125">
                 Menu
               </button>
             </div>
@@ -48,8 +48,7 @@
           </div>
           <div class="<%= prefix %>-header__search <%= prefix %>-modal" id="modal-122">
             <div class="<%= prefix %>-container <%= prefix %>-container-lg--fluid">
-              <button class="<%= prefix %>-btn--close <%= prefix %>-btn" aria-controls="modal-122" id="button-130"
-                title="Fermer">
+              <button class="<%= prefix %>-btn--close <%= prefix %>-btn" aria-controls="modal-122" id="button-130">
                 Fermer
               </button>
               <div class="<%= prefix %>-search-bar" id="search-121" role="search">
@@ -60,7 +59,7 @@
                   placeholder="Rechercher" id="search-121-input" type="search">
                 <div class="<%= prefix %>-messages-group" id="search-121-input-messages" aria-live="polite">
                 </div>
-                <button class="<%= prefix %>-btn" id="search-btn-132" title="Rechercher">
+                <button class="<%= prefix %>-btn" id="search-btn-132">
                   Rechercher
                 </button>
               </div>
@@ -72,8 +71,7 @@
   </div>
   <div class="<%= prefix %>-header__menu <%= prefix %>-modal" id="modal-124">
     <div class="<%= prefix %>-container">
-      <button class="<%= prefix %>-btn--close <%= prefix %>-btn" aria-controls="modal-124" id="button-133"
-        title="Fermer">
+      <button class="<%= prefix %>-btn--close <%= prefix %>-btn" aria-controls="modal-124" id="button-133">
         Fermer
       </button>
       <div class="<%= prefix %>-header__menu-links">

--- a/src/analytics/example/spa/angular/_index.ejs
+++ b/src/analytics/example/spa/angular/_index.ejs
@@ -31,10 +31,10 @@ app.config(function($routeProvider) {
                             </p>
                         </div>
                         <div class="fr-header__navbar">
-                            <button class="fr-btn--search fr-btn" data-fr-opened="false" aria-controls="modal-122" id="button-123" title="Rechercher" >
+                            <button class="fr-btn--search fr-btn" data-fr-opened="false" aria-controls="modal-122" id="button-123">
                                 Rechercher
                             </button>
-                            <button class="fr-btn--menu fr-btn" data-fr-opened="false" aria-controls="modal-124" id="button-125" title="Menu">
+                            <button class="fr-btn--menu fr-btn" data-fr-opened="false" aria-controls="modal-124" id="button-125">
                                 Menu
                             </button>
                         </div>
@@ -58,7 +58,7 @@ app.config(function($routeProvider) {
                     </div>
                     <div class="fr-header__search fr-modal" id="modal-122">
                         <div class="fr-container fr-container-lg--fluid">
-                            <button class="fr-btn--close fr-btn" aria-controls="modal-122" id="button-130" title="Fermer">
+                            <button class="fr-btn--close fr-btn" aria-controls="modal-122" id="button-130">
                                 Fermer
                             </button>
                             <div class="fr-search-bar" id="search-121" role="search">
@@ -68,7 +68,7 @@ app.config(function($routeProvider) {
                                 <input class="fr-input" aria-describedby="search-121-input-messages" placeholder="Rechercher" id="search-121-input" type="search"/>
                                 <div class="fr-messages-group" id="search-121-input-messages" aria-live="polite">
                                 </div>
-                                <button class="fr-btn" id="search-btn-132" title="Rechercher">
+                                <button class="fr-btn" id="search-btn-132">
                                     Rechercher
                                 </button>
                             </div>
@@ -80,7 +80,7 @@ app.config(function($routeProvider) {
     </div>
     <div class="fr-header__menu fr-modal" id="modal-124">
       <div class="fr-container">
-        <button class="fr-btn--close fr-btn" aria-controls="modal-2414" id="button-2419" title="Fermer">
+        <button class="fr-btn--close fr-btn" aria-controls="modal-2414" id="button-2419">
             Fermer
         </button>
         <div class="fr-header__menu-links">

--- a/src/analytics/example/spa/angular/_index.ejs
+++ b/src/analytics/example/spa/angular/_index.ejs
@@ -40,7 +40,7 @@ app.config(function($routeProvider) {
                         </div>
                     </div>
                     <div class="fr-header__service">
-                        <a href="/" title="Accueil - [À MODIFIER - Nom du site / service] - [À MODIFIER - texte alternatif de l’image : nom de l'opérateur ou du site serviciel] - République Française">
+                        <a href="/" aria-label="Accueil - [À MODIFIER - Nom du site / service] - [À MODIFIER - texte alternatif de l’image : nom de l'opérateur ou du site serviciel] - République Française">
                             <p class="fr-header__service-title">
                                 Nom du site / service
                             </p>

--- a/src/analytics/example/spa/react/index.ejs
+++ b/src/analytics/example/spa/react/index.ejs
@@ -40,7 +40,7 @@
                             </div>
                         </div>
                         <div class="fr-header__service">
-                            <a href="/" title="Accueil - [À MODIFIER - Nom du site / service] - [À MODIFIER - texte alternatif de l’image : nom de l'opérateur ou du site serviciel] - République Française">
+                            <a href="/" aria-label="Accueil - [À MODIFIER - Nom du site / service] - [À MODIFIER - texte alternatif de l’image : nom de l'opérateur ou du site serviciel] - République Française">
                                 <p class="fr-header__service-title">
                                     Nom du site / service
                                 </p>

--- a/src/analytics/example/spa/react/index.ejs
+++ b/src/analytics/example/spa/react/index.ejs
@@ -31,10 +31,10 @@
                                 </p>
                             </div>
                             <div class="fr-header__navbar">
-                                <button class="fr-btn--search fr-btn" data-fr-opened="false" aria-controls="modal-122" id="button-123" title="Rechercher" >
+                                <button class="fr-btn--search fr-btn" data-fr-opened="false" aria-controls="modal-122" id="button-123">
                                     Rechercher
                                 </button>
-                                <button class="fr-btn--menu fr-btn" data-fr-opened="false" aria-controls="modal-124" id="button-125" title="Menu">
+                                <button class="fr-btn--menu fr-btn" data-fr-opened="false" aria-controls="modal-124" id="button-125">
                                     Menu
                                 </button>
                             </div>
@@ -58,7 +58,7 @@
                         </div>
                         <div class="fr-header__search fr-modal" id="modal-122">
                             <div class="fr-container fr-container-lg--fluid">
-                                <button class="fr-btn--close fr-btn" aria-controls="modal-122" id="button-130" title="Fermer">
+                                <button class="fr-btn--close fr-btn" aria-controls="modal-122" id="button-130" >
                                     Fermer
                                 </button>
                                 <div class="fr-search-bar" id="search-121" role="search">
@@ -68,7 +68,7 @@
                                     <input class="fr-input" aria-describedby="search-121-input-messages" placeholder="Rechercher" id="search-121-input" type="search"/>
                                     <div class="fr-messages-group" id="search-121-input-messages" aria-live="polite">
                                     </div>
-                                    <button class="fr-btn" id="search-btn-132" title="Rechercher">
+                                    <button class="fr-btn" id="search-btn-132" >
                                         Rechercher
                                     </button>
                                 </div>
@@ -80,7 +80,7 @@
         </div>
         <div class="fr-header__menu fr-modal" id="modal-124">
           <div class="fr-container">
-            <button class="fr-btn--close fr-btn" aria-controls="modal-2414" id="button-2419" title="Fermer">
+            <button class="fr-btn--close fr-btn" aria-controls="modal-2414" id="button-2419" >
                 Fermer
             </button>
             <div class="fr-header__menu-links">

--- a/src/analytics/example/spa/vue/index.ejs
+++ b/src/analytics/example/spa/vue/index.ejs
@@ -27,7 +27,7 @@
                             </div>
                         </div>
                         <div class="<%= prefix %>-header__service">
-                            <a href="/" title="Accueil - [À MODIFIER - Nom du site / service] - [À MODIFIER - texte alternatif de l’image : nom de l'opérateur ou du site serviciel] - République Française">
+                            <a href="/" aria-label="Accueil - [À MODIFIER - Nom du site / service] - [À MODIFIER - texte alternatif de l’image : nom de l'opérateur ou du site serviciel] - République Française">
                                 <p class="<%= prefix %>-header__service-title">
                                     Nom du site / service
                                 </p>

--- a/src/analytics/example/spa/vue/index.ejs
+++ b/src/analytics/example/spa/vue/index.ejs
@@ -18,10 +18,10 @@
                                 <!-- L’alternative de l’image (attribut alt) doit impérativement être renseignée et reprendre le texte visible dans l’image -->
                             </div>
                             <div class="<%= prefix %>-header__navbar">
-                                <button class="<%= prefix %>-btn--search <%= prefix %>-btn" data-<%= prefix %>-opened="false" aria-controls="modal-122" id="button-123" title="Rechercher" data-<%= prefix %>-js-modal-button="true" >
+                                <button class="<%= prefix %>-btn--search <%= prefix %>-btn" data-<%= prefix %>-opened="false" aria-controls="modal-122" id="button-123" data-<%= prefix %>-js-modal-button="true">
                                     Rechercher
                                 </button>
-                                <button class="<%= prefix %>-btn--menu <%= prefix %>-btn" data-<%= prefix %>-opened="false" aria-controls="modal-124" id="button-125" title="Menu">
+                                <button class="<%= prefix %>-btn--menu <%= prefix %>-btn" data-<%= prefix %>-opened="false" aria-controls="modal-124" id="button-125">
                                     Menu
                                 </button>
                             </div>
@@ -45,7 +45,7 @@
                         </div>
                         <div class="<%= prefix %>-header__search <%= prefix %>-modal" id="modal-122">
                             <div class="<%= prefix %>-container <%= prefix %>-container-lg--fluid">
-                                <button class="<%= prefix %>-btn--close <%= prefix %>-btn" aria-controls="modal-122" id="button-130" title="Fermer">
+                                <button class="<%= prefix %>-btn--close <%= prefix %>-btn" aria-controls="modal-122" id="button-130" >
                                     Fermer
                                 </button>
                                 <div class="<%= prefix %>-search-bar" id="search-121" role="search">
@@ -55,7 +55,7 @@
                                     <input class="<%= prefix %>-input" aria-describedby="search-121-input-messages" placeholder="Rechercher" id="search-121-input" type="search">
                                     <div class="<%= prefix %>-messages-group" id="search-121-input-messages" aria-live="polite">
                                     </div>
-                                    <button class="<%= prefix %>-btn" id="search-btn-132" title="Rechercher">
+                                    <button class="<%= prefix %>-btn" id="search-btn-132" >
                                         Rechercher
                                     </button>
                                 </div>
@@ -67,7 +67,7 @@
         </div>
         <div class="<%= prefix %>-header__menu <%= prefix %>-modal" id="modal-124">
             <div class="<%= prefix %>-container">
-                <button class="<%= prefix %>-btn--close <%= prefix %>-btn" aria-controls="modal-124" id="button-133" title="Fermer">
+                <button class="<%= prefix %>-btn--close <%= prefix %>-btn" aria-controls="modal-124" id="button-133" >
                     Fermer
                 </button>
                 <div class="<%= prefix %>-header__menu-links">

--- a/src/component/footer/template/ejs/brand.ejs
+++ b/src/component/footer/template/ejs/brand.ejs
@@ -18,13 +18,13 @@ let link = brand.link || brandData('footer', brand.logo !== undefined, false, br
 
 <div class="<%= prefix %>-footer__brand <%= prefix %>-enlarge-link" >
 	<% if (link.position !== 'operator') { %>
-		<a id="footer-operator" href="<%= link.href %>" title="<%= link.title %>">
+		<a id="footer-operator" href="<%= link.href %>" aria-label="<%= link.title %>">
 	<% } %>
 			<%- include( '../../../logo/template/ejs/logo', {logo: brand.logo}); %>
 	<% if (link.position !== 'operator') { %>
 		</a>
 	<% } else { %>
-		<a id="footer-brand" class="<%= prefix %>-footer__brand-link" href="<%= link.href %>" title="<%= link.title %>">
+		<a id="footer-brand" class="<%= prefix %>-footer__brand-link" href="<%= link.href %>" aria-label="<%= link.title %>">
 			<%- include('../../../../core/template/ejs/media/img.ejs', {media: { ...brand.operator, classes: [prefix + '-footer__logo']}}); %>
 		</a>
 	<% } %>

--- a/src/component/header/deprecated/template/ejs/brand.ejs
+++ b/src/component/header/deprecated/template/ejs/brand.ejs
@@ -37,7 +37,7 @@ let brand = locals.brand || {};
       title += contentPlaceholder(logoPlaceholder);
   }
 
-  const link = `<a href="/" title="${title}" >`;
+  const link = `<a href="/" aria-label="${title}" >`;
   %>
 
   <div class="<%= prefix %>-header__brand-top" >

--- a/src/component/header/template/ejs/brand.ejs
+++ b/src/component/header/template/ejs/brand.ejs
@@ -21,7 +21,7 @@ let brand = locals.brand || {};
   <%
   const linkInfos = brand.link || brandData('header', header.logo !== undefined, brand.service !== undefined && brand.service.title !== undefined, brand.operator !== undefined);
 
-  const link = `<a href="${linkInfos.href}" title="${linkInfos.title}" >`;
+  const link = `<a href="${linkInfos.href}" aria-label="${linkInfos.title}" >`;
   %>
 
   <div class="<%= prefix %>-header__brand-top" >

--- a/src/core/example/link/link-raw/index.ejs
+++ b/src/core/example/link/link-raw/index.ejs
@@ -5,11 +5,11 @@
 <div class="<%= prefix %>-container" >
   <%- section('Liens bruts', null, 0) %>
   
-  <%- sample({ title: 'Lien brut', subtitle: rawSubtitle }, '../../reset/sample/paragraph', { paragraph: {insert: `<a class="${prefix}-raw-link" title="titre lien" href="../">lien interne</a>`} }, true); %>
+  <%- sample({ title: 'Lien brut', subtitle: rawSubtitle }, '../../reset/sample/paragraph', { paragraph: {insert: `<a class="${prefix}-raw-link" href="../">lien interne</a>`} }, true); %>
 
   <%- sample({ title: 'Lien externe brut', subtitle: rawSubtitle }, '../../reset/sample/paragraph', { paragraph: {insert: `<a class="${prefix}-raw-link" href="https://www.systeme-de-design.gouv.fr/" ${includeAttrs(targetBlankData())}>lien externe - nouvelle fenêtre</a>`} }, true); %>
 
-  <%- sample({ title: 'Exemple sur plusieurs blocs de texte', subtitle: rawWrapperSubtitle}, '../sample/blocks', { classes: [`${prefix}-raw-link`], paragraphes: [ {insert: `<a title="titre lien" href="../">lien interne</a>`}, {insert: `<a href="https://www.systeme-de-design.gouv.fr/" ${includeAttrs(targetBlankData())}>lien externe - nouvelle fenêtre</a>`}] }, true); %>
+  <%- sample({ title: 'Exemple sur plusieurs blocs de texte', subtitle: rawWrapperSubtitle}, '../sample/blocks', { classes: [`${prefix}-raw-link`], paragraphes: [ {insert: `<a href="../">lien interne</a>`}, {insert: `<a href="https://www.systeme-de-design.gouv.fr/" ${includeAttrs(targetBlankData())}>lien externe - nouvelle fenêtre</a>`}] }, true); %>
 
   <%- sample({ title: 'Exemple d\'utilisation avec une librairie externe', subtitle: rawWrapperSubtitle }, '../sample/library', { classes: [`${prefix}-raw-link`] }, true); %>
 </div>

--- a/src/core/example/link/link-reset/index.ejs
+++ b/src/core/example/link/link-reset/index.ejs
@@ -5,11 +5,11 @@
 <div class="<%= prefix %>-container" >
   <%- section('Liens réinitialisés', `Utilisation de la classe <code>${prefix}-reset-link</code> pour réinitialiser le style des liens.`, 0) %>
 
-  <%- sample({ title: 'Lien réinitialisé', subtitle: resetSubtitle }, '../../reset/sample/paragraph', { paragraph: {insert: `<a class="${prefix}-reset-link" title="titre lien" href="../">lien interne</a>`} }, true); %>
+  <%- sample({ title: 'Lien réinitialisé', subtitle: resetSubtitle }, '../../reset/sample/paragraph', { paragraph: {insert: `<a class="${prefix}-reset-link" href="../">lien interne</a>`} }, true); %>
 
   <%- sample({ title: 'Lien externe réinitialisé', subtitle: resetSubtitle }, '../../reset/sample/paragraph', { paragraph: {insert: `<a class="${prefix}-reset-link" href="https://www.systeme-de-design.gouv.fr/" ${includeAttrs(targetBlankData())}>lien externe - nouvelle fenêtre</a>`} }, true); %>
 
-  <%- sample({ title: 'Exemple sur plusieurs blocs de texte', subtitle: `Utilisation de la classe <code>${prefix}-reset-link</code> sur un wrapper pour réinitialiser le style des liens.`}, '../sample/blocks', { classes: [`${prefix}-reset-link`], paragraphes: [ {insert: `<a title="titre lien" href="../">lien interne</a>`}, {insert: `<a href="https://www.systeme-de-design.gouv.fr/" ${includeAttrs(targetBlankData())}>lien externe - nouvelle fenêtre</a>`}] }, true); %>
+  <%- sample({ title: 'Exemple sur plusieurs blocs de texte', subtitle: `Utilisation de la classe <code>${prefix}-reset-link</code> sur un wrapper pour réinitialiser le style des liens.`}, '../sample/blocks', { classes: [`${prefix}-reset-link`], paragraphes: [ {insert: `<a href="../">lien interne</a>`}, {insert: `<a href="https://www.systeme-de-design.gouv.fr/" ${includeAttrs(targetBlankData())}>lien externe - nouvelle fenêtre</a>`}] }, true); %>
 
   <%- sample({ title: 'Exemple d\'utilisation avec une librairie externe', subtitle: resetWrapperSubtitle }, '../sample/library', { classes: [`${prefix}-reset-link`] }, true); %>
 </div>

--- a/src/core/example/reset/index.ejs
+++ b/src/core/example/reset/index.ejs
@@ -22,7 +22,7 @@ let ol = {
 
 <%- sample('Test de titre de paragraphe :', './sample/headings', {}, true); %>
 
-<%- sample('Test de paragraphe et de lien interne :', './sample/paragraph', { paragraph: {insert: '<a title="titre lien interne" href="#" target="_self">lien interne</a>'} }, true); %>
+<%- sample('Test de paragraphe et de lien interne :', './sample/paragraph', { paragraph: {insert: '<a href="#" target="_self">lien interne</a>'} }, true); %>
 
 <%- sample('Test de paragraphe et de lien externe :', './sample/paragraph', { paragraph: {insert: `<a href="#" ${includeAttrs(targetBlankData())}>lien externe - nouvelle fenêtre</a>`} }, true); %>
 

--- a/tool/example/decorator.ejs
+++ b/tool/example/decorator.ejs
@@ -268,7 +268,7 @@ const targetBlankData = () => {
   const attr = {};
   attr.target = '_blank';
   attr.rel = 'noopener external';
-  attr.title = `${contentPlaceholder('Intitulé')} - ${getText('blank')}`;
+  attr['aria-label'] = `${contentPlaceholder('Intitulé')} - ${getText('blank')}`;
   return attr;
 }
 


### PR DESCRIPTION
Bonjour :)

Je viens ici avec une micro PR d'exemple (et une méga description :see_no_evil:) pour commencer une discussion sur les attributs `title` utilisés sur les éléments interactifs du DSFR.

À mes yeux ces attributs ne sont pas le mieux qu'on puisse faire pour deux raisons :

1. le support des lecteurs d'écran est peu fiable
2. l'intérêt pour les utilisateurs en général est très limité

Je m'explique !

## 1. L'attribut `title` et les lecteurs d'écrans

Quand on utilise un lecteur d'écran audio (VoiceOver, NVDA, Jaws et autres), l'attribut `title` n'est pas souvent le plus adapté.

Par exemple, sur les liens s'ouvrant dans une nouvelle fenêtre, le DSFR conseille d'écrire du HTML comme ceci :

```html
<a [...] target="_blank" title="legifrance.gouv.fr - nouvelle fenêtre">
    legifrance.gouv.fr
</a>
```

Ceci peut avoir plusieurs résultats différents suivant le lecteur d'écran, sa configuration utilisateur, ou son usage. Avec ce code, voici ce qui est peut être vocalisé :

- Lien _legifrance.gouv.fr_,
- Lien _legifrance.gouv.fr legifrance.gouv.fr nouvelle fenêtre_,
- Lien _legifrance.gouv.fr_ [pause nécessaire sur l'élément] Lien _legifrance.gouv.fr nouvelle fenêtre_,

Par exemple, avec NVDA ou JAWS, si je navigue pas à pas avec les flèches et que j'arrive sur un lien, le `title` n'est pas vocalisé. Il l'est en naviguant sur le lien via la touche Tabulation, ou en naviguant de lien en lien par exemple. On peut argumenter que cet usage n'est pas le principal (peut-être), mais on peut aussi argumenter de faire un truc supporté au mieux, plutôt que partiellement, pour répondre à tous les usages.

Avec VoiceOver, le `title` n'est pas vocalisé directement mais avec un temps d'attente sur le lien. Rien n'indique cependant avant d'attendre qu'une info supplémentaire est disponible.

Avec JAWS et NVDA, quand le `title` est vocalisé, il l'est directement après le contenu : le contenu est donc répété. Cependant si le `title` est strictement identique au contenu, alors il ne sera pas forcément [*] vocalisé.

_[*] je dis "pas forcément" car c'est le cas la plupart du temps dans mes tests, mais suivant le sens du vent et des planètes, des fois il répète quand même l'info. Oui, grosse étude scientifique fiable de mon côté effectivement…_

## 2. L'attribut `title` sans lecteur d'écran

Les attributs title dans le DSFR ne semblent pas utilisés qu'à des fins d'usages pour lecteurs d'écran. Notamment sur les boutons icone de recherche, menu, on double le contenu du bouton avec un title :

```html
<button [...] title="Menu">Menu</button>
```

On a relevé plus haut que dans ce cas précis de `title` strictement identique au contenu, le `title` ne pose pas forcément problème avec un lecteur d'écran. Cependant il n'est pas nécessaire pour le lecteur d'écran, car le contenu texte à l'intérieur de la balise suffit.

Je suppose donc que ceci est fait afin de donner un contexte supplémentaire aux utilisateurs de souris. C'est cet usage que je remets en question ici.

- la tooltip ne sert que pour les utilisateurs à la souris. Pas aux utilisateurs au clavier. Pas aux utilisateurs sur mobile/écran tactile,
- la tooltip ne s'affiche qu'après une relativement longue pause sur un élément, sans bouger sa souris ne serait-ce que d'un pixel,
- aucune info visuelle n'indique la présence de la tooltip à l'utilisateur. C'est un jeu de devinettes.

À mes yeux, tous ces éléments combinés font que, se reposer sur cette tooltip pour donner de l'info, n'est pas une solution satisfaisante.

Car la plupart des utilisateurs ne vont jamais en profiter. Soit parce qu'ils sont sur mobile. Soit parce qu'ils ne devineront pas qu'on peut attendre sur l'interface avec la souris, sans bouger d'un seul pixel (!), pour afficher de l'aide. S'ils ont conscience du fonctionnement des tooltip "title", c'est souvent qu'ils découvrent ça par hasard, ou parce que ce sont des utilisateurs plutôt avertis. Autrement dit : c'est très rare.

_Je vous donne une stat inutile pas du tout objective juste pour pousser mon argument : perso, j'ai jamais vu quelqu'un essayer d'afficher une tooltip `title` dans la vrai vie, sauf des développeurs qui savent que ça existe car c'est eux qui les codent :P_

Une autre façon de voir les choses est : si l'info supplémentaire donnée par le `title` était vraiment nécessaire, on aurait surement mis en place de quoi rendre cette info disponible aussi au clavier et sur mobile, non ?

## Réponse au point 1 pour les lecteurs d'écran : `aria-label`

À mes yeux, une meilleure façon de répondre au 1er problème serait d'utiliser l'attribut `aria-label` :

```html
<a [...] target="_blank" aria-label="legifrance.gouv.fr - nouvelle fenêtre">
    legifrance.gouv.fr
</a>
```

Cet attribut a un support lecteur d'écran bien plus stable et cohérent que `title`. Ici, tous les lecteurs d'écran, quelque soit leur config, quelque soit l'usage, vocaliseront :

Lien _legifrance.gouv.fr - nouvelle fenêtre_

Pas de risque que ce ne soit pas vocalisé. Pas de risque que ce soit vocalisé en différé après une attente sur l'élément. Pas de répétition déroutante du contenu du lien.

## Et la tooltip du point 2 ?

Je suis d'avis de simplement : ne plus se reposer sur la tooltip des title pour des infos considérées importantes pour tout le monde. Et proposer des changements d'UX au cas par cas si besoin :

- si on considère que le bouton de Menu n'est pas assez explicite en lui-même de par son icone + sa position dans la page : pourquoi pas avoir "Menu" affiché en texte pour tout le monde en plus de l'icone ? Cela rendrait explicite la chose pour 100% des gens, y compris les gens sur mobile.
- à minima, utiliser le composant Infobulle permettrait un support des utilisateurs au clavier et une meilleure découverte de la tooltip à la souris, avec un affichage immédiat, qui ne repose pas sur le fait de ne pas bouger la souris pour fonctionner. Cependant ça n'aide pas les utilisateurs sur mobile sans clavier/souris.

Bref vous l'avez compris, je ne suis pas convaincu par l'usage des tooltip en général pour donner de l'info importante, en particulier si cette tooltip est implémentée uniquement avec un attribut `title`.
___
Enlever ces `title` du DSFR c'est aussi décider de moins montrer cette pratique qui, on l'a vu, a un usage plutôt "sensible". Si je suis du genre à m'inspirer des bouts du DSFR pour coder mon app, à copier/coller des bouts de code ici et là, je peux facilement me mettre dans la tête que cet attribut `title` est une bonne pratique fiable, alors qu'en réalité, pas trop.

## Conclusion

J'ai créé deux pages de tests un peu isolés : [le DSFR actuel](http://files.manu.habite.la/dsfr-aria-labels/title.html) vs [une version avec aria-label](http://files.manu.habite.la/dsfr-aria-labels/aria-label.html) pour tester facilement avec lecteurs d'écrans.

Qu'en pensez-vous ? Si ça vous paraît intéressant, je serai ensuite ravi de continuer le travail sur cette PR pour peaufiner la documentation et autres choses nécessaires que je n'aurais pas vues.

Merci !
