### PR TITLE
🐛 fix(storybook): corrige tooltip [DSFR-53]

### DIFF
--- a/src/dsfr/component/tooltip/template/stories/tooltip.stories.js
+++ b/src/dsfr/component/tooltip/template/stories/tooltip.stories.js
@@ -31,10 +31,19 @@ export default {
 };
 
 export const TooltipStory = {
+  tags: ['!autodocs'],
   args: {}
 };
 
-export const TooltipHoverStory = {
+export const TooltipClickButtonStory = {
+  tags: ['autodocs', '!dev'],
+  args: {
+    id: uniqueId('tooltip'),
+    type: 'infobulle'
+  }
+};
+
+export const TooltipHoverLinkStory = {
   tags: ['autodocs', '!dev'],
   args: {
     id: uniqueId('tooltip')


### PR DESCRIPTION
- Corrige l'affichage du tooltip sur la story par défaut,
- Ajoute une story pour l'infobulle actionnable au clic.