### PR TITLE
✨ feat(build): ajoute la config au premier build & precision readme [DS-3681]

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,11 @@ yarn add @gouvfr/dsfr
 
 Une fois terminé le dsfr sera alors installé dans le dossier ```node_modules/@gouvfr/dsfr/```.
 
-Pour visualiser les exemples, il est nécessaire de lancer un serveur local :
+Pour visualiser les exemples, il est nécessaire de lancer un serveur local. Pour cela, installer le package browser-sync, puis lancer le serveur dans le dossier du dsfr :
 
 ```
+npm install browser-sync
+cd node_modules/@gouvfr/dsfr/
 npm run serve
 ```
 
@@ -102,7 +104,7 @@ Consulter la [documentation des paramètres d’affichage](https://www.systeme-d
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="format-detection" content="telephone=no">
+    <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no">
 
     <meta name="theme-color" content="#000091"><!-- Défini la couleur de thème du navigateur (Safari/Android) -->
     <link rel="apple-touch-icon" href="favicon/apple-touch-icon.png"><!-- 180×180 -->
@@ -111,7 +113,7 @@ Consulter la [documentation des paramètres d’affichage](https://www.systeme-d
     <link rel="manifest" href="favicon/manifest.webmanifest" crossorigin="use-credentials">
     <!-- Modifier les chemins relatifs des favicons en fonction de la structure du projet -->
     <!-- Dans le fichier manifest.webmanifest aussi, modifier les chemins vers les images -->
-    
+
     <link rel="stylesheet" href="dsfr.min.css">
     <link rel="stylesheet" href="utility/utility.min.css">
 

--- a/package.json
+++ b/package.json
@@ -82,6 +82,9 @@
     "svgo": "^2.8.0",
     "yargs": "^17.7.1"
   },
+  "peerDependencies": {
+    "browser-sync": "^2.27.10"
+  },
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"

--- a/tool/build/build.js
+++ b/tool/build/build.js
@@ -12,11 +12,12 @@ const generateConfig = require('../generate/config');
 const clean = require('../utilities/clean');
 const { I18n } = require('../classes/i18n/i18n');
 const { Config } = require('../classes/config/config');
+const fs = require('fs');
 
 const build = async (settings) => {
   log(36, `build ${global.config.namespace} - version ${global.version}`);
   if (settings.clean) clean();
-  if (settings.clean || settings.config) {
+  if (settings.clean || settings.config || !fs.existsSync('.config/config.json')) {
     await generateConfig();
     copyImages();
     copyIcons();


### PR DESCRIPTION
- lors de l'execution de la commande `yarn build`, crée les fichiers de configuration s'ils n'existent pas
- ajout de browser-sync en tant que peerDependencies dans le package.json
- ajout de précision sur le lancement du serveur des pages d'exemple dans le README