### PR TITLE
✨ refactor(pictogram): passage des pictogrammes en stroke

### DIFF
--- a/module/color/mixin/_element.scss
+++ b/module/color/mixin/_element.scss
@@ -189,6 +189,16 @@ $COLOR: constant.$value;
   @include element(fill, background , $tokens, $options);
 }
 
+/// Ajout d'une couleur de stroke sur un élément
+/// @access public
+/// @param {list} $tokens - liste des tokens de décision
+/// @param {map} $options - map des options :
+///   - legacy {boolean}: version pour navigateurs modernes ou anciens.
+///   - important {boolean}: si true, applique !important à la règle css
+@mixin stroke($tokens, $options) {
+  @include element(stroke, background , $tokens, $options);
+}
+
 /// Ajout d'une couleur de border sur un élément
 /// @access public
 /// @param {list} $tokens - liste des tokens de décision

--- a/src/core/asset/artwork/pictograms/buildings/city-hall-border.svg
+++ b/src/core/asset/artwork/pictograms/buildings/city-hall-border.svg
@@ -1,0 +1,27 @@
+<svg width="80px" height="80px" viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg">
+ 	<style>
+    .fr-artwork-decorative, .fr-artwork-minor, .fr-artwork-major {
+      fill: none;
+      stroke-linecap: round;
+      stroke-width: 2;
+    }
+		.fr-artwork-decorative {
+			stroke: #ECECFF;
+		}
+		.fr-artwork-minor {
+			stroke: #E1000F;
+		}
+		.fr-artwork-major {
+			stroke: #000091;
+		}
+	</style>
+	<g class="fr-artwork-decorative" id="artwork-decorative">
+    <path d="M61,5L61,5 M27,77L27,77 M57,77L57,77"/>
+  </g>
+  <g class="fr-artwork-minor" id="artwork-minor">
+    <path d="M44 10V14M13 35H19M13 39H19M25 35H31M25 39H31M49 35H55M49 39H55M61 35H67M61 39H67M40 35C38.895 35 38 35.895 38 37C38 38.105 38.895 39 40 39C41.105 39 42 38.105 42 37C42 35.895 41.105 35 40 35Z"/>
+  </g>
+  <g class="fr-artwork-major" id="artwork-major">
+    <path d="M17 27V21H53M57 21H59M3 27H77M35 45H45M29 65H51M7 69H21V49M47 65V49H33V65M25 69H69V49M40 10V14M40 17V21M63 21V27M7 31V65M11 49V69M15 45V61M25 45V65M55 45V65M59 49V61M65 45V65M73 31V69M40 55V65"/>
+  </g>
+</svg>

--- a/src/core/style/_module.scss
+++ b/src/core/style/_module.scss
@@ -4,6 +4,7 @@
 ////
 
 @import 'action/module';
+@import 'artwork/module';
 @import 'motion/module';
 @import 'typography/module';
 @import 'color/module';

--- a/src/core/style/artwork/_module.scss
+++ b/src/core/style/artwork/_module.scss
@@ -1,0 +1,31 @@
+////
+/// Core Module : Artwork
+/// @group core
+////
+
+@use 'module/selector';
+
+#{selector.ns(artwork)} {
+  &-decorative,
+  &-minor,
+  &-major {
+    fill: none;
+    stroke-width: 1.75;
+  }
+
+  &--sm {
+    #{selector.ns(artwork)}-decorative,
+    #{selector.ns(artwork)}-minor,
+    #{selector.ns(artwork)}-major {
+      stroke-width: 1.5;
+    }
+  }
+
+  &--lg {
+    #{selector.ns(artwork)}-decorative,
+    #{selector.ns(artwork)}-minor,
+    #{selector.ns(artwork)}-major {
+      stroke-width: 2;
+    }
+  }
+}

--- a/src/core/style/artwork/_module.scss
+++ b/src/core/style/artwork/_module.scss
@@ -6,26 +6,17 @@
 @use 'module/selector';
 
 #{selector.ns(artwork)} {
