### PR TITLE
🐛 fix(button): ajoute le type button par défaut [DS-3828]

### DIFF
--- a/src/analytics/example/action/index.ejs
+++ b/src/analytics/example/action/index.ejs
@@ -2,13 +2,13 @@
   <div>
     <h4>action activée</h4>
     <div class="<%= prefix %>-mb-6v">
-      <button class="<%= prefix %>-btn" data-<%= prefix %>-analytics-action="libellé envoyé à l'analytics" id="action-true" >libellé du bouton</button>
+      <button type="button" class="<%= prefix %>-btn" data-<%= prefix %>-analytics-action="libellé envoyé à l'analytics" id="action-true" >libellé du bouton</button>
     </div>
   </div>
   <div>
     <h4>action prévenue</h4>
     <div class="<%= prefix %>-mb-6v">
-      <button class="<%= prefix %>-btn" data-<%= prefix %>-analytics-action="false" id="action-false" >libellé du bouton</button>
+      <button type="button" class="<%= prefix %>-btn" data-<%= prefix %>-analytics-action="false" id="action-false" >libellé du bouton</button>
     </div>
   </div>
 </div>

--- a/src/analytics/example/spa/agnostic/index.ejs
+++ b/src/analytics/example/spa/agnostic/index.ejs
@@ -17,12 +17,12 @@
               <!-- L’alternative de l’image (attribut alt) doit impérativement être renseignée et reprendre le texte visible dans l’image -->
             </div>
             <div class="<%= prefix %>-header__navbar">
-              <button class="<%= prefix %>-btn--search <%= prefix %>-btn" data-<%= prefix %>-opened="false"
+              <button type="button" class="<%= prefix %>-btn--search <%= prefix %>-btn" data-<%= prefix %>-opened="false"
                 aria-controls="modal-122" id="button-123" title="Rechercher"
                 data-<%= prefix %>-js-modal-button="true">
                 Rechercher
               </button>
-              <button class="<%= prefix %>-btn--menu <%= prefix %>-btn" data-<%= prefix %>-opened="false"
+              <button type="button" class="<%= prefix %>-btn--menu <%= prefix %>-btn" data-<%= prefix %>-opened="false"
                 aria-controls="modal-124" id="button-125" title="Menu">
                 Menu
               </button>
@@ -48,7 +48,7 @@
           </div>
           <div class="<%= prefix %>-header__search <%= prefix %>-modal" id="modal-122">
             <div class="<%= prefix %>-container <%= prefix %>-container-lg--fluid">
-              <button class="<%= prefix %>-btn--close <%= prefix %>-btn" aria-controls="modal-122" id="button-130"
+              <button type="button" class="<%= prefix %>-btn--close <%= prefix %>-btn" aria-controls="modal-122" id="button-130"
                 title="Fermer">
                 Fermer
               </button>
@@ -60,7 +60,7 @@
                   placeholder="Rechercher" id="search-121-input" type="search">
                 <div class="<%= prefix %>-messages-group" id="search-121-input-messages" aria-live="polite">
                 </div>
-                <button class="<%= prefix %>-btn" id="search-btn-132" title="Rechercher">
+                <button type="button" class="<%= prefix %>-btn" id="search-btn-132" title="Rechercher">
                   Rechercher
                 </button>
               </div>

--- a/src/analytics/example/spa/agnostic/route.js.ejs
+++ b/src/analytics/example/spa/agnostic/route.js.ejs
@@ -31,7 +31,7 @@
       description: 'This is the about page',
     },
     'button': {
-      template: `<button id="btn-3" class="<%= prefix %>-btn">Button page 3</button>`,
+      template: `<button type="button" id="btn-3" class="<%= prefix %>-btn">Button page 3</button>`,
       title: 'Buttons | ' + urlPageTitle,
       description: 'This is the contact page',
     },

