### PR TITLE
🐛 fix(core): disclosure evenement dsfr.conceal [DSFR-71]

### DIFF
--- a/src/dsfr/component/accordion/example/sample/accordions-group.ejs
+++ b/src/dsfr/component/accordion/example/sample/accordions-group.ejs
@@ -6,7 +6,6 @@ for (let i = 0; i < 6; i++) accordions.push({
   label: 'Libellé accordéon',
   content: randomContent(),
   id: uniqueId('accordion'),
-  isExpanded: true
 });
 
 accordionsGroup = {

--- a/src/dsfr/core/script/disclosure/disclosure.js
+++ b/src/dsfr/core/script/disclosure/disclosure.js
@@ -122,7 +122,7 @@ class Disclosure extends Instance {
 
   set isDisclosed (value) {
     if (this._isDisclosed === value || (!this.isEnabled && value === true)) return;
-    if (this._isPristine) this.dispatch(value ? DisclosureEvent.DISCLOSE : DisclosureEvent.CONCEAL, this);
+    if (!this._isPristine) this.dispatch(value ? DisclosureEvent.DISCLOSE : DisclosureEvent.CONCEAL, this);
     this._isDisclosed = value;
     if (value) this.addClass(this.modifier);
     else this.removeClass(this.modifier);

--- a/src/dsfr/core/script/disclosure/disclosure.js
+++ b/src/dsfr/core/script/disclosure/disclosure.js
@@ -122,7 +122,7 @@ class Disclosure extends Instance {
 
   set isDisclosed (value) {
     if (this._isDisclosed === value || (!this.isEnabled && value === true)) return;
-    this.dispatch(value ? DisclosureEvent.DISCLOSE : DisclosureEvent.CONCEAL, this);
+    if (this._isPristine) this.dispatch(value ? DisclosureEvent.DISCLOSE : DisclosureEvent.CONCEAL, this);
     this._isDisclosed = value;
     if (value) this.addClass(this.modifier);
     else this.removeClass(this.modifier);


### PR DESCRIPTION
- Pour les composants de type closure, l'événement de fermeture n'est plus lancé au chargement du composant (accordion, modal, etc)