### PR TITLE
🐛 fix(core): opacité du texte du select désactivé

### DIFF
--- a/src/core/style/action/setting/_elements.scss
+++ b/src/core/style/action/setting/_elements.scss
@@ -164,6 +164,9 @@ $action-elements: (
       not-allowed: (
         selector: '&:disabled'
       )
+    ),
+    disabled: (
+      selector: '&:disabled'
     )
   ),
   textarea: (


### PR DESCRIPTION
- Correction de l'opacité du texte des listes déroulantes (select) désactivées ( fix #994 )