### PR TITLE
🐛 fix(breadcrumb): alignement vertical des icônes de chevron [DS-3779]

### DIFF
--- a/src/component/breadcrumb/style/_module.scss
+++ b/src/component/breadcrumb/style/_module.scss
@@ -68,14 +68,12 @@ un padding de 4px et une marge négative en compensation sont mis en place afin 
       &:not(:first-child) {
         @include icon(arrow-right-s-line, sm, before) {
           @include margin-x(1v);
-          vertical-align: -0.0625em;
         }
       }
     }
   }
 
   &__link {
-    vertical-align: top;
     position: relative;
     @include link-underline;
     @include disable-tint;

--- a/src/component/breadcrumb/style/_module.scss
+++ b/src/component/breadcrumb/style/_module.scss
@@ -68,12 +68,14 @@ un padding de 4px et une marge négative en compensation sont mis en place afin 
       &:not(:first-child) {
         @include icon(arrow-right-s-line, sm, before) {
           @include margin-x(1v);
+          vertical-align: -0.0625em;
         }
       }
     }
   }
 
   &__link {
+    vertical-align: spacing.space(1v);
     position: relative;
     @include link-underline;
     @include disable-tint;


### PR DESCRIPTION
- corrige l'alignement vertical des icônes de chevron sur tout les navigateurs (bug sur Safari 17)