### PR TITLE
🐛 fix(link, card, tile): enlarge button [DS-3798]

### DIFF
--- a/src/component/card/example/index.ejs
+++ b/src/component/card/example/index.ejs
@@ -14,10 +14,10 @@
       title: 'Variations',
       path: 'sample-variations'
     },
-    // {
-    //   title: 'Markup button',
-    //   path: 'sample-button'
-    // },
+    {
+      title: 'Markup button',
+      path: 'sample-button'
+    },
     {
       title: 'Sans image',
       path: 'sample-no-img'

--- a/src/component/card/example/sample/sample-disabled.ejs
+++ b/src/component/card/example/sample/sample-disabled.ejs
@@ -2,4 +2,4 @@
 
 <%- sample('Carte avec lien désactivé (a sans href)', './card-default', { card : { img: true, content: { disabled: true }}}, true, './card-layout', {col: {md:4}}); %>
 
-<%- // sample('Carte avec bouton désactivé (disabled)', './card-default', { card : { img: true, title: 'Intitulé de la carte (sur lequel se trouve le bouton)', content: { disabled: true, actionMarkup: 'button' } }}, true, './card-layout', {col: {md:4}}); %>
+<%- sample('Carte avec bouton désactivé (disabled)', './card-default', { card : { img: true, title: 'Intitulé de la carte (sur lequel se trouve le bouton)', content: { disabled: true, actionMarkup: 'button' } }}, true, './card-layout', {col: {md:4}}); %>

--- a/src/component/card/style/_legacy.scss
+++ b/src/component/card/style/_legacy.scss
@@ -17,7 +17,8 @@
     }
 
     &__title {
-      a {
+      a,
+      button {
         @include icon-legacy(arrow-right-line, sm, after) {
           background-color: transparent;
         }
@@ -65,6 +66,16 @@
       }
     }
 
+    &#{ns(enlarge-button)} {
+      #{ns(card)}__title {
+        button {
+          @include icon-size-legacy(md, after) {
+            background-color: transparent;
+          }
+        }
+      }
+    }
+
     @include respond-from(md) {
       &--download,
       &--horizontal,
@@ -78,32 +89,38 @@
   }
 
   #{ns(card--sm)} {
-    &#{ns(enlarge-link)} {
+    &#{ns(enlarge-link)},
+    &#{ns(enlarge-button)} {
       #{ns(card)}__title {
-        a {
+        a,
+        button {
           @include icon-size-legacy(sm, after);
         }
       }
     }
 
     #{ns(card)}__title {
-      a {
+      a,
+      button {
         @include icon-size-legacy(sm, after);
       }
     }
   }
 
   #{ns(card--lg)} {
-    &#{ns(enlarge-link)} {
+    &#{ns(enlarge-link)},
+    &#{ns(enlarge-button)} {
       #{ns(card)}__title {
-        a {
+        a,
+        button {
           @include icon-size-legacy(lg, after);
         }
       }
     }
 
     #{ns(card)}__title {
-      a {
+      a,
+      button {
         @include icon-size-legacy(md, after);
       }
     }

--- a/src/component/card/style/module/_content.scss
+++ b/src/component/card/style/module/_content.scss
@@ -78,14 +78,16 @@
     }
   }
 
-  &#{ns(enlarge-link)}:not(&--no-icon) &__end {
+  &#{ns(enlarge-link)}:not(&--no-icon) &__end,
+  &#{ns(enlarge-button)}:not(&--no-icon) &__end {
     @include margin-bottom(-12v); // 6v (icon) + 2v (padding end) + 4v (marge texte icon)
     @include min-height(8v); // 6v (icon) + 2v (padding end)
     @include padding-right(8v); // 6v (icon) + 2v (padding)
     justify-content: flex-end;
   }
 
-  &#{ns(enlarge-link)}:not(&--no-icon) &__content {
+  &#{ns(enlarge-link)}:not(&--no-icon) &__content,
+  &#{ns(enlarge-button)}:not(&--no-icon) &__content {
     @include padding-bottom(20v); // 8v (padding card) + 6v (icon) + 2v (padding end) + 4v (marge texte icon)
   }
 }

