### PR TITLE
✨ feat: évolution du rendu à l'impression des composants [DSFR-78]

### DIFF
--- a/.stylelintrc.yml
+++ b/.stylelintrc.yml
@@ -5,6 +5,7 @@
     "stylelint-scss"
   ],
   "rules": {
+    "property-no-unknown": [true, { "ignoreProperties": ["print-color-adjust"] }],
     "at-rule-no-unknown": null,
     "scss/at-rule-no-unknown": true,
     "no-descending-specificity": null,

--- a/src/dsfr/component/accordion/print.scss
+++ b/src/dsfr/component/accordion/print.scss
@@ -5,9 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _accordion-scheme('print');
-
   @import 'style/print';
 }

--- a/src/dsfr/component/accordion/style/_print.scss
+++ b/src/dsfr/component/accordion/style/_print.scss
@@ -1,9 +1,24 @@
+@use 'src/module/color';
+
 #{ns(accordion)} {
-  &__btn::after {
-    transform: rotate(-180deg);
+  box-shadow: inset 0 0 0 1px var(--border-default-grey);
+
+  @include before {
+    box-shadow: none;
   }
 
-  #{ns(collapse)}:not(#{ns(collapse--expanded)}) {
+  &__btn {
+    box-shadow: inset 0 0 0 1px var(--border-default-grey);
+    page-break-after: avoid;
+
+    @include after {
+      -webkit-print-color-adjust: exact;
+      print-color-adjust: exact;
+      transform: rotate(-180deg);
+    }
+  }
+
+  #{ns(collapse)} {
     --collapse-max-height: none !important;
     --collapse: inherit !important;
 

--- a/src/dsfr/component/alert/print.scss
+++ b/src/dsfr/component/alert/print.scss
@@ -5,7 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _alert-scheme('print');
+  @import 'style/print';
 }

--- a/src/dsfr/component/alert/style/_print.scss
+++ b/src/dsfr/component/alert/style/_print.scss
@@ -1,0 +1,13 @@
+////
+/// Alert Print
+/// @group alert
+////
+
+#{ns(alert)} {
+  -webkit-print-color-adjust: exact;
+  print-color-adjust: exact;
+
+  #{ns(btn--close)} {
+    display: none;
+  }
+}

--- a/src/dsfr/component/badge/print.scss
+++ b/src/dsfr/component/badge/print.scss
@@ -5,7 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _badge-scheme('print');
+  @import 'style/print';
 }

--- a/src/dsfr/component/badge/style/_print.scss
+++ b/src/dsfr/component/badge/style/_print.scss
@@ -1,0 +1,13 @@
+////
+/// Badge Print
+/// @group badge
+////
+
+#{ns(badge)} {
+  border: solid 1px currentColor;
+
+  @include before {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+}

--- a/src/dsfr/component/breadcrumb/print.scss
+++ b/src/dsfr/component/breadcrumb/print.scss
@@ -5,9 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _breadcrumb-scheme('print');
-
   @import 'style/print';
 }

--- a/src/dsfr/component/button/print.scss
+++ b/src/dsfr/component/button/print.scss
@@ -5,9 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _button-scheme('print');
-
   @import 'style/print';
 }

--- a/src/dsfr/component/button/style/_print.scss
+++ b/src/dsfr/component/button/style/_print.scss
@@ -1,11 +1,9 @@
+////
+/// Button Print
+/// @group button
+////
+
 #{ns(btn)} {
-  &--secondary,
-  &--tertiary,
-  &--tertiary-no-outline,
-  &--close,
-  &--display,
-  &--fullscreen,
-  &--tooltip {
-    background-color: transparent;
-  }
+  -webkit-print-color-adjust: exact;
+  print-color-adjust: exact;
 }

--- a/src/dsfr/component/callout/print.scss
+++ b/src/dsfr/component/callout/print.scss
@@ -5,7 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _callout-scheme('print');
+  @import 'style/print';
 }

--- a/src/dsfr/component/callout/style/_print.scss
+++ b/src/dsfr/component/callout/style/_print.scss
@@ -1,0 +1,12 @@
+////
+/// Callout Print
+/// @group callout
+////
+
+#{ns(callout)} {
+  page-break-inside: avoid;
+  background: transparent;
+  background-image: none;
+  border: 1px solid var(--border-default-grey);
+  border-left: 0.25rem solid var(--border-default-grey);
+}

