### PR TITLE
🐛 fix(modal): correction modal footer z-index [DS-3839]

### DIFF
--- a/src/component/modal/.package.yml
+++ b/src/component/modal/.package.yml
@@ -13,3 +13,6 @@ example:
   style:
     - form
     - input
+    - table
+  script:
+    - table

--- a/src/component/modal/example/index.ejs
+++ b/src/component/modal/example/index.ejs
@@ -19,6 +19,13 @@ let dataFooterButtons = {
     body: include('sample/body/text', { text: { paragraphs: 6 } }),
     footer: include('../example/sample/footer/buttons')
 }
+
+let dataTable = {
+    title: 'Titre de la modale',
+    icon: 'arrow-right-line',
+    body: include('sample/body/table'),
+    footer: include('../example/sample/footer/buttons')
+}
 %>
 
 <%- sample('Modale simple', './sample/modal-default', {modal: { ...dataText, label: 'Modale simple'}}, true ); %>
@@ -34,5 +41,7 @@ let dataFooterButtons = {
 <%- sample('Modale avec zone d\'action et boutons', './sample/modal-default', {modal: { ...dataFooterButtons, label: 'Modale avec zone d\'action'}}, true ); %>
 
 <%- sample('Modale avec zone d\'action ancré en haut en mobile', './sample/modal-default', {modal: { ...dataFooterButtons, label: 'Modale ancrée en haut', top: true}}, true ); %>
+
+<%- sample('Modale avec zone d\'action et tableau', './sample/modal-default', {modal: { ...dataTable, label: 'Modale tableau'}}, true ); %>
 
 <%- sample('Modale simple non refermable au click sur le fond', './sample/modal-default', {modal: { ...dataText, label: 'Modale simple', concealingBackdrop: false}}, true ); %>

--- a/src/component/modal/example/sample/body/table.ejs
+++ b/src/component/modal/example/sample/body/table.ejs
@@ -1,0 +1,5 @@
+<%
+  const tableData = JSON.parse(include('../../../../table/example/data/data-simple.json.ejs', {table: {id: 'modal-table', table: { col: 2, row: 16 }}})) || [];
+%>
+
+<%- include('../../../../table/template/ejs/wrapper', { table: tableData }); %>

--- a/src/component/modal/style/_module.scss
+++ b/src/component/modal/style/_module.scss
@@ -128,8 +128,8 @@
     @include margin-top(-10v);
     @include margin-top(-12v, md);
     @include sticky(null,null,0);
+    @include z-index(above);
     transition: box-shadow 0.3s;
-    z-index: z-index(modal-footer);
 
     @include preference.forced-colors {
       border-top: 1px solid;

--- a/src/component/modal/style/_module.scss
+++ b/src/component/modal/style/_module.scss
@@ -128,7 +128,7 @@
     @include margin-top(-10v);
     @include margin-top(-12v, md);
     @include sticky(null,null,0);
-    @include z-index(above);
+    @include elevation.z-index(overlap-over);
     transition: box-shadow 0.3s;
 
     @include preference.forced-colors {


### PR DESCRIPTION
- passe le footer de la modale au niveau "overlap-above" permettant d'être au dessus du tooltip ( fix #978 )
- ajoute un exemple de modale comportant une zone d'actions et un tableau long