### PR TITLE
🐛 fix(notice): correction css markup hx sur le titre du bandeau [DS-3840]

### DIFF
--- a/src/component/notice/style/_module.scss
+++ b/src/component/notice/style/_module.scss
@@ -21,6 +21,17 @@
     @include relative;
     @include padding(0 9v 0 0);
     @include padding(0 12v 0 0, md);
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      color: inherit;
+      line-height: inherit;
+      font-size: inherit;
+    }
   }
 
   &__title {


### PR DESCRIPTION
- correction du style du titre du bandeau lors de l'utilisation d'un niveau d'entête hx à la place de la balise p