--- a/src/dsfr/component/card/print.scss
+++ b/src/dsfr/component/card/print.scss
@@ -5,9 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _card-scheme('print');
-
   @import 'style/print';
 }

--- a/src/dsfr/component/card/style/_print.scss
+++ b/src/dsfr/component/card/style/_print.scss
@@ -1,4 +1,8 @@
 #{ns(card)} {
+  page-break-inside: avoid;
+  border: 1px solid var(--border-default-grey);
+  background-image: none !important;
+
   &__detail,
   &__desc {
     @include text-style(md);
@@ -6,5 +10,10 @@
 
   &__detail {
     line-height: 1rem !important;
+
+    @include before {
+      -webkit-print-color-adjust: exact;
+      print-color-adjust: exact;
+    }
   }
 }

--- a/src/dsfr/component/checkbox/print.scss
+++ b/src/dsfr/component/checkbox/print.scss
@@ -5,7 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _checkbox-scheme('print');
+  @import 'style/print';
 }

--- a/src/dsfr/component/checkbox/style/_print.scss
+++ b/src/dsfr/component/checkbox/style/_print.scss
@@ -1,0 +1,21 @@
+////
+/// Card Print
+/// @group card
+////
+
+#{ns(checkbox-group)} {
+  input[type=checkbox] + #{ns(label)} {
+    @include before {
+      border: 1px solid var(--border-default-grey);
+      border-radius: 4px;
+      background-image: none;
+    }
+  }
+
+  input[type=checkbox]:checked + #{ns(label)} {
+    @include before {
+      -webkit-print-color-adjust: exact;
+      print-color-adjust: exact;
+    }
+  }
+}

--- a/src/dsfr/component/connect/print.scss
+++ b/src/dsfr/component/connect/print.scss
@@ -5,9 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _connect-scheme('print');
-
   @import 'style/print';
 }

--- a/src/dsfr/component/connect/style/_print.scss
+++ b/src/dsfr/component/connect/style/_print.scss
@@ -1,4 +1,7 @@
 #{ns-group(connect)} {
+  -webkit-print-color-adjust: exact;
+  print-color-adjust: exact;
+
   p {
     @include text-style(md);
   }

--- a/src/dsfr/component/consent/print.scss
+++ b/src/dsfr/component/consent/print.scss
@@ -5,9 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _consent-scheme('print');
-
   @import 'style/print';
 }

--- a/src/dsfr/component/content/print.scss
+++ b/src/dsfr/component/content/print.scss
@@ -5,9 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _content-scheme('print');
-
   @import 'style/print';
 }

--- a/src/dsfr/component/follow/print.scss
+++ b/src/dsfr/component/follow/print.scss
@@ -5,7 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _follow-scheme('print');
+  @import 'style/print';
 }

--- a/src/dsfr/component/follow/style/_print.scss
+++ b/src/dsfr/component/follow/style/_print.scss
@@ -1,0 +1,8 @@
+////
+/// Follow Print
+/// @group follow
+////
+
+#{ns(follow)} {
+  display: none;
+}

--- a/src/dsfr/component/footer/print.scss
+++ b/src/dsfr/component/footer/print.scss
@@ -5,9 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _footer-scheme('print');
-
   @import 'style/print';
 }

--- a/src/dsfr/component/form/print.scss
+++ b/src/dsfr/component/form/print.scss
@@ -5,9 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _form-scheme('print');
-
   @import 'style/print';
 }

--- a/src/dsfr/component/form/style/_print.scss
+++ b/src/dsfr/component/form/style/_print.scss
@@ -1,4 +1,10 @@
-#{ns(hint-text)},
-#{ns(message)} {
+#{ns(hint-text)} {
   @include text-style(md);
+}
+
+#{ns(message)} {
+  @include before {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
 }

--- a/src/dsfr/component/header/print.scss
+++ b/src/dsfr/component/header/print.scss
@@ -5,9 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _header-scheme('print');
-
   @import 'style/print';
 }

--- a/src/dsfr/component/highlight/print.scss
+++ b/src/dsfr/component/highlight/print.scss
@@ -5,7 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _highlight-scheme('print');
+  @import 'style/print';
 }

