### PR TITLE
✨ build(release): retrait de storybook dans la release [DSFR-58]

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "/i18n",
     "/example",
     "/doc",
-    "/storybook",
     "/.config",
     "SECURITY.md",
     "CONTRIBUTING.md"


### PR DESCRIPTION
- Pour réduire le poids du package @gouvfr/dsfr, storybook n'est plus exporté