### PR TITLE
🐛 fix(toggle): Corrige la taille du focus sur le bouton [DSFR-11]

### DIFF
--- a/src/dsfr/component/toggle/style/module/_default.scss
+++ b/src/dsfr/component/toggle/style/module/_default.scss
@@ -124,7 +124,7 @@
     @include before('', block) {
       flex-shrink: 0;
       height: spacing.space(calc(5v + 1px));
-      @include padding-top(7v);
+      @include padding-top(6v);
       @include text-style(xs);
       border-radius: spacing.space(3v);
       @include margin-right(8v);


### PR DESCRIPTION
- Corrige la taille du focus pour que la hauteur du focus corresponde à la hauteur du bouton. 