--- a/src/dsfr/component/highlight/style/_print.scss
+++ b/src/dsfr/component/highlight/style/_print.scss
@@ -1,0 +1,9 @@
+////
+/// Highlight Print
+/// @group Highlight
+////
+
+#{ns(highlight)} {
+  border-left: 4px solid var(--border-default-grey);
+  background-image: none;
+}

--- a/src/dsfr/component/input/input-base/print.scss
+++ b/src/dsfr/component/input/input-base/print.scss
@@ -5,7 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _input-scheme('print');
+  @import 'style/print';
 }

--- a/src/dsfr/component/input/input-base/style/_print.scss
+++ b/src/dsfr/component/input/input-base/style/_print.scss
@@ -1,0 +1,16 @@
+////
+/// Input Print
+/// @group Input
+////
+
+#{ns(input-group)} {
+  @include before {
+    background-image: none;
+  }
+
+  input,
+  textarea {
+    background-color: transparent;
+    border: 1px solid var(--border-default-grey);
+  }
+}

--- a/src/dsfr/component/link/print.scss
+++ b/src/dsfr/component/link/print.scss
@@ -5,7 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _link-scheme('print');
+  @import 'style/print';
 }

--- a/src/dsfr/component/link/style/_print.scss
+++ b/src/dsfr/component/link/style/_print.scss
@@ -1,0 +1,11 @@
+////
+/// Link Print
+/// @group Link
+////
+
+#{ns(link)} {
+  @include _pseudo(before after) {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+}

--- a/src/dsfr/component/logo/print.scss
+++ b/src/dsfr/component/logo/print.scss
@@ -5,9 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _logo-scheme('print');
-
   @import 'style/print';
 }

--- a/src/dsfr/component/logo/style/_print.scss
+++ b/src/dsfr/component/logo/style/_print.scss
@@ -1,5 +1,4 @@
 #{ns(logo)} {
-  &::after {
-    background-position: 0 calc(100% + 1.875rem) !important;
-  }
+  -webkit-print-color-adjust: exact;
+  print-color-adjust: exact;
 }

--- a/src/dsfr/component/modal/print.scss
+++ b/src/dsfr/component/modal/print.scss
@@ -5,9 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _modal-scheme('print');
-
   @import 'style/print';
 }

--- a/src/dsfr/component/modal/style/_print.scss
+++ b/src/dsfr/component/modal/style/_print.scss
@@ -1,3 +1,17 @@
 #{ns(modal)} {
-  display: none;
+  background-color: white;
+  flex-direction: column-reverse;
+
+  &__body {
+    border: 1px solid var(--border-default-grey);
+    margin-bottom: auto;
+    height: max-content;
+    max-height: max-content !important;
+  }
+
+  &__header {
+    #{ns(btn--close)} {
+      display: none;
+    }
+  }
 }

--- a/src/dsfr/component/notice/print.scss
+++ b/src/dsfr/component/notice/print.scss
@@ -5,7 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _notice-scheme('print');
+  @import 'style/print';
 }

--- a/src/dsfr/component/notice/style/_print.scss
+++ b/src/dsfr/component/notice/style/_print.scss
@@ -1,0 +1,38 @@
+////
+/// Notice Print
+/// @group Notice
+////
+
+#{ns(notice)} {
+  border-top: 1px solid var(--border-default-grey);
+  border-bottom: 1px solid var(--border-default-grey);
+  margin-bottom: 1rem;
+
+  #{ns(btn--close)} {
+    display: none;
+  }
+
+  &__title {
+    @include before {
+      -webkit-print-color-adjust: exact;
+      print-color-adjust: exact;
+    }
+  }
+
+  &--weather-red,
+  &--attack {
+    color: var(--text-default-error);
+    background: none;
+  }
+
+  &--witness,
+  &--cyberattack {
+    color: var(--text-default-grey);
+    background: none;
+  }
+
+  &--weather-purple {
+    color: var(--text-label-purple-glycine);
+    background: none;
+  }
+}

--- a/src/dsfr/component/pagination/print.scss
+++ b/src/dsfr/component/pagination/print.scss
@@ -5,7 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _pagination-scheme('print');
+  @import 'style/print';
 }