--- a/src/analytics/example/spa/angular/_index.ejs
+++ b/src/analytics/example/spa/angular/_index.ejs
@@ -11,7 +11,7 @@ app.config(function($routeProvider) {
     template : '<div><h2>LINK</h2><a href="#" data-<%= prefix %>-analytics-click="libellé du lien envoyé à l\'analytics" id="link-attr-click">test</a></div>'
   })
   .when("/button", {
-    template : '<div><h2>BUTTON</h2><button id="btn-3" class="<%= prefix %>-btn">Button</button></div>'
+    template : '<div><h2>BUTTON</h2><button type="button" id="btn-3" class="<%= prefix %>-btn">Button</button></div>'
   });
 });
 </script>
@@ -31,10 +31,10 @@ app.config(function($routeProvider) {
                             </p>
                         </div>
                         <div class="fr-header__navbar">
-                            <button class="fr-btn--search fr-btn" data-fr-opened="false" aria-controls="modal-122" id="button-123" title="Rechercher" >
+                            <button type="button" class="fr-btn--search fr-btn" data-fr-opened="false" aria-controls="modal-122" id="button-123" title="Rechercher" >
                                 Rechercher
                             </button>
-                            <button class="fr-btn--menu fr-btn" data-fr-opened="false" aria-controls="modal-124" id="button-125" title="Menu">
+                            <button type="button" class="fr-btn--menu fr-btn" data-fr-opened="false" aria-controls="modal-124" id="button-125" title="Menu">
                                 Menu
                             </button>
                         </div>
@@ -58,7 +58,7 @@ app.config(function($routeProvider) {
                     </div>
                     <div class="fr-header__search fr-modal" id="modal-122">
                         <div class="fr-container fr-container-lg--fluid">
-                            <button class="fr-btn--close fr-btn" aria-controls="modal-122" id="button-130" title="Fermer">
+                            <button type="button" class="fr-btn--close fr-btn" aria-controls="modal-122" id="button-130" title="Fermer">
                                 Fermer
                             </button>
                             <div class="fr-search-bar" id="search-121" role="search">
@@ -68,7 +68,7 @@ app.config(function($routeProvider) {
                                 <input class="fr-input" aria-describedby="search-121-input-messages" placeholder="Rechercher" id="search-121-input" type="search"/>
                                 <div class="fr-messages-group" id="search-121-input-messages" aria-live="polite">
                                 </div>
-                                <button class="fr-btn" id="search-btn-132" title="Rechercher">
+                                <button type="button" class="fr-btn" id="search-btn-132" title="Rechercher">
                                     Rechercher
                                 </button>
                             </div>
@@ -80,7 +80,7 @@ app.config(function($routeProvider) {
     </div>
     <div class="fr-header__menu fr-modal" id="modal-124">
       <div class="fr-container">
-        <button class="fr-btn--close fr-btn" aria-controls="modal-2414" id="button-2419" title="Fermer">
+        <button type="button" class="fr-btn--close fr-btn" aria-controls="modal-2414" id="button-2419" title="Fermer">
             Fermer
         </button>
         <div class="fr-header__menu-links">

--- a/src/analytics/example/spa/react/index.ejs
+++ b/src/analytics/example/spa/react/index.ejs
@@ -31,10 +31,10 @@
                                 </p>
                             </div>
                             <div class="fr-header__navbar">
-                                <button class="fr-btn--search fr-btn" data-fr-opened="false" aria-controls="modal-122" id="button-123" title="Rechercher" >
+                                <button type="button" class="fr-btn--search fr-btn" data-fr-opened="false" aria-controls="modal-122" id="button-123" title="Rechercher" >
                                     Rechercher
                                 </button>
-                                <button class="fr-btn--menu fr-btn" data-fr-opened="false" aria-controls="modal-124" id="button-125" title="Menu">
+                                <button type="button" class="fr-btn--menu fr-btn" data-fr-opened="false" aria-controls="modal-124" id="button-125" title="Menu">
                                     Menu
                                 </button>
                             </div>
@@ -58,7 +58,7 @@
                         </div>
                         <div class="fr-header__search fr-modal" id="modal-122">
                             <div class="fr-container fr-container-lg--fluid">
-                                <button class="fr-btn--close fr-btn" aria-controls="modal-122" id="button-130" title="Fermer">
+                                <button type="button" class="fr-btn--close fr-btn" aria-controls="modal-122" id="button-130" title="Fermer">
                                     Fermer
                                 </button>
                                 <div class="fr-search-bar" id="search-121" role="search">
@@ -68,7 +68,7 @@
                                     <input class="fr-input" aria-describedby="search-121-input-messages" placeholder="Rechercher" id="search-121-input" type="search"/>
                                     <div class="fr-messages-group" id="search-121-input-messages" aria-live="polite">
                                     </div>
-                                    <button class="fr-btn" id="search-btn-132" title="Rechercher">
+                                    <button type="button" class="fr-btn" id="search-btn-132" title="Rechercher">
                                         Rechercher
                                     </button>
                                 </div>
@@ -80,7 +80,7 @@
         </div>
         <div class="fr-header__menu fr-modal" id="modal-124">
           <div class="fr-container">
-            <button class="fr-btn--close fr-btn" aria-controls="modal-2414" id="button-2419" title="Fermer">
+            <button type="button" class="fr-btn--close fr-btn" aria-controls="modal-2414" id="button-2419" title="Fermer">
                 Fermer
             </button>
             <div class="fr-header__menu-links">
@@ -108,7 +108,7 @@
 
   const Home = props => <div><h2>HOME</h2><p>lorem ipsum dolor sit amet</p></div>
   const Links = props => <div><h2>LINK</h2><a href="#" data-fr-analytics-click="libellé du lien envoyé à l'analytics" id="link-attr-click">test</a></div>
-  const Button = props => <div><h2>BUTTON</h2><button id="btn-3" class="<%= prefix %>-btn">Button</button></div>
+  const Button = props => <div><h2>BUTTON</h2><button type="button" id="btn-3" class="<%= prefix %>-btn">Button</button></div>
 
   ReactDOM.render(<ReactRouterDOM.BrowserRouter><App /></ReactRouterDOM.BrowserRouter>, document.querySelector('#react-container'));
 

--- a/src/analytics/example/spa/vue/index.ejs
+++ b/src/analytics/example/spa/vue/index.ejs
@@ -18,10 +18,10 @@
                                 <!-- L’alternative de l’image (attribut alt) doit impérativement être renseignée et reprendre le texte visible dans l’image -->
                             </div>
                             <div class="<%= prefix %>-header__navbar">
-                                <button class="<%= prefix %>-btn--search <%= prefix %>-btn" data-<%= prefix %>-opened="false" aria-controls="modal-122" id="button-123" title="Rechercher" data-<%= prefix %>-js-modal-button="true" >
+                                <button type="button" class="<%= prefix %>-btn--search <%= prefix %>-btn" data-<%= prefix %>-opened="false" aria-controls="modal-122" id="button-123" title="Rechercher" data-<%= prefix %>-js-modal-button="true" >
                                     Rechercher
                                 </button>
-                                <button class="<%= prefix %>-btn--menu <%= prefix %>-btn" data-<%= prefix %>-opened="false" aria-controls="modal-124" id="button-125" title="Menu">
+                                <button type="button" class="<%= prefix %>-btn--menu <%= prefix %>-btn" data-<%= prefix %>-opened="false" aria-controls="modal-124" id="button-125" title="Menu">
                                     Menu
                                 </button>
                             </div>
@@ -45,7 +45,7 @@
                         </div>
                         <div class="<%= prefix %>-header__search <%= prefix %>-modal" id="modal-122">
                             <div class="<%= prefix %>-container <%= prefix %>-container-lg--fluid">
-                                <button class="<%= prefix %>-btn--close <%= prefix %>-btn" aria-controls="modal-122" id="button-130" title="Fermer">
+                                <button type="button" class="<%= prefix %>-btn--close <%= prefix %>-btn" aria-controls="modal-122" id="button-130" title="Fermer">
                                     Fermer
                                 </button>
                                 <div class="<%= prefix %>-search-bar" id="search-121" role="search">
@@ -55,7 +55,7 @@
                                     <input class="<%= prefix %>-input" aria-describedby="search-121-input-messages" placeholder="Rechercher" id="search-121-input" type="search">
                                     <div class="<%= prefix %>-messages-group" id="search-121-input-messages" aria-live="polite">
                                     </div>
-                                    <button class="<%= prefix %>-btn" id="search-btn-132" title="Rechercher">
+                                    <button type="button" class="<%= prefix %>-btn" id="search-btn-132" title="Rechercher">
                                         Rechercher
                                     </button>
                                 </div>
@@ -67,7 +67,7 @@
         </div>
         <div class="<%= prefix %>-header__menu <%= prefix %>-modal" id="modal-124">
             <div class="<%= prefix %>-container">
-                <button class="<%= prefix %>-btn--close <%= prefix %>-btn" aria-controls="modal-124" id="button-133" title="Fermer">
+                <button type="button" class="<%= prefix %>-btn--close <%= prefix %>-btn" aria-controls="modal-124" id="button-133" title="Fermer">
                     Fermer
                 </button>
                 <div class="<%= prefix %>-header__menu-links">
@@ -104,11 +104,11 @@
         </div>
         <div v-if="pagination==2">
           <h1>Page {{pagination}}</h1>
-          <button id="btn-1" class="<%= prefix %>-btn">Button 1</button>
+          <button type="button" id="btn-1" class="<%= prefix %>-btn">Button 1</button>
         </div>
         <div v-if="pagination==3">
           <h1>Page {{pagination}}</h1>
-          <button id="btn-2" class="<%= prefix %>-btn">Button 2</button>
+          <button type="button" id="btn-2" class="<%= prefix %>-btn">Button 2</button>
         </div>
 
         <nav role="navigation" class="<%= prefix %>-pagination <%= prefix %>-mt-8v" aria-label="Pagination">
@@ -143,7 +143,7 @@
 
   const Base = { template: `lorem ipsum dolor sit amet` };
   const Link = { template: `<a href="#" id="btn-4" data-<%= prefix %>-analytics-click="libellé du lien envoyé à l'analytics" id="link-attr-click">test</a>` };
-  const Button = { template: `<button id="btn-5" class="<%= prefix %>-btn">Button page 3</button>` };
+  const Button = { template: `<button type="button" id="btn-5" class="<%= prefix %>-btn">Button page 3</button>` };
 
   const routes = [
       { path: "/", component: Base },

--- a/src/component/accordion/template/ejs/accordion.ejs
+++ b/src/component/accordion/template/ejs/accordion.ejs
@@ -20,7 +20,7 @@
 
 <section class="<%= prefix %>-accordion">
   <h3 class="<%= prefix %>-accordion__title">
-    <button class="<%= prefix %>-accordion__btn" aria-expanded="<%= isExpanded %>" aria-controls="<%= accordion.id %>" ><%- accordion.label %></button>
+    <button type="button" class="<%= prefix %>-accordion__btn" aria-expanded="<%= isExpanded %>" aria-controls="<%= accordion.id %>" ><%- accordion.label %></button>
   </h3>
   <div class="<%= prefix %>-collapse" id="<%= accordion.id %>">
     <% if (accordion.content !== undefined) { %>

--- a/src/component/alert/example/layout-dynamic.ejs
+++ b/src/component/alert/example/layout-dynamic.ejs
@@ -4,7 +4,7 @@
   <h4><%= title %></h4>
   <% } %>
   <div class="<%= prefix %>-mb-6v" >
-    <button class="fr-btn" id="button-add" onclick="const component = document.createElement('div'); component.className = 'fr-my-8v'; component.innerHTML = decodeURIComponent('<%- encodeURIComponent(component) %>'); this.after(component);">Bouton d'ajout</button>
+    <button type="button" class="fr-btn" id="button-add" onclick="const component = document.createElement('div'); component.className = 'fr-my-8v'; component.innerHTML = decodeURIComponent('<%- encodeURIComponent(component) %>'); this.after(component);">Bouton d'ajout</button>
 
 </div>
   <% if (locals.snippet !== undefined) { %>

--- a/src/component/breadcrumb/template/ejs/breadcrumb.ejs
+++ b/src/component/breadcrumb/template/ejs/breadcrumb.ejs
@@ -19,7 +19,7 @@ if (breadcrumb.button === undefined) breadcrumb.button = 'Voir le fil d’Ariane
 %>
 
 <nav role="navigation" class="<%= prefix %>-breadcrumb" aria-label="vous êtes ici :">
-  <button class="<%= prefix %>-breadcrumb__button" aria-expanded="false"
+  <button type="button" class="<%= prefix %>-breadcrumb__button" aria-expanded="false"
     aria-controls="<%= breadcrumb.id %>"><%= breadcrumb.button %></button>
   <div class="<%= prefix %>-collapse" id="<%= breadcrumb.id %>">
     <ol class="<%= prefix %>-breadcrumb__list">

--- a/src/component/button/template/ejs/button.ejs
+++ b/src/component/button/template/ejs/button.ejs
@@ -43,6 +43,7 @@ const button = locals.button || {};
 let btnClasses = button.classes || [];
 let btnAttrs = button.attributes || {};
 btnAttrs.id = button.id || uniqueId('button');
+btnAttrs.type = button.type || 'button';
 btnClasses.push(prefix + '-btn');
 let action;
 const markup = button.markup || 'button';

--- a/src/component/card/template/ejs/content.ejs
+++ b/src/component/card/template/ejs/content.ejs
@@ -49,6 +49,7 @@ switch (actionMarkup) {
     break;
   default:
     action = actionMarkup;
+    if (actionMarkup === 'button') attributes.type = actionMarkup;
     break;
 }
 

--- a/src/component/connect/example/data/connect.json.ejs
+++ b/src/component/connect/example/data/connect.json.ejs
@@ -1,16 +1,16 @@
 <%
 const connect = locals.connect || {};
-const type = connect.type || 'default';
+const variant = connect.variant || 'default';
 
 const data = {
   markup: connect.markup || 'button',
   id: connect.id || uniqueId('connect'),
   login: getText('default.login', 'connect'),
-  brand: getText(`${type}.brand`, 'connect', true),
-  type: type,
+  brand: getText(`${variant}.brand`, 'connect', true),
+  variant: variant,
 };
 
-const linkType = hasText(`${type}.link`, 'connect') && hasText(`${type}.href`, 'connect') ? type : 'default';
+const linkType = hasText(`${variant}.link`, 'connect') && hasText(`${variant}.href`, 'connect') ? variant : 'default';
 data.link = connect.link ? connect.link : { label: getText(`${linkType}.link`, 'connect'), href: getText(`${linkType}.href`, 'connect') };
 
 %>

--- a/src/component/connect/example/index.ejs
+++ b/src/component/connect/example/index.ejs
@@ -4,7 +4,7 @@
 
 <%- sample('Bouton FranceConnect+', './sample/connect-plus', {}, !locals.isStandalone); %>
 
-<%- //sample('Bouton AgentConnect', './sample/connect-default', {connect: {type: 'agent'}}, true); %>
+<%- //sample('Bouton AgentConnect', './sample/connect-default', {connect: {variant: 'agent'}}, true); %>
 
 <%- //sample('Bouton FranceConnect en Anglais', './sample/connect-default', {connect: {lang: 'en'}}, true); %>
 

--- a/src/component/connect/example/sample/connect-agent.ejs
+++ b/src/component/connect/example/sample/connect-agent.ejs
@@ -1,4 +1,4 @@
 <%
-const data = { ...locals.connect, type: 'agent' };
+const data = { ...locals.connect, variant: 'agent' };
 %>
 <%- include('connect-default.ejs', {connect: data}) %>

--- a/src/component/connect/example/sample/connect-plus.ejs
+++ b/src/component/connect/example/sample/connect-plus.ejs
@@ -1,4 +1,4 @@
 <%
-const data = { ...locals.connect, type: 'plus' };
+const data = { ...locals.connect, variant: 'plus' };
 %>
 <%- include('connect-default.ejs', {connect: data}) %>

--- a/src/component/connect/template/ejs/connect.ejs
+++ b/src/component/connect/template/ejs/connect.ejs
@@ -3,12 +3,14 @@
 
 * connect.id (string) : id du bouton connect
 
+* connect.type (string) : attribut type du bouton connect
+
 * connect.link (object, required) paramètres du lien france connnect
   ** connect.link.href (string, required) : lien vers france connect
   ** connect.link.label (string, required) : Libellé "Qu'est ce que france connect ?"
   ** connect.link.attributes (object, optionnal) : Attributs supplémentaire sur le lien (ex: {target:'_blank'})
 
-* connect.type (string, optional) type du bouton connect
+* connect.variant (string, optional) variante du bouton connect
 
 * connect.lang (string, optional) langue du bouton connect
 
@@ -25,12 +27,13 @@
 const connect = locals.connect || {};
 const connectClasses = [];
 const connectAttrs = {};
+connectAttrs.type = connect.type || 'button';
 if (connect.id) connectAttrs.id = connect.id;
 const markup = connect.markup || 'button';
 if (markup === 'a') connectAttrs.href = '';
 connectClasses.push(prefix + '-connect');
 
-switch(connect.type) {
+switch(connect.variant) {
   case 'plus':
     connectClasses.push(prefix + '-connect--plus');
   break;

--- a/src/component/consent/template/ejs/manager.ejs
+++ b/src/component/consent/template/ejs/manager.ejs
@@ -44,7 +44,7 @@ let buttons = consent.buttons || [{label: 'Confirmer mes choix'}];
 
       <% if (finalities[finality].services) { %>
         <div class="<%= prefix %>-consent-service__collapse">
-          <button class="<%= prefix %>-consent-service__collapse-btn" aria-expanded="false" aria-describedby="<%= finalities[finality].id + '-legend' %>" aria-controls="<%= finalities[finality].id  %>-collapse"> Voir plus de détails</button>
+          <button type="button" class="<%= prefix %>-consent-service__collapse-btn" aria-expanded="false" aria-describedby="<%= finalities[finality].id + '-legend' %>" aria-controls="<%= finalities[finality].id  %>-collapse"> Voir plus de détails</button>
         </div>
 
         <div class="<%= prefix %>-consent-services <%= prefix %>-collapse" id="<%= finalities[finality].id  %>-collapse">

--- a/src/component/display/deprecated/example/index.ejs
+++ b/src/component/display/deprecated/example/index.ejs
@@ -52,6 +52,7 @@ let dataFooter = {
           markup: 'button',
           classes: [prefix + '-fi-theme-fill', prefix + '-link--icon-left'],
           attributes: {
+            type: 'button',
             'aria-controls': prefix + '-theme-modal-deprecated',
             [`data-${prefix}-opened`]: false,
           }

--- a/src/component/follow/example/data/newsletter-form.json.ejs
+++ b/src/component/follow/example/data/newsletter-form.json.ejs
@@ -18,6 +18,7 @@ data.newsletter = {
       },
       button: {
         id: uniqueId("newsletter-button"),
+        type: 'submit',
         label: "S\'abonner",
         title: "S‘abonner à notre lettre d’information",
       }

--- a/src/component/input/input-base/example/sample/inputs.ejs
+++ b/src/component/input/input-base/example/sample/inputs.ejs
@@ -18,7 +18,7 @@ for (let i = 1; i < 4; i++) elements.push({
   data: {
     ...input,
     id: `${id}-${i}`,
-    name: `${id}`
+    name: `${id}-${i}`
   }
 });
 

--- a/src/component/modal/example/sample/body/form.ejs
+++ b/src/component/modal/example/sample/body/form.ejs
@@ -1,4 +1,4 @@
 <form action="">
-  <%- include("../../../../input/input-base/example/sample/inputs", {input: {group: true, id:'text'}}); %>
-  <%- include("../../../../button/example/sample/button-default", {button: {title: 'Envoyer'}}); %>
+  <%- include("../../../../input/input-base/example/sample/inputs", {inputs: {id: 'modal-form'}}); %>
+  <%- include("../../../../button/example/sample/button-default", {button: {type: 'submit', title: 'Envoyer'}}); %>
 </form>

--- a/src/component/navigation/template/ejs/btn.ejs
+++ b/src/component/navigation/template/ejs/btn.ejs
@@ -10,4 +10,4 @@
 %>
 
 <% let menu = locals.menu || {} %>
-<button class="<%= prefix %>-nav__btn" aria-expanded="false" aria-controls="<%= menu.collapseId %>" <% if(menu.active) { %> aria-current="true" <% } %>><%- menu.label %></button>
+<button type="button" class="<%= prefix %>-nav__btn" aria-expanded="false" aria-controls="<%= menu.collapseId %>" <% if(menu.active) { %> aria-current="true" <% } %>><%- menu.label %></button>

--- a/src/component/sidemenu/template/ejs/btn.ejs
+++ b/src/component/sidemenu/template/ejs/btn.ejs
@@ -11,4 +11,4 @@ Paramètres de sidemenu btn
 %>
 
 <% let sidemenuBtn = locals.sidemenuBtn || {}; %>
-<button class="<%= prefix %>-sidemenu__btn" aria-expanded="false" aria-controls="<%= sidemenuBtn.collapseId %>" <% if(sidemenuBtn.active) { %> aria-current="true" <% } %>><%- sidemenuBtn.label %></button>
+<button type="button" class="<%= prefix %>-sidemenu__btn" aria-expanded="false" aria-controls="<%= sidemenuBtn.collapseId %>" <% if(sidemenuBtn.active) { %> aria-current="true" <% } %>><%- sidemenuBtn.label %></button>

--- a/src/component/sidemenu/template/ejs/sidemenu.ejs
+++ b/src/component/sidemenu/template/ejs/sidemenu.ejs
@@ -15,7 +15,7 @@
 
 <nav class="<%= prefix %>-sidemenu<% if(sidemenu.modifier){%> <%= prefix %>-sidemenu--<%- sidemenu.modifier %><%}%>" role="navigation" aria-labelledby="<%= sidemenu.titleId %>">
 	<div class="<%= prefix %>-sidemenu__inner">
-		<button class="<%= prefix %>-sidemenu__btn" aria-controls="<%= sidemenu.collapseId %>" aria-expanded="false">Dans cette rubrique</button>
+		<button type="button" class="<%= prefix %>-sidemenu__btn" aria-controls="<%= sidemenu.collapseId %>" aria-expanded="false">Dans cette rubrique</button>
 		<div class="<%= prefix %>-collapse" id="<%- sidemenu.collapseId %>">
 			<p class="<%= prefix %>-sidemenu__title" id="<%= sidemenu.titleId %>"><%- sidemenu.title %></p>
 			<%- include('./list', {sidemenuItems: sidemenu.items}); %>

--- a/src/component/tab/template/ejs/tab.ejs
+++ b/src/component/tab/template/ejs/tab.ejs
@@ -31,5 +31,5 @@ if (tab.icon !== undefined) {
 %>
 
 <li role="presentation">
-  <button id="<%= tab.id %>" <%- includeClasses(btn.classes) %> <%- includeAttrs(btn.attributes); %>><%= tab.label %></button>
+  <button type="button" id="<%= tab.id %>" <%- includeClasses(btn.classes) %> <%- includeAttrs(btn.attributes); %>><%= tab.label %></button>
 </li>

--- a/src/component/tag/template/ejs/tag.ejs
+++ b/src/component/tag/template/ejs/tag.ejs
@@ -11,6 +11,10 @@
 
 * tag.clickable (bool, optional) : si true, rend cliquable le composant
 
+* tag.pressable (bool, optional) : si true, rend sélectionnable le composant
+
+* tag.dismissible (bool, optional) : si true, rend supprimable le composant
+
 * tag.button (boolean, optional) : si true, le composant est un bouton
 
 * tag.size (string, optional) : taille du composant
@@ -67,10 +71,12 @@ switch(tag.type) {
   break;
   case 'pressable':
     if (tag.markup === undefined) tag.markup = 'button';
+    tagAttrs.type = 'button';
     tagAttrs["aria-pressed"] = tag.pressed === true ? 'true' : 'false';
   break;
   case 'dismissible':
     if (tag.markup === undefined) tag.markup = 'button';
+    tagAttrs.type = 'button';
     tagClasses.push(prefix + '-tag--dismiss');
     tagAttrs["aria-label"] = 'Retirer ' + contentPlaceholder('le filtre ' + tag.label);
   break;

--- a/src/component/tile/template/ejs/content.ejs
+++ b/src/component/tile/template/ejs/content.ejs
@@ -45,6 +45,7 @@ switch (actionMarkup) {
     break;
   default:
     action = actionMarkup;
+    if (actionMarkup === 'button') attributes.type = actionMarkup;
     break;
 }
 

--- a/src/component/transcription/template/ejs/transcription.ejs
+++ b/src/component/transcription/template/ejs/transcription.ejs
@@ -37,7 +37,7 @@ let collapseId = prefix + '-transcription-collapse-' + transcription.id;
 %>
 
 <div class="<%= prefix %>-transcription" <%- includeAttrs(attributes) %>>
-  <button class="<%= prefix %>-transcription__btn" aria-expanded="<%= isExpanded %>" aria-controls="<%= collapseId %>"><%= title %></button>
+  <button type="button" class="<%= prefix %>-transcription__btn" aria-expanded="<%= isExpanded %>" aria-controls="<%= collapseId %>"><%= title %></button>
   <div class="<%= prefix %>-collapse" id="<%= collapseId %>">
     <div class="<%= prefix %>-transcription__footer">
       <div class="<%= prefix %>-transcription__actions-group">

--- a/src/page/account/login/example/data/login.json.ejs
+++ b/src/page/account/login/example/data/login.json.ejs
@@ -95,6 +95,7 @@ elements.push({
       {
         label: getText('login.button', 'login'),
         kind: 1,
+        type: 'submit',
         classes: [prefix + '-mt-2v']
       }
     ]

--- a/tool/example/controls.ejs
+++ b/tool/example/controls.ejs
@@ -18,10 +18,10 @@
       </div>
     </div>
   </div>
-  <button class="<%= prefix %>-btn <%= prefix %>-btn--sm <%= prefix %>-fi-add-line" aria-expanded="false"
+  <button type="button" class="<%= prefix %>-btn <%= prefix %>-btn--sm <%= prefix %>-fi-add-line" aria-expanded="false"
           aria-controls="controls">Interface de contrôle
   </button>
-  <button class="<%= prefix %>-btn <%= prefix %>-btn--sm <%= prefix %>-fi-subtract-line" aria-controls="controls">
+  <button type="button" class="<%= prefix %>-btn <%= prefix %>-btn--sm <%= prefix %>-fi-subtract-line" aria-controls="controls">
     Fermer
   </button>
 </div>


### PR DESCRIPTION
- ajoute le type `button` aux boutons par défaut
- met à jour les exemples des modèles de pages analytics et page de connexion
- met à jour les snippets d'exemple des composants : accordéon, alerte, fil d'ariane, bouton, bouton France Connect, carte, gestionnaire de consentement, paramètres d'affichage, champ de saisie, lettre d'information, navigation principale, menu latéral, onglets, tag, tuile et transcription
- remplace l'attribut `type` par `variant` dans le template du Bouton France Connect et ajoute le type `button` par défaut