### PR TITLE
🐛 fix: lint & es5 export

### DIFF
--- a/src/dsfr/component/toggle/template/stories/toggle.stories.js
+++ b/src/dsfr/component/toggle/template/stories/toggle.stories.js
@@ -3,7 +3,6 @@ import { renderToggle } from './toggle';
 import { uniqueId } from '../../../../core/template/stories/unique-id';
 
 const render = (args) => renderToggle({ toggle: toggleProps(args) });
-const renders = (argsArray) => argsArray.map(args => render(args)).join('\n\n');
 
 export default {
   id: 'toggle',

--- a/src/dsfr/core/script/api/modules/register/focus-manager.js
+++ b/src/dsfr/core/script/api/modules/register/focus-manager.js
@@ -32,7 +32,7 @@ class FocusManager {
   }
 
   focusOnLogo () {
-    const logo = document.querySelector(api?.header?.HeaderSelector?.BRAND_LINK);
+    const logo = document.querySelector(api.header.HeaderSelector.BRAND_LINK);
     if (logo) logo.focus();
   }
 
@@ -45,7 +45,6 @@ class FocusManager {
     }
     return true;
   }
-
 }
 
 const focusManager = new FocusManager();


### PR DESCRIPTION
- correction mineure du lint et du legacy js