### PR TITLE
🐛 fix(table): bordure disparait lors d'un rowspan en dernière position [DS-3862] 

### DIFF
--- a/src/dsfr/component/table/style/_scheme.scss
+++ b/src/dsfr/component/table/style/_scheme.scss
@@ -27,11 +27,6 @@
             &[role='columnheader'] {
               @include color.background-image((border plain grey) (border plain grey), (legacy: $legacy));
             }
-
-            &:last-child {
-              @include color.background(alt grey, (legacy: $legacy));
-              @include color.background-image((border plain grey), (legacy: $legacy));
-            }
           }
         }
 

--- a/src/dsfr/component/table/style/module/_variants.scss
+++ b/src/dsfr/component/table/style/module/_variants.scss
@@ -64,12 +64,6 @@
         background-size: 100% 1px, 1px 100%;
         background-repeat: no-repeat, no-repeat;
         background-position: 0 100%, 100% 0;
-
-        &:last-child {
-          background-size: 100% 1px;
-          background-repeat: no-repeat;
-          background-position: 100% 100%;
-        }
       }
     }
   }


### PR DESCRIPTION
- Correction de la bordure lorsqu'un rowspan est en dernière position. #1035