### PR TITLE
🐛 fix(select): correction option par défaut & navigation clavier [DSFR-63]

### DIFF
--- a/src/dsfr/component/select/template/ejs/select.ejs
+++ b/src/dsfr/component/select/template/ejs/select.ejs
@@ -80,7 +80,7 @@ if (select.disabled === true) attributes['disabled'] = '';
 
 <select <%- includeClasses(classes); %> <%- includeAttrs(attributes); %> id="<%= select.id %>" name="<%= select.name || select.id %>">
   <% if (select.placeholder != undefined) { %>
-  <option value="" selected disabled hidden><%= select.placeholder %></option>
+  <option value="" selected disabled><%= select.placeholder %></option>
   <% } %>
 
   <% if (select.optionGroups != undefined) { %>


### PR DESCRIPTION
BREAKING CHANGE :
- Retrait de l'attribut hidden sur la première option du select. Cela rend la navigation au clavier impossible sur firefox.