--- a/src/component/card/style/module/_default.scss
+++ b/src/component/card/style/module/_default.scss
@@ -7,7 +7,8 @@
   @include display-flex(column);
   @include relative();
 
-  &#{ns(enlarge-link)} {
+  &#{ns(enlarge-link)},
+  &#{ns(enlarge-button)} {
     #{ns(card)}__title {
       a,
       button {
@@ -28,7 +29,15 @@
   &--no-icon,
   &:not(#{ns(enlarge-link)}):not(#{ns(card--download)}) {
     #{ns(card__title)} {
-      a:not([target="_blank"]),
+      a:not([target="_blank"]) {
+        @include after(none);
+      }
+    }
+  }
+
+  &--no-icon,
+  &:not(#{ns(enlarge-button)}):not(#{ns(card--download)}) {
+    #{ns(card__title)} {
       button {
         @include after(none);
       }

--- a/src/component/card/style/module/_download.scss
+++ b/src/component/card/style/module/_download.scss
@@ -44,7 +44,8 @@
     @include icon(download-line, null, after);
   }
 
-  &#{ns(enlarge-link)} {
+  &#{ns(enlarge-link)},
+  &#{ns(enlarge-button)} {
     @include hover-media-query {
       &:hover {
         #{ns(card__header)} {

--- a/src/component/card/style/module/_header.scss
+++ b/src/component/card/style/module/_header.scss
@@ -18,6 +18,7 @@
   }
 
   @include hover-brighten(#{&}#{ns(enlarge-link)}, '#{&}__img, #{&}__vid');
+  @include hover-brighten(#{&}#{ns(enlarge-button)}, '#{&}__img, #{&}__vid');
 
   &__img,
   &__vid {

--- a/src/component/card/style/module/_lg.scss
+++ b/src/component/card/style/module/_lg.scss
@@ -40,17 +40,20 @@
     @include padding-top(2v);
   }
 
-  &--lg#{ns(enlarge-link)}:not(&--no-icon) &__end {
+  &--lg#{ns(enlarge-link)}:not(&--no-icon) &__end,
+  &--lg#{ns(enlarge-button)}:not(&--no-icon) &__end {
     @include margin-bottom(-16v); // 8v (icon) + 2v (padding end) + 6v (marge texte icon)
     @include min-height(10v); // 8v (icon) + 2v (padding end)
     @include padding-right(10v); // 8v (icon) + 2v (padding)
   }
 
-  &--lg#{ns(enlarge-link)}:not(&--no-icon) &__content {
+  &--lg#{ns(enlarge-link)}:not(&--no-icon) &__content,
+  &--lg#{ns(enlarge-button)}:not(&--no-icon) &__content {
     @include padding-bottom(26v); // 10v (padding card) + 8v (icon) + 2v (padding end) + 6v (marge texte icon)
   }
 
-  &--lg#{ns(enlarge-link)}:not(&--no-icon) &__title {
+  &--lg#{ns(enlarge-link)}:not(&--no-icon) &__title,
+  &--lg#{ns(enlarge-button)}:not(&--no-icon) &__title {
     a,
     button {
       @include icon-size(lg, after) {

--- a/src/component/card/style/module/_sm.scss
+++ b/src/component/card/style/module/_sm.scss
@@ -44,17 +44,20 @@
     @include padding-top(1v);
   }
 
-  &--sm#{ns(enlarge-link)}:not(&--no-icon) &__end {
+  &--sm#{ns(enlarge-link)}:not(&--no-icon) &__end,
+  &--sm#{ns(enlarge-button)}:not(&--no-icon) &__end {
     @include margin-bottom(-8v); // 4v (icon) + 1v (padding end) + 3v (marge texte icon)
     @include min-height(5v); // 4v (icon) + 1v (padding end)
     @include padding-right(6v); // 4v (icon) + 2v (padding)
   }
 
-  &--sm#{ns(enlarge-link)}:not(&--no-icon) &__content {
+  &--sm#{ns(enlarge-link)}:not(&--no-icon) &__content,
+  &--sm#{ns(enlarge-button)}:not(&--no-icon) &__content {
     @include padding-bottom(14v); // 6v (padding card) + 4v (icon) + 1v (padding end) + 3v (marge texte icon)
   }
 
