### PR TITLE
🐛 fix(storybook): nom du type de bandeau attentat dans le storybook

### DIFF
--- a/src/dsfr/component/notice/template/ejs/notice.ejs
+++ b/src/dsfr/component/notice/template/ejs/notice.ejs
@@ -9,7 +9,7 @@
 
 * notice.link (object, optional): Paramètres du lien
 
-* notice.type (String, optional): Type de bandeau [info/warning/alert/weather-orange/weather-red/weather-purple/kidnapping/cyberattack/vigipirate/witness]
+* notice.type (String, optional): Type de bandeau [info/warning/alert/weather-orange/weather-red/weather-purple/kidnapping/cyberattack/attack/witness]
 
 * notice.icon (String, optional): Nom de l'icône du bandeau ou false pour ne pas afficher d'icône
 

--- a/src/dsfr/component/notice/template/stories/notice-arg-types.js
+++ b/src/dsfr/component/notice/template/stories/notice-arg-types.js
@@ -57,12 +57,12 @@ const noticeArgTypes = {
         'weather-purple': 'weather-purple',
         kidnapping: 'kidnapping',
         cyberattack: 'cyberattack',
-        vigipirate: 'vigipirate',
+        attack: 'attack',
         witness: 'witness'
       }
     },
     description: 'Type de bandeau',
-    options: ['info', 'warning', 'alert', 'weather-orange', 'weather-purple', 'kidnapping', 'cyberattack', 'vigipirate', 'witness'],
+    options: ['info', 'warning', 'alert', 'weather-orange', 'weather-purple', 'kidnapping', 'cyberattack', 'attack', 'witness'],
     table: {
       category: 'type'
     }


### PR DESCRIPTION
Dans le storybook, le nom du type de bandeau utilisé pour les alertes attentat est incorrect. 

`vigipirate` -> `attack` 