### PR TITLE
🐛 fix(link): alignement icone link close deprécié [DS-3837]

### DIFF
--- a/src/component/link/deprecated/style/module/_close.scss
+++ b/src/component/link/deprecated/style/module/_close.scss
@@ -5,7 +5,7 @@
 
 #{ns(link--close)} {
   @include nest-btn(sm, right, close-line, null, false);
-  display: flex;
+  @include display-flex(row, center);
   @include margin-left(auto);
   @include margin-right(-4v);
 }


### PR DESCRIPTION
- Correction de l'alignement vertical de l'icone du lien de fermeture déprécié (maintenant btn-close)