### PR TITLE
🐛 fix(header): retire aria-label sur modales désactivées

### DIFF
--- a/src/component/header/script/header/header-modal.js
+++ b/src/component/header/script/header/header-modal.js
@@ -18,6 +18,10 @@ class HeaderModal extends api.core.Instance {
     const modal = this.element.getInstance('Modal');
     if (!modal) return;
     modal.isEnabled = true;
+    this._hasAriaLabelledByData = this.getAttribute('data-fr-aria-labelledby');
+    this._hasAriaLabelData = this.getAttribute('data-fr-aria-label');
+    if (this._hasAriaLabelledByData) this.setAttribute('aria-labelledby', this._hasAriaLabelledByData);
+    if (this._hasAriaLabelData) this.setAttribute('aria-label', this._hasAriaLabelData);
     this.listenClick({ capture: true });
   }
 
@@ -26,6 +30,14 @@ class HeaderModal extends api.core.Instance {
     if (!modal) return;
     modal.conceal();
     modal.isEnabled = false;
+    if (this.hasAttribute('aria-labelledby')) {
+      if (!this._hasAriaLabelledByData) this.setAttribute('data-fr-aria-labelledby', this.getAttribute('aria-labelledby'));
+      this.removeAttribute('aria-labelledby');
+    };
+    if (this.hasAttribute('aria-label')) {
+      if (!this._hasAriaLabelData) this.setAttribute('data-fr-aria-label', this.getAttribute('aria-label'));
+      this.removeAttribute('aria-label');
+    }
     this.unlistenClick({ capture: true });
   }
 


### PR DESCRIPTION
- En desktop, lorsque les modales de menu et recherche sont désactivés, les attributs aria-label et aria-labelledby doivent être retirés. #1017 