-  &--sm#{ns(enlarge-link)}:not(&--no-icon) &__title {
+  &--sm#{ns(enlarge-link)}:not(&--no-icon) &__title,
+  &--sm#{ns(enlarge-button)}:not(&--no-icon) &__title {
     a,
     button {
       @include icon-size(sm, after) {

--- a/src/component/card/template/ejs/card.ejs
+++ b/src/component/card/template/ejs/card.ejs
@@ -34,7 +34,7 @@ const content = card.content || {};
 
 if (card.id) attributes.id = card.id;
 
-if (card.enlarge) classes.push(`${prefix}-enlarge-link`);
+if (card.enlarge) classes.push(`${prefix}-enlarge-${card.content.actionMarkup}`);
 
 switch (card.size) {
   case 'sm':

--- a/src/component/card/template/ejs/card.ejs
+++ b/src/component/card/template/ejs/card.ejs
@@ -34,7 +34,14 @@ const content = card.content || {};
 
 if (card.id) attributes.id = card.id;
 
-if (card.enlarge) classes.push(`${prefix}-enlarge-${card.content.actionMarkup}`);
+if (card.enlarge) switch (card.content.actionMarkup) {
+  case 'button':
+    classes.push(`${prefix}-enlarge-button`);
+    break;
+
+  default:
+    classes.push(`${prefix}-enlarge-link`);
+}
 
 switch (card.size) {
   case 'sm':

--- a/src/component/card/template/ejs/content.ejs
+++ b/src/component/card/template/ejs/content.ejs
@@ -41,25 +41,31 @@ const actionMarkup = content.actionMarkup || 'a';
 const hasLink = !content.noLink;
 const href = content.href || '#';
 let attributes = content.attributes || {};
-if (content.assess === true) {
-    attributes[`data-${prefix}-assess-file`] = '';
-} else if (typeof(content.assess) === 'string') {
-    attributes[`data-${prefix}-assess-file`] = content.assess;
+
+let action;
+switch (actionMarkup) {
+  case 'a':
+    action = 'link';
+    break;
+  default:
+    action = actionMarkup;
+    break;
 }
-if (actionMarkup === 'a') {
-    if (content.disabled !== true) {
-        attributes.href = href;
-    } else {
-      attributes.role = 'link';
-      attributes['aria-disabled'] = true;
+
+switch (action) {
+  case 'link':
+    if (content.rel) attributes.rel = content.rel;
+    if (content.lang) attributes.hreflang = content.lang;
+    if (content.assess === true) {
+        attributes[`data-${prefix}-assess-file`] = ''
+    } else if (typeof(content.assess) === 'string') {
+        attributes[`data-${prefix}-assess-file`] = content.assess
     }
-} else {
-    attributes.disabled = content.disabled ? null : undefined;
+    break;
 }
-if (content.lang) attributes.hreflang = content.lang;
+
 if (content.downloadable === true && actionMarkup === 'a') attributes.download = '';
 if (typeof(content.downloadable) === 'string') attributes.download = content.downloadable;
-if (content.blank === true) attributes = { ...targetBlankData(), ...attributes};
 
 switch (true) {
     case content.badgesGroup !== undefined :
@@ -85,11 +91,9 @@ switch (true) {
 <div class="<%= prefix %>-card__content">
     <<%= markup %> class="<%= prefix %>-card__title">
         <% if (hasLink) { %>
-            <<%= actionMarkup %> <%- includeAttrs(attributes) %>>
-        <% } %>
-        <%- content.title %>
-        <% if (hasLink) { %>
-            </<%= actionMarkup %>>
+            <%- include('../../../../core/template/ejs/action/action', {action: {...content, attributes, kind: action, label: content.title, disabled: content.disabled}}) %>
+        <% } else { %>
+            <%- content.title %>
         <% } %>
     </<%= markup %>>
 

--- a/src/component/link/template/ejs/link.ejs
+++ b/src/component/link/template/ejs/link.ejs
@@ -61,6 +61,11 @@ switch (action) {
   case 'link':
     if (link.rel) linkAttrs.rel = link.rel;
     if (link.hreflang) linkAttrs.hreflang = link.hreflang;
+    if (link.assess === true) {
+      linkAttrs[`data-${prefix}-assess-file`] = ''
+    } else if (typeof(link.assess) === 'string') {
+      linkAttrs[`data-${prefix}-assess-file`] = link.assess
+    }
     break;
 }
 
@@ -77,12 +82,6 @@ switch (link.size) {
 if (link.download) {
   linkAttrs.download = link.download;
   linkClasses.push(prefix + '-link--download');
-}
-
-if (link.assess === true) {
-  linkAttrs[`data-${prefix}-assess-file`] = ''
-} else if (typeof(link.assess) === 'string') {
-  linkAttrs[`data-${prefix}-assess-file`] = link.assess
 }
 
 if (link.icon !== undefined) linkClasses.push(`${prefix}-icon-${link.icon}`);

--- a/src/component/link/template/ejs/link.ejs
+++ b/src/component/link/template/ejs/link.ejs
@@ -61,15 +61,6 @@ switch (action) {
   case 'link':
     if (link.rel) linkAttrs.rel = link.rel;
     if (link.hreflang) linkAttrs.hreflang = link.hreflang;
-    if (link.download) {
-      linkAttrs.download = link.download;
-      linkClasses.push(prefix + '-link--download');
-    }
-    if (link.assess === true) {
-        linkAttrs[`data-${prefix}-assess-file`] = ''
-    } else if (typeof(link.assess) === 'string') {
-        linkAttrs[`data-${prefix}-assess-file`] = link.assess
-    }
     break;
 }
 
@@ -81,6 +72,17 @@ switch (link.size) {
   case 'lg':
     linkClasses.push(prefix + '-link--lg');
     break;
+}
+
+if (link.download) {
+  linkAttrs.download = link.download;
+  linkClasses.push(prefix + '-link--download');
+}
+
+if (link.assess === true) {
+  linkAttrs[`data-${prefix}-assess-file`] = ''
+} else if (typeof(link.assess) === 'string') {
+  linkAttrs[`data-${prefix}-assess-file`] = link.assess
 }
 
 if (link.icon !== undefined) linkClasses.push(`${prefix}-icon-${link.icon}`);

--- a/src/component/tile/example/index.ejs
+++ b/src/component/tile/example/index.ejs
@@ -18,10 +18,10 @@
       title: 'Variantes',
       path: 'sample-variations'
     },
-    // {
-    //   title: 'Markup button',
-    //   path: 'sample-button'
-    // },
+    {
+      title: 'Markup button',
+      path: 'sample-button'
+    },
     {
       title: 'Sans lien',
       path: 'sample-no-link'

--- a/src/component/tile/example/sample/sample-disabled.ejs
+++ b/src/component/tile/example/sample/sample-disabled.ejs
@@ -2,4 +2,4 @@
 
 <%- sample('Tuile avec lien désactivé (a sans href)', './tile-default', {tile: {pictogram: true, content: {disabled: true} }}, true, './tile-layout', {col: {md:4}}); %>
 
-<%- // sample('Tuile avec bouton désactivé (disabled)', './tile-default', {tile: {pictogram: true, content: {disabled: true, actionMarkup: 'button'} }}, true, './tile-layout', {col: {md:4}}); %>
+<%- sample('Tuile avec bouton désactivé (disabled)', './tile-default', {tile: {pictogram: true, content: {disabled: true, actionMarkup: 'button'} }}, true, './tile-layout', {col: {md:4}}); %>

--- a/src/component/tile/style/_legacy.scss
+++ b/src/component/tile/style/_legacy.scss
@@ -43,7 +43,8 @@
       @include margin(0 0 2v);
       max-width: 100%;
 
-      a {
+      a,
+      button {
         @include icon-legacy(arrow-right-line, sm, after);
       }
 
@@ -63,8 +64,11 @@
     }
 
     &--download {
-      #{ns(tile__title a)} {
-        @include icon-legacy(download-line, null, after);
+      #{ns(tile__title)} {
+        a,
+        button {
+          @include icon-legacy(download-line, null, after);
+        }
       }
     }
 
@@ -78,12 +82,23 @@
         }
       }
     }
+
+    &#{ns(enlarge-button)} {
+      #{ns(tile)}__title {
+        button {
+          @include icon-size-legacy(md, after) {
+            background-color: transparent;
+          }
+        }
+      }
+    }
   }
 
   #{ns(tile--sm)} {
     #{ns(tile)} {
       &__title {
-        a {
+        a,
+        button {
           @include icon-size-legacy(sm, after);
         }
       }

--- a/src/component/tile/style/_scheme.scss
+++ b/src/component/tile/style/_scheme.scss
@@ -48,23 +48,12 @@
         }
       }
 
-      a {
-        &:not([href]) {
-          @include disabled.colors((legacy: $legacy, text: true));
-  
-          @include before {
-            @include color.background-image((border disabled grey), (legacy: $legacy));
-          }
-        }
-      }
+      a:not([href]),
+      button:disabled {
+        @include disabled.colors((legacy: $legacy, text: true));
 
-      button {
-        &:disabled {
-          @include disabled.colors((legacy: $legacy, text: true));
-
-          @include before {
-            @include color.background-image((border disabled grey), (legacy: $legacy));
-          }
+        @include before {
+          @include color.background-image((border disabled grey), (legacy: $legacy));
         }
       }
     }

--- a/src/component/tile/style/_tool.scss
+++ b/src/component/tile/style/_tool.scss
@@ -72,7 +72,8 @@
     @include margin-top(3v);
   }
 
-  &#{ns(enlarge-link)}:not(#{ns(tile--no-icon)}) {
+  &#{ns(enlarge-link)}:not(#{ns(tile--no-icon)}),
+  &#{ns(enlarge-button)}:not(#{ns(tile--no-icon)}) {
     #{ns(tile__content)} {
       @include padding-bottom(10v);
     }

--- a/src/component/tile/style/module/_default.scss
+++ b/src/component/tile/style/module/_default.scss
@@ -21,6 +21,7 @@
   }
 
   @include hover-brighten(#{&}#{ns(enlarge-link)}, #{&}__pictogram);
+  @include hover-brighten(#{&}#{ns(enlarge-button)}, #{&}__pictogram);
 
   &__header {
     order: 1;
@@ -50,7 +51,8 @@
     flex: 1 1 auto;
   }
 
-  &#{ns(enlarge-link)} {
+  &#{ns(enlarge-link)},
+  &#{ns(enlarge-button)} {
     #{ns(tile)}__title {
       a,
       button {
@@ -60,7 +62,6 @@
       }
 
       button {
-        font-size: inherit;
         font-weight: inherit;
         line-height: inherit;
         text-align: inherit;
@@ -72,7 +73,15 @@
   &--no-icon,
   &:not(#{ns(enlarge-link)}):not(#{ns(tile--download)}) {
     #{ns(tile__title)} {
-      a:not([target="_blank"]),
+      a:not([target="_blank"]) {
+        @include after(none);
+      }
+    }
+  }
+
+  &--no-icon,
+  &:not(#{ns(enlarge-button)}):not(#{ns(tile--download)}) {
+    #{ns(tile__title)} {
       button {
         @include after(none);
       }
@@ -141,7 +150,8 @@
     }
   }
 
-  &#{ns(enlarge-link)}:not(&--no-icon) &__content {
+  &#{ns(enlarge-link)}:not(&--no-icon) &__content,
+  &#{ns(enlarge-button)}:not(&--no-icon) &__content {
     @include padding-bottom(10v);
   }
 }

