### PR TITLE
🐛 fix(anayltics): correction doc page.path [DS-3823]

### DIFF
--- a/src/analytics/doc/analytics/collector/page.md
+++ b/src/analytics/doc/analytics/collector/page.md
@@ -52,7 +52,7 @@ _String_ (EA: path)
 
 * Défini le chemin de la page
 
-* Utilise `document.location.pathname` si non défini
+* Utilise `document.location.pathname/document.location.search` si non défini
 
 * * *
 


### PR DESCRIPTION
- Correction de la valeur, si non renseignée, du paramètre page.path dans la documentation analytics