### PR TITLE
🐛 fix(modal): correction warning header

### DIFF
--- a/src/dsfr/component/modal/script/modal/modal.js
+++ b/src/dsfr/component/modal/script/modal/modal.js
@@ -118,7 +118,7 @@ class Modal extends api.core.Disclosure {
   }
 
   _ensureAccessibleName () {
-    if (!this.isEnabled || (this.isEnabled && (this.hasAttribute('aria-labelledby') || this.hasAttribute('aria-label')))) return;
+    if (!this.isActive || !this.isEnabled || (this.isEnabled && (this.hasAttribute('aria-labelledby') || this.hasAttribute('aria-label')))) return;
     this.warn('missing accessible name');
     const title = this.node.querySelector(ModalSelector.TITLE);
     const primary = this.primaryButtons[0];


### PR DESCRIPTION
- Lorsque le header est desactivé en desktop, le js de header retire l'aria-label de la modal car inutile. Le message d'avertissement dans la console indique alors que la modal ne contient pas d'atribut aria. Cette vérification ne doit être faite que si la modale est active. #1120 