--- a/src/dsfr/component/pagination/style/_print.scss
+++ b/src/dsfr/component/pagination/style/_print.scss
@@ -1,0 +1,21 @@
+////
+/// Pagination Print
+/// @group Pagination
+////
+
+#{ns(pagination)} {
+  &__link[aria-current]:not([aria-current=false]) {
+    font-weight: bold;
+    background: none;
+    color: black;
+    border: 1px solid;
+  }
+
+  &__link--prev,
+  &__link--next {
+    @include _pseudo(before after) {
+      -webkit-print-color-adjust: exact;
+      print-color-adjust: exact;
+    }
+  }
+}

--- a/src/dsfr/component/password/print.scss
+++ b/src/dsfr/component/password/print.scss
@@ -5,7 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _password-scheme('print');
+  @import 'style/print';
 }

--- a/src/dsfr/component/password/style/_print.scss
+++ b/src/dsfr/component/password/style/_print.scss
@@ -1,0 +1,11 @@
+////
+/// Password Print
+/// @group Password
+////
+
+#{ns(password)} {
+  input {
+    background-color: transparent;
+    border: 1px solid var(--border-default-grey);
+  }
+}

--- a/src/dsfr/component/print.scss
+++ b/src/dsfr/component/print.scss
@@ -4,6 +4,7 @@
 ////
 
 @import 'upload/print';
+@import 'range/print';
 @import 'accordion/print';
 @import 'badge/print';
 @import 'logo/print';

--- a/src/dsfr/component/quote/print.scss
+++ b/src/dsfr/component/quote/print.scss
@@ -5,9 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _quote-scheme('print');
-
   @import 'style/print';
 }

--- a/src/dsfr/component/quote/style/_print.scss
+++ b/src/dsfr/component/quote/style/_print.scss
@@ -4,4 +4,8 @@
   figcaption li {
     @include text-style(md);
   }
+
+  @include before {
+    display: none;
+  }
 }

--- a/src/dsfr/component/radio/main.scss
+++ b/src/dsfr/component/radio/main.scss
@@ -3,10 +3,6 @@
 /// @group radio
 ////
 
-/* ¯¯¯¯¯¯¯¯¯ *\
-  RADIO
-\* ˍˍˍˍˍˍˍˍˍ */
-
 @use 'src/module/path';
 @use 'src/module/shame/media-query';
 

--- a/src/dsfr/component/radio/print.scss
+++ b/src/dsfr/component/radio/print.scss
@@ -5,7 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _radio-scheme('print');
+  @import 'style/print';
 }

--- a/src/dsfr/component/radio/style/_print.scss
+++ b/src/dsfr/component/radio/style/_print.scss
@@ -1,0 +1,19 @@
+////
+/// Radio Print
+/// @group Radio
+////
+
+#{ns(radio-group)} {
+  page-break-inside: avoid;
+
+  input[type=radio]:checked + label,
+  input[type=radio] + label {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  #{ns(radio-rich__pictogram)} {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+}

--- a/src/dsfr/component/range/print.scss
+++ b/src/dsfr/component/range/print.scss
@@ -1,0 +1,9 @@
+////
+/// Range Print
+/// @group range
+////
+
+@media print {
+  @import 'index';
+  @import 'style/print';
+}

--- a/src/dsfr/component/range/style/_print.scss
+++ b/src/dsfr/component/range/style/_print.scss
@@ -1,0 +1,19 @@
+////
+/// Range Print
+/// @group Range
+////
+
+#{ns(range-group)} {
+  @include before {
+    background-image: none !important;
+  }
+}
+
+#{ns(range)}[data-fr-js-range] {
+  @include after {
+    background-color: transparent !important;
+    box-shadow: none !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+}

--- a/src/dsfr/component/search/print.scss
+++ b/src/dsfr/component/search/print.scss
@@ -5,7 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _search-scheme('print');
+  @import 'style/print';
 }

--- a/src/dsfr/component/search/style/_print.scss
+++ b/src/dsfr/component/search/style/_print.scss
@@ -1,0 +1,12 @@
+////
+/// Search Print
+/// @group Search
+////
+
+#{ns(search-bar)} {
+  input {
+    background-color: transparent;
+    border-top: 1px solid var(--border-default-grey);
+    border-left: 1px solid var(--border-default-grey);
+  }
+}

