### PR TITLE
🐛 fix(quote): ratio de l'image de citation [DS-3767]

### DIFF
--- a/src/component/quote/style/_module.scss
+++ b/src/component/quote/style/_module.scss
@@ -86,6 +86,7 @@
 
     img {
       @include size(100%, 100%);
+      object-fit: cover;
     }
 
     @include respond-from(md) {


### PR DESCRIPTION
- ajout de la propriété `object-fit: cover` sur l'image de citation pour conserver le ratio de l'image lorsqu'elle n'est pas carrée. 
- dans la mesure du possible, privilégiez un ratio d'image carré pour un meilleur support navigateur