### PR TITLE
🐛 fix(core): bug firefox menu passe en arrière plan [DS-3852]

### DIFF
--- a/src/core/style/collapse/_tool.scss
+++ b/src/core/style/collapse/_tool.scss
@@ -15,6 +15,10 @@
   // max-height: 0;
   max-height: var(--collapse-max-height);
 
+  &--expanded {
+    overflow: auto;
+  }
+
   @include preference.reduce-motion {
     transition: none;
   }


### PR DESCRIPTION
- Ajout d'un overflow auto sur le collapse pour éviter le passage des menus sous des éléments survolés ou le texte surligné #1014