### PR TITLE
🐛 fix(modal): input sans type bug dans le focus trap de la modale [DS-3831]

### DIFF
--- a/src/component/input/input-base/example/sample/inputs.ejs
+++ b/src/component/input/input-base/example/sample/inputs.ejs
@@ -18,7 +18,7 @@ for (let i = 1; i < 4; i++) elements.push({
   data: {
     ...input,
     id: `${id}-${i}`,
-    name: `${id}`
+    name: `${id}-${i}`
   }
 });
 

--- a/src/component/modal/example/sample/body/form.ejs
+++ b/src/component/modal/example/sample/body/form.ejs
@@ -1,4 +1,4 @@
 <form action="">
-  <%- include("../../../../input/input-base/example/sample/inputs", {input: {group: true, id:'text'}}); %>
+  <%- include("../../../../input/input-base/example/sample/inputs", {inputs: {id:'input-sample'}}); %>
   <%- include("../../../../button/example/sample/button-default", {button: {title: 'Envoyer'}}); %>
 </form>

--- a/src/component/modal/script/modal/focus-trap.js
+++ b/src/component/modal/script/modal/focus-trap.js
@@ -157,7 +157,7 @@ class FocusTrap {
       }
 
       unordereds = unordereds.filter((unordered) => {
-        if (unordered.tagName.toLowerCase() !== 'input' || unordered.getAttribute('type').toLowerCase() !== 'radio') return true;
+        if (unordered.tagName.toLowerCase() !== 'input' || (!unordered.getAttribute('type') || unordered.getAttribute('type').toLowerCase() !== 'radio')) return true;
         const name = unordered.getAttribute('name');
         return groups[name].keep(unordered);
       });

--- a/src/component/modal/script/modal/focus-trap.js
+++ b/src/component/modal/script/modal/focus-trap.js
@@ -157,7 +157,7 @@ class FocusTrap {
       }
 
       unordereds = unordereds.filter((unordered) => {
-        if (unordered.tagName.toLowerCase() !== 'input' || (!unordered.getAttribute('type') || unordered.getAttribute('type').toLowerCase() !== 'radio')) return true;
+        if (unordered.tagName.toLowerCase() !== 'input' || unordered.getAttribute('type')?.toLowerCase() !== 'radio') return true;
         const name = unordered.getAttribute('name');
         return groups[name].keep(unordered);
       });


### PR DESCRIPTION
- Correction d'une erreur js lorsqu'un champs de saisie n'a pas d'attribut "type" à l'ouverture d'une modale