### PR TITLE
🐛 fix(footer): title des liens obligatoires du footer [DS-3760, DS-3789]

### DIFF
--- a/src/component/footer/example/sample/footer.ejs
+++ b/src/component/footer/example/sample/footer.ejs
@@ -50,7 +50,7 @@ if (footer.bottom === true) data.bottom = {
     {label: 'Données personnelles', url: footer.href},
     {label: 'Gestion des cookies', url: footer.href}
   ],
-  copyright: `Sauf mention explicite de propriété intellectuelle détenue par des tiers, les contenus de ce site sont proposés sous <a href="https://github.com/etalab/licence-ouverte/blob/master/LO.md" ${includeAttrs(targetBlankData())}>licence etalab-2.0</a>`
+  copyright: `Sauf mention explicite de propriété intellectuelle détenue par des tiers, les contenus de ce site sont proposés sous <a href="https://github.com/etalab/licence-ouverte/blob/master/LO.md" ${includeAttrs(targetBlankData('Licence etalab'))}>licence etalab-2.0</a>`
 };
 %>
 

--- a/src/component/footer/example/sample/footer.ejs
+++ b/src/component/footer/example/sample/footer.ejs
@@ -14,9 +14,9 @@ if (footer.brand === true) {
 if (footer.content === true) data.content = {
   desc: lorem('', 240),
   links: [
-    {label: 'legifrance.gouv.fr'},
-    {label: 'gouvernement.fr'},
+    {label: 'info.gouv.fr'},
     {label: 'service-public.fr'},
+    {label: 'legifrance.gouv.fr'},
     {label: 'data.gouv.fr'}
   ]
 };

--- a/src/component/footer/template/ejs/content.ejs
+++ b/src/component/footer/template/ejs/content.ejs
@@ -19,7 +19,7 @@
       	attributes.id = uniqueId('footer__content-link');
 		%>
 		<li class="<%= prefix %>-footer__content-item">
-			<a <%- includeAttrs({...targetBlankData(), ...attributes}) %> class="<%= prefix %>-footer__content-link" href="https://<%= links[i].label %>"><%= links[i].label %></a>
+			<a <%- includeAttrs({...targetBlankData(links[i].label), ...attributes}) %> class="<%= prefix %>-footer__content-link" href="https://<%= links[i].label %>"><%= links[i].label %></a>
 		</li>
 		<% } %>
 	</ul>

--- a/tool/example/decorator.ejs
+++ b/tool/example/decorator.ejs
@@ -264,11 +264,11 @@ const errorData = (error) => {
 
 locals.errorData = errorData;
 
-const targetBlankData = () => {
+const targetBlankData = (title = contentPlaceholder('Intitulé')) => {
   const attr = {};
   attr.target = '_blank';
   attr.rel = 'noopener external';
-  attr.title = `${contentPlaceholder('Intitulé')} - ${getText('blank')}`;
+  attr.title = `${title} - ${getText('blank')}`;
   return attr;
 }
 


### PR DESCRIPTION
- remplace l'intitulé par défaut "[A modifier]" de l'attribut title par l'intitulé officiel sur les liens obligatoires du footer.
- **Change l'ordre des liens, et gouvernement.fr devient info.gouv.fr**