-  &-decorative,
-  &-minor,
-  &-major {
-    fill: none;
-    stroke-width: 1.75;
-  }
+  fill: none;
+  stroke-width: 2;
+  transition: stroke-dashoffset 1.5s;
+  stroke-dasharray: 80;
+  stroke-dashoffset: 0;
 
   &--sm {
-    #{selector.ns(artwork)}-decorative,
-    #{selector.ns(artwork)}-minor,
-    #{selector.ns(artwork)}-major {
-      stroke-width: 1.5;
-    }
+    stroke-width: 2.25;
   }
 
   &--lg {
-    #{selector.ns(artwork)}-decorative,
-    #{selector.ns(artwork)}-minor,
-    #{selector.ns(artwork)}-major {
-      stroke-width: 2;
-    }
+    stroke-width: 1.5;
   }
 }

--- a/src/core/style/artwork/_scheme.scss
+++ b/src/core/style/artwork/_scheme.scss
@@ -1,5 +1,5 @@
 ////
-/// Core Module : Artwork
+/// Core Scheme : Artwork
 /// @group core
 ////
 
@@ -9,15 +9,15 @@
 @mixin _core-artwork-scheme($legacy: false) {
   #{selector.ns(artwork)} {
     &-decorative {
-      @include color.fill(artwork decorative blue-france, (legacy: $legacy));
+      @include color.stroke(artwork decorative blue-france, (legacy: $legacy));
     }
 
     &-minor {
-      @include color.fill(artwork minor red-marianne, (legacy: $legacy));
+      @include color.stroke(artwork minor red-marianne, (legacy: $legacy));
     }
 
     &-major {
-      @include color.fill(artwork major blue-france, (legacy: $legacy));
+      @include color.stroke(artwork major blue-france, (legacy: $legacy));
     }
 
     &-background {
@@ -30,14 +30,14 @@
 
     @include color.accentuate {
       #{selector.ns(artwork-minor)} {
-        @include color.fill(artwork minor accent, (legacy: $legacy));
+        @include color.stroke(artwork minor accent, (legacy: $legacy));
       }
     }
   }
 
   [disabled] {
     #{selector.ns(artwork)} * {
-      @include color.fill(text disabled grey, (legacy: $legacy));
+      @include color.stroke(text disabled grey, (legacy: $legacy));
     }
   }
 }

--- a/src/core/template/ejs/artwork/pictogram.ejs
+++ b/src/core/template/ejs/artwork/pictogram.ejs
@@ -5,6 +5,10 @@
 
 * pictogram.accent (string, optional): couleur d'accentuation (ex: green-emeraude)
 
+* pictogram.size (string, optional): épaisseur du pictogramme (sm, lg)
+
+* pictogram.classes (array, optional): classes supplémentaires
+
 %>
 <% eval(include('../../../index.ejs')); %>
 <%
@@ -12,12 +16,27 @@
 
   const pictogram = locals.pictogram || {} ;
   let classes = pictogram.classes || [];
+  let width, height;
   classes.push(prefix + '-artwork');
   if (pictogram.accent) classes.push(prefix + '-artwork--' + pictogram.accent);
   const category = pictograms.filter(p => p.name === pictogram.name)[0].category;
+  if (pictogram.size && pictogram.size !== 'md') classes.push(prefix + '-artwork--' + pictogram.size);
+  switch (pictogram.size) {
+    case 'sm':
+      width = height = 40;
+      break;
+
+    case 'lg':
+      width = height = 120;
+      break;
+
+    default:
+      width = height = 80;
+      break;
+  }
 %>
 
-<svg aria-hidden="true" <%- includeClasses(classes) %> viewBox="0 0 80 80" width="80px" height="80px" >
+<svg aria-hidden="true" <%- includeClasses(classes) %> viewBox="0 0 80 80" width="<%= width %>" height="<%= height %>" >
   <use class="<%= prefix %>-artwork-decorative" href="<%= relativeRoot %>dist/artwork/pictograms/<%= category %>/<%= pictogram.name %>.svg#artwork-decorative"></use>
   <use class="<%= prefix %>-artwork-minor" href="<%= relativeRoot %>dist/artwork/pictograms/<%= category %>/<%= pictogram.name %>.svg#artwork-minor"></use>
   <use class="<%= prefix %>-artwork-major" href="<%= relativeRoot %>dist/artwork/pictograms/<%= category %>/<%= pictogram.name %>.svg#artwork-major"></use>

