### PR TITLE
🐛 💥 fix(table): correction de l'attribut aria-sort [DS-3858]

### DIFF
--- a/src/component/button/style/_legacy.scss
+++ b/src/component/button/style/_legacy.scss
@@ -79,10 +79,9 @@
 
   #{ns(btn--sort)} {
     @include icon-legacy(arrow-up-down-line, sm);
-    @include animate.rotate('&[aria-sorting='desc']');
 
-    &[aria-sorting='asc'],
-    &[aria-sorting='desc'] {
+    &[aria-sort='ascending'],
+    &[aria-sort='descending'] {
       @include icon-legacy(arrow-up-line, sm);
     }
   }

--- a/src/component/button/style/module/_sort.scss
+++ b/src/component/button/style/module/_sort.scss
@@ -7,10 +7,10 @@
 
 #{ns(btn--sort)} {
   @include nest-btn(sm, only, arrow-up-down-line, null, false);
-  @include animate.rotate('&[aria-sorting='desc']');
+  @include animate.rotate('&[aria-sort='descending']');
 
-  &[aria-sorting='asc'],
-  &[aria-sorting='desc'] {
+  &[aria-sort='ascending'],
+  &[aria-sort='descending'] {
     @include nest-btn(sm, only, arrow-up-line, null, false);
   }
 }

--- a/src/component/table/example/data/data-miscellaneous.json.ejs
+++ b/src/component/table/example/data/data-miscellaneous.json.ejs
@@ -33,13 +33,13 @@ const thead = [
       content: `<div class="${prefix}-cell--sort">${getTitleCell()} ${getButton({id: `${table.id}-thead-sort-asc-desc`, label: `${getText('data.cell.action.sort', 'table')}`, classes: [`${prefix}-btn--sort`]})}</div>`
     },
     {
-      content: getButton({id: `${table.id}-thead-sort-desc`, label: `${getText('data.cell.action.sort', 'table')}`, classes: [`${prefix}-btn--sort`], attributes: {'aria-sorting': 'desc'}})
+      content: getButton({id: `${table.id}-thead-sort-descending`, label: `${getText('data.cell.action.sort', 'table')}`, classes: [`${prefix}-btn--sort`], attributes: {'aria-sort': 'descending'}})
     },
     {
       content: `${getTextCell()} ${getButton({label: getText('data.cell.text', 'table'), classes: [`${prefix}-ml-2v`, `${prefix}-btn--tooltip`], tooltip: {id: `${table.id}-thead-tooltip`, content: lorem()}})}`
     },
     {
-      content: getButton({id: `${table.id}-thead-sort-asc`, label: `${getText('data.cell.action.sort', 'table')}`, classes: [`${prefix}-btn--sort`], attributes: {'aria-sorting': 'asc'}})
+      content: getButton({id: `${table.id}-thead-sort-ascending`, label: `${getText('data.cell.action.sort', 'table')}`, classes: [`${prefix}-btn--sort`], attributes: {'aria-sort': 'ascending'}})
     },
     {
       content: getBadge({id: `${table.id}-thead-badge`, type: 'info', label: getText('data.cell.label', 'table')})


### PR DESCRIPTION
- remplace l'attribut `aria-sorting` par `aria-sort` sur les bouton de tri avec comme valeurs `descending` et `ascending` ( fix #1026 )
- met à jour la page d'exemple des tableaux