### PR TITLE
🐛 fix(footer, header): réduction de la zone de clic retour à l'accueil [DS-3800]

### DIFF
--- a/src/component/footer/style/module/_default.scss
+++ b/src/component/footer/style/module/_default.scss
@@ -24,7 +24,6 @@
    */
   &__brand {
     @include display-flex(row, center);
-    flex-basis: 100%;
 
     @include logo(md, lg) {
       @include margin(-4v);
@@ -47,7 +46,6 @@
     }
 
     @include respond-from(md) {
-      flex-basis: auto;
       @include margin-right(4v);
 
       &#{ns(enlarge-link)} {

--- a/src/component/header/style/_scheme.scss
+++ b/src/component/header/style/_scheme.scss
@@ -15,7 +15,10 @@
 
     &__service {
       @include color.text(title grey, (legacy:$legacy));
-      @include color.box-shadow(default grey, (legacy:$legacy), top-1-in);
+
+      @include before {
+        @include color.background(border default grey, (legacy:$legacy));
+      }
     }
 
     @include media-query.respond-from(lg) {

--- a/src/component/header/style/module/_brand.scss
+++ b/src/component/header/style/module/_brand.scss
@@ -4,6 +4,7 @@
 ////
 
 @use 'module/media-query';
+@use 'module/spacing';
 
 #{ns(header)} {
   &__brand {
@@ -11,6 +12,13 @@
     @include margin-y(-4v, lg);
     @include size(100%);
     @include padding-x(1v);
+
+    @include after('', block) {
+      @include relative;
+      @include z-index(over);
+      flex: 1;
+      align-self: stretch;
+    }
 
     @include media-query.respond-from(lg) {
       flex-wrap: nowrap;
@@ -70,12 +78,15 @@
     @include padding-y(3v);
     @include margin-x(3v);
     @include margin-x(0, lg);
-    @include size(100%);
-
     @include disable-external();
 
-    @include media-query.respond-from(lg) {
-      width: auto;
+    @include before("", block) {
+      @include size(calc(100% - 8v), 1px);
+      @include absolute;
+      transform: translateY(spacing.space(-3v));
+      @include media-query.respond-from(lg) {
+        content: none;
+      }
     }
 
     &-title {

--- a/src/component/header/style/module/_navbar.scss
+++ b/src/component/header/style/module/_navbar.scss
@@ -7,14 +7,13 @@
 
 #{ns(header)} {
   &__navbar {
-    @include display-flex(row,flex-end);
+    @include display-flex(row, flex-start, flex-end);
     @include padding(1v);
-    @include margin-left(auto);
     @include margin-right(-2v);
     @include margin-top(1v);
     order: 3;
-    flex: 0 0 auto;
-    align-self: flex-start;
+    flex: 1;
+    align-self: stretch;
     @include elevation.z-index(overlap);
 
     @include respond-from(lg) {


### PR DESCRIPTION
- sur le header mobile la partie à droite du brand n'est plus cliquable pour éviter les clics manqués sur le burger ou la recherche, et le lien du nom de service n'est plus étendu sur toute la largeur
- sur le footer mobile la zone de clic n'est plus étendu sur toute la largeur