--- a/src/page/response/template/ejs/response.ejs
+++ b/src/page/response/template/ejs/response.ejs
@@ -70,9 +70,9 @@
                     <use class="<%= prefix %>-artwork-motif" href="<%= relativeRoot %>dist/artwork/background/ovoid.svg#artwork-motif"></use>
                     <use class="<%= prefix %>-artwork-background" href="<%= relativeRoot %>dist/artwork/background/ovoid.svg#artwork-background"></use>
                     <g transform="translate(40, 60)">
-                        <use class="<%= prefix %>-artwork-decorative" href="<%= relativeRoot %>dist/artwork/pictograms/system/technical-error.svg#artwork-decorative"></use>
-                        <use class="<%= prefix %>-artwork-minor" href="<%= relativeRoot %>dist/artwork/pictograms/system/technical-error.svg#artwork-minor"></use>
-                        <use class="<%= prefix %>-artwork-major" href="<%= relativeRoot %>dist/artwork/pictograms/system/technical-error.svg#artwork-major"></use>
+                        <use class="<%= prefix %>-artwork-decorative" href="<%= relativeRoot %>dist/artwork/pictograms/buildings/city-hall-border.svg#artwork-decorative"></use>
+                        <use class="<%= prefix %>-artwork-minor" href="<%= relativeRoot %>dist/artwork/pictograms/buildings/city-hall-border.svg#artwork-minor"></use>
+                        <use class="<%= prefix %>-artwork-major" href="<%= relativeRoot %>dist/artwork/pictograms/buildings/city-hall-border.svg#artwork-major"></use>
                     </g>
                 </svg>
             </div>

--- a/src/page/response/template/ejs/response.ejs
+++ b/src/page/response/template/ejs/response.ejs
@@ -70,9 +70,9 @@
                     <use class="<%= prefix %>-artwork-motif" href="<%= relativeRoot %>dist/artwork/background/ovoid.svg#artwork-motif"></use>
                     <use class="<%= prefix %>-artwork-background" href="<%= relativeRoot %>dist/artwork/background/ovoid.svg#artwork-background"></use>
                     <g transform="translate(40, 60)">
-                        <use class="<%= prefix %>-artwork-decorative" href="<%= relativeRoot %>dist/artwork/pictograms/buildings/city-hall-border.svg#artwork-decorative"></use>
-                        <use class="<%= prefix %>-artwork-minor" href="<%= relativeRoot %>dist/artwork/pictograms/buildings/city-hall-border.svg#artwork-minor"></use>
-                        <use class="<%= prefix %>-artwork-major" href="<%= relativeRoot %>dist/artwork/pictograms/buildings/city-hall-border.svg#artwork-major"></use>
+                        <use class="<%= prefix %>-artwork-decorative" href="<%= relativeRoot %>dist/artwork/pictograms/building/technical-error.svg#artwork-decorative"></use>
+                        <use class="<%= prefix %>-artwork-minor" href="<%= relativeRoot %>dist/artwork/pictograms/building/technical-error.svg#artwork-minor"></use>
+                        <use class="<%= prefix %>-artwork-major" href="<%= relativeRoot %>dist/artwork/pictograms/building/technical-error.svg#artwork-major"></use>
                     </g>
                 </svg>
             </div>

--- a/src/utility/pictograms/example/category.ejs
+++ b/src/utility/pictograms/example/category.ejs
@@ -3,9 +3,15 @@
 
  const pictograms = JSON.parse(include('../../../../.config/pictogram.json'));
  const selected = pictograms.filter(pictogram => pictogram.category === locals.category);
-
+ const sizes = ['sm', 'md', 'lg']
  for (const pictogram of selected) {
  %>
-<%- sample(pictogram.name, '../../../core/template/ejs/artwork/pictogram', { pictogram: pictogram }, true); %>
 
+  <%
+  for (const size of sizes) {
+  %>
+
+  <%- sample(pictogram.name + ` ${size}`, '../../../core/template/ejs/artwork/pictogram', { pictogram: {...pictogram, size: size} }, true); %>
+
+  <% } %>
 <% } %>


### PR DESCRIPTION
- Les pictogrammes sont actuellement déssinés avec la propriété 'fill'.
- On utilisera maintenant la propriété 'stroke' afin de pouvoir définir une largeur de trait
- Ajout de modifier fr-artwork--sm et fr-artwork--lg pour changer l'épaisseur du trait