--- a/src/component/tile/style/module/_download.scss
+++ b/src/component/tile/style/module/_download.scss
@@ -4,7 +4,10 @@
 ////
 
 #{ns(tile)}#{ns(tile--download)} {
-  #{ns(tile__title a)} {
-    @include icon(download-line, null, after);
+  #{ns(tile__title)} {
+    a,
+    button {
+      @include icon(download-line, null, after);
+    }
   }
 }

--- a/src/component/tile/style/module/_sm.scss
+++ b/src/component/tile/style/module/_sm.scss
@@ -44,7 +44,8 @@
     }
   }
 
-  &#{ns(enlarge-link)}:not(#{ns(tile--no-icon)}) {
+  &#{ns(enlarge-link)}:not(#{ns(tile--no-icon)}),
+  &#{ns(enlarge-button)}:not(#{ns(tile--no-icon)}) {
     #{ns(tile__title)} {
       a,
       button {

--- a/src/component/tile/template/ejs/content.ejs
+++ b/src/component/tile/template/ejs/content.ejs
@@ -37,25 +37,31 @@ const actionMarkup = content.actionMarkup || 'a';
 const href = content.href || '#';
 let attributes = content.attributes || {};
 const hasLink = !content.noLink;
-if (content.assess === true) {
-    attributes[`data-${prefix}-assess-file`] = '';
-} else if (typeof(content.assess) === 'string') {
-    attributes[`data-${prefix}-assess-file`] = content.assess;
+
+let action;
+switch (actionMarkup) {
+  case 'a':
+    action = 'link';
+    break;
+  default:
+    action = actionMarkup;
+    break;
 }
-if (actionMarkup === 'a') {
-  if (content.disabled !== true) {
-    attributes.href = href;
-  } else {
-    attributes.role = 'link';
-    attributes['aria-disabled'] = true;
-  }
-} else {
-    attributes.disabled = content.disabled ? null : undefined;
+
+switch (action) {
+  case 'link':
+    if (content.rel) attributes.rel = content.rel;
+    if (content.lang) attributes.hreflang = content.lang;
+    if (content.assess === true) {
+        attributes[`data-${prefix}-assess-file`] = ''
+    } else if (typeof(content.assess) === 'string') {
+        attributes[`data-${prefix}-assess-file`] = content.assess
+    }
+    break;
 }
-if (content.lang) attributes.hreflang = content.lang;
-if (content.downloadable === true) attributes.download = '';
+
+if (content.downloadable === true && actionMarkup === 'a') attributes.download = '';
 if (typeof(content.downloadable) === 'string') attributes.download = content.downloadable;
-if (content.blank === true) attributes = {...targetBlankData(), ...attributes};
 
 if (content.badgesGroup) start.badgesGroup = content.badgesGroup;
 if (content.tagsGroup) start.tagsGroup = content.tagsGroup;
@@ -66,13 +72,11 @@ if (content.badge) start.badge = content.badge;
 
 <div class="<%= prefix %>-tile__content">
   <<%= markup %> class="<%= prefix %>-tile__title">
-      <% if (hasLink) { %>
-        <<%= actionMarkup %> <%- includeAttrs(attributes) %>>
-      <% } %>
-      <%- content.title %>
-      <% if (hasLink) { %>
-        </<%= actionMarkup %>>
-      <% } %>
+    <% if (hasLink) { %>
+      <%- include('../../../../core/template/ejs/action/action', {action: {...content, attributes, kind: action, label: content.title, disabled: content.disabled}}) %>
+    <% } else { %>
+        <%- content.title %>
+    <% } %>
   </<%= markup %>>
 
   <% if (content.description !== undefined) { %>

--- a/src/component/tile/template/ejs/tile.ejs
+++ b/src/component/tile/template/ejs/tile.ejs
@@ -91,7 +91,15 @@ if (tile.variations) for (const variation of tile.variations) switch(variation) 
 
 if (tile.download) classes.push(`${prefix}-tile--download`);
 if (tile.icon === false) classes.push(`${prefix}-tile--no-icon`);
-if (tile.enlarge) classes.push(`${prefix}-enlarge-${tile.content.actionMarkup}`);
+
+if (tile.enlarge) switch (tile.content.actionMarkup) {
+  case 'button':
+    classes.push(`${prefix}-enlarge-button`);
+    break;
+
+  default:
+    classes.push(`${prefix}-enlarge-link`);
+}
 %>
 
 <div <%- includeClasses(classes)%> <%- includeAttrs(attributes) %>>

--- a/src/component/tile/template/ejs/tile.ejs
+++ b/src/component/tile/template/ejs/tile.ejs
@@ -91,7 +91,7 @@ if (tile.variations) for (const variation of tile.variations) switch(variation) 
 
 if (tile.download) classes.push(`${prefix}-tile--download`);
 if (tile.icon === false) classes.push(`${prefix}-tile--no-icon`);
-if (tile.enlarge) classes.push(`${prefix}-enlarge-link`);
+if (tile.enlarge) classes.push(`${prefix}-enlarge-${tile.content.actionMarkup}`);
 %>
 
 <div <%- includeClasses(classes)%> <%- includeAttrs(attributes) %>>

--- a/src/core/style/action/_module.scss
+++ b/src/core/style/action/_module.scss
@@ -10,4 +10,4 @@
 @import 'module/hover';
 @import 'module/cursor';
 @import 'module/disabled';
-@import 'module/enlarge-link';
+@import 'module/enlarge';

--- a/src/core/style/action/legacy/_hover.scss
+++ b/src/core/style/action/legacy/_hover.scss
@@ -7,7 +7,8 @@
 @use 'module/legacy';
 
 @include legacy.is(ie11) {
-  #{ns(enlarge-link)} {
+  #{ns(enlarge-link)},
+  #{ns(enlarge-button)} {
     @include color.transparent-background((legacy: true, hover: true));
 
     @include disable-underline-legacy;

--- a/src/core/style/action/module/_enlarge.scss
+++ b/src/core/style/action/module/_enlarge.scss
@@ -3,44 +3,41 @@
 /// @group core
 ////
 
-@mixin enlarge($markup) {
-  position: relative;
+@mixin enlarge($selector, $markup) {
+  #{ns(enlarge-#{$selector})} {
+    position: relative;
 
-  #{$markup} {
-    background-image: none;
-    outline-width: 0;
-    @include before('', block) {
-      @include absolute(0, 0, 0, 0, 100%, 100%);
-      outline-offset: 2px;
-      outline-style: inherit;
-      outline-color: inherit;
-      outline-width: 2px;
-      @include z-index(over);
-    }
-  }
-
-  @include hover-media-query {
     #{$markup} {
-      &:hover,
-      &:active {
-        background: none;
+      background-image: none;
+      outline-width: 0;
+      @include before('', block) {
+        @include absolute(0, 0, 0, 0, 100%, 100%);
+        outline-offset: 2px;
+        outline-style: inherit;
+        outline-color: inherit;
+        outline-width: 2px;
+        @include z-index(over);
       }
     }
 
-    &:hover {
-      background-color: var(--hover);
-    }
+    @include hover-media-query {
+      #{$markup} {
+        &:hover,
+        &:active {
+          background: none;
+        }
+      }
 
-    &:active {
-      background-color: var(--active);
+      &:hover {
+        background-color: var(--hover);
+      }
+
+      &:active {
+        background-color: var(--active);
+      }
     }
   }
 }
 
-#{ns(enlarge-link)} {
-  @include enlarge('a');
-}
-
-#{ns(enlarge-button)} {
-  @include enlarge('button');
-}
+@include enlarge(link, a);
+@include enlarge(button, button);

--- a/src/core/style/action/module/_enlarge.scss
+++ b/src/core/style/action/module/_enlarge.scss
@@ -1,13 +1,12 @@
 ////
-/// Core Module : Action enlarge link
+/// Core Module : Action enlarge
 /// @group core
 ////
 
-#{ns(enlarge-link)} {
+@mixin enlarge($markup) {
   position: relative;
 
-  a,
-  button {
+  #{$markup} {
     background-image: none;
     outline-width: 0;
     @include before('', block) {
@@ -21,8 +20,7 @@
   }
 
   @include hover-media-query {
-    a,
-    button {
+    #{$markup} {
       &:hover,
       &:active {
         background: none;
@@ -37,4 +35,12 @@
       background-color: var(--active);
     }
   }
+}
+
+#{ns(enlarge-link)} {
+  @include enlarge('a');
+}
+
+#{ns(enlarge-button)} {
+  @include enlarge('button');
 }

--- a/src/core/template/ejs/action/action.ejs
+++ b/src/core/template/ejs/action/action.ejs
@@ -1,7 +1,7 @@
 <%#
 # paramètres action
 
-* button.kind (string, optional) : type d'action [button/input/link]
+* action.kind (string, optional) : type d'action [button/input/link]
 valeurs :
   ** button (default) : bouton
   ** input : input


### PR DESCRIPTION
- ajoute une classe utilitaire `enlarge-button` utilisée sur les cartes et les tuiles de téléchargement pour élargir la zone de clique à tout le composant quand l'element cliquable est un bouton