--- a/src/dsfr/component/select/print.scss
+++ b/src/dsfr/component/select/print.scss
@@ -5,7 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _select-scheme('print');
+  @import 'style/print';
 }

--- a/src/dsfr/component/select/style/_print.scss
+++ b/src/dsfr/component/select/style/_print.scss
@@ -1,0 +1,17 @@
+////
+/// Select Print
+/// @group Select
+////
+
+#{ns(select-group)} {
+  @include before {
+    background-image: none !important;
+  }
+}
+
+#{ns(select)} {
+  background-color: transparent;
+  border: 1px solid var(--border-default-grey);
+  -webkit-print-color-adjust: exact;
+  print-color-adjust: exact;
+}

--- a/src/dsfr/component/share/print.scss
+++ b/src/dsfr/component/share/print.scss
@@ -5,9 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _share-scheme('print');
-
   @import 'style/print';
 }

--- a/src/dsfr/component/sidemenu/print.scss
+++ b/src/dsfr/component/sidemenu/print.scss
@@ -5,9 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _sidemenu-scheme('print');
-
   @import 'style/print';
 }

--- a/src/dsfr/component/skiplink/print.scss
+++ b/src/dsfr/component/skiplink/print.scss
@@ -5,9 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _skiplink-scheme('print');
-
   @import 'style/print';
 }

--- a/src/dsfr/component/stepper/print.scss
+++ b/src/dsfr/component/stepper/print.scss
@@ -5,9 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _stepper-scheme('print');
-
   @import 'style/print';
 }

--- a/src/dsfr/component/stepper/style/_print.scss
+++ b/src/dsfr/component/stepper/style/_print.scss
@@ -1,4 +1,9 @@
 #{ns(stepper)} {
+  &__steps {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
   &__state,
   &__details {
     @include text-style(md);

--- a/src/dsfr/component/summary/print.scss
+++ b/src/dsfr/component/summary/print.scss
@@ -5,9 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _summary-scheme('print');
-
   @import 'style/print';
 }

--- a/src/dsfr/component/tab/print.scss
+++ b/src/dsfr/component/tab/print.scss
@@ -5,7 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _tab-scheme('print');
+  @import 'style/print';
 }

--- a/src/dsfr/component/tab/style/_print.scss
+++ b/src/dsfr/component/tab/style/_print.scss
@@ -1,0 +1,19 @@
+////
+/// Tab Print
+/// @group Tab
+////
+
+#{ns(tabs)} {
+  page-break-inside: avoid;
+
+  &__tab {
+    background-color: transparent;
+    border: 1px solid var(--border-default-grey);
+    background-image: none !important;
+
+    &[aria-selected=true] {
+      border-top: 2px solid var(--border-active-blue-france);
+      border-bottom: none;
+    }
+  }
+}

--- a/src/dsfr/component/table/print.scss
+++ b/src/dsfr/component/table/print.scss
@@ -5,9 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _table-scheme('print');
-
   @import 'style/print';
 }

--- a/src/dsfr/component/table/style/_print.scss
+++ b/src/dsfr/component/table/style/_print.scss
@@ -1,4 +1,7 @@
 #{ns(table)} {
+  -webkit-print-color-adjust: exact;
+  print-color-adjust: exact;
+
   td,
   th {
     @include text-style(md);

--- a/src/dsfr/component/tag/print.scss
+++ b/src/dsfr/component/tag/print.scss
@@ -5,7 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _tag-scheme('print');
+  @import 'style/print';
 }

--- a/src/dsfr/component/tag/style/_print.scss
+++ b/src/dsfr/component/tag/style/_print.scss
@@ -1,0 +1,9 @@
+////
+/// Tag Print
+/// @group tag
+////
+
+#{ns(tag)} {
+  -webkit-print-color-adjust: exact;
+  print-color-adjust: exact;
+}

--- a/src/dsfr/component/tile/print.scss
+++ b/src/dsfr/component/tile/print.scss
@@ -5,9 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _tile-scheme('print');
-
   @import 'style/print';
 }

--- a/src/dsfr/component/tile/style/_print.scss
+++ b/src/dsfr/component/tile/style/_print.scss
@@ -1,10 +1,40 @@
+////
+/// Tile Print
+/// @group tile
+////
+
 #{ns(tile)},
 #{ns(tile--sm)} {
