### PR TITLE
fixes infinite loop in stepWidth computation of the range Component

### DIFF
--- a/src/component/range/script/range/range-model.js
+++ b/src/component/range/script/range/range-model.js
@@ -140,6 +140,7 @@ class RangeModelStep extends RangeModel {
     super._update();
     const steps = this._rangeWidth / this._step;
     this._stepWidth = this._innerWidth / steps;
+    if (this._stepWidth < 1 || !isFinite(this._stepWidth)) this._stepWidth = 1;
     while (this._stepWidth < 4) this._stepWidth *= 2;
   }
 }


### PR DESCRIPTION
Après avoir incorporé le composant Range dans une page utilisant le dsfr,
le chargement de la page est bloqué. Même expérience sous Safari, Chrome et Firefox. Firefox propose de fermer la page qui consomme trop de ressources. La suppression du composant range corrige le problème.

Sous certaine conditions, une boucle infinie de calcul peut apparaître dans le calcul de la largeur d'un pas dans src/component/range/script/range/range-model.js

Dans la ligne

https://github.com/GouvernementFR/dsfr/blob/0872677c9a433007d6a3db2329000b448c216817/src/component/range/script/range/range-model.js#L143

la boucle ne s'arrête pas si _stepWidth vaut -Infinite. Cela peut arriver si la division précédente a un quotient 0.


Le patch proposé dans cette PR semble corriger le problème.