-
   #{ns(tile)}__desc,
   #{ns(tile)}__detail,
   &__desc,
   &__detail {
     @include text-style(md);
+  }
+}
+
+#{ns(tile)} {
+  page-break-inside: avoid;
+  border: 1px solid var(--border-default-grey);
+
+  &:not(#{ns(tile--horizontal)}):not(#{ns(tile--download)}) &__content {
+    padding-bottom: 0 !important;
+  }
+
+  &__title {
+    @include before {
+      background-image: none !important;
+    }
+
+    a,
+    button {
+      @include before {
+        background-image: none !important;
+      }
+
+      @include after {
+        display: none;
+      }
+    }
   }
 }

--- a/src/dsfr/component/toggle/print.scss
+++ b/src/dsfr/component/toggle/print.scss
@@ -5,9 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _toggle-scheme('print');
-
   @import 'style/print';
 }

--- a/src/dsfr/component/toggle/style/_print.scss
+++ b/src/dsfr/component/toggle/style/_print.scss
@@ -1,8 +1,13 @@
 #{ns(toggle)} {
+  page-break-inside: avoid;
+
+  @include before {
+    background-color: none !important;
+  }
+
   label {
-    @include before('', block) {
-      @include text-style(md);
-    }
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
   }
 
   #{ns(hint-text)} {

--- a/src/dsfr/component/tooltip/print.scss
+++ b/src/dsfr/component/tooltip/print.scss
@@ -5,9 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _tooltip-scheme('print');
-
   @import 'style/print';
 }

--- a/src/dsfr/component/transcription/print.scss
+++ b/src/dsfr/component/transcription/print.scss
@@ -5,9 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _transcription-scheme('print');
-
   @import 'style/print';
 }

--- a/src/dsfr/component/translate/print.scss
+++ b/src/dsfr/component/translate/print.scss
@@ -5,9 +5,5 @@
 
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _translate-scheme('print');
-
   @import 'style/print';
 }

--- a/src/dsfr/component/translate/style/_print.scss
+++ b/src/dsfr/component/translate/style/_print.scss
@@ -1,5 +1,3 @@
 #{ns(translate)} {
-  #{ns(translate__btn)} {
-    @include text-style(md);
-  }
+  display: none;
 }

--- a/src/dsfr/core/print.scss
+++ b/src/dsfr/core/print.scss
@@ -1,8 +1,4 @@
 @media print {
   @import 'index';
-  @import 'style/scheme';
-
-  @include _core-scheme('print');
-
   @import 'style/print';
 }

--- a/src/dsfr/core/style/_print.scss
+++ b/src/dsfr/core/style/_print.scss
@@ -5,3 +5,4 @@
 
 @import './print/module';
 @import './print/typography';
+@import './print/icon';

--- a/src/dsfr/core/style/print/_icon.scss
+++ b/src/dsfr/core/style/print/_icon.scss
@@ -1,0 +1,9 @@
+////
+/// Core Module : Icons
+/// @group core
+////
+
+@include has-icon {
+  -webkit-print-color-adjust: exact;
+  print-color-adjust: exact;
+}


### PR DESCRIPTION
Accordion: tous ouverts, pas de couleur, encadré gris, pas de page break apres le bouton
bouton : exact
connect: exact
callout : bordure grise sans fond, no page break
card : bordure grise, no page break
follow: caché
footer: caché
header : caché sauf logo / nom service
highlight: bordure gauche grise
input: bordure grise, fond transparent
modal: pleine page, encadrée
notice: bordure top/bottom + couleur texte
pagination: page courante encadrée et en noir
range: sans remplissage bleu
radio: exact, no page break
search: border, fond transparent
select: border, fond transparent
share: caché
sidemenu: caché
navigation: caché
skiplink: caché
summary: caché
tabs: bouton fond blanc, bordure bleu sur l’actif, no page break
table: exact
tag: exact
tile: bordure grise, retrait icone, no page break
toggle exact, no page break
tooltip: caché
transcription : caché
translate caché
utilitaire d’icone : exact

grille et breakpoint: L’impression en A4 correspond aux breakpoint SM ce qui explique que des cartes prennent 100% de la largeur, car le breakpoint SM est peu utilisé

Textes SM passent en MD partout