### PR TITLE
🐛 fix(fieldset): aligne les inputs inline

### DIFF
--- a/src/dsfr/component/form/style/module/_fieldset.scss
+++ b/src/dsfr/component/form/style/module/_fieldset.scss
@@ -6,7 +6,7 @@
   @include relative;
   @include margin(0 -3v 4v);
   @include padding(0 1v);
-  @include display-flex(row, flex-end, null, wrap);
+  @include display-flex(row, last baseline, null, wrap);
   border: 0;
 
   &__legend {
@@ -70,7 +70,6 @@
     @include max-width(100%);
     @include padding-x(2v);
     @include margin-bottom(4v);
-    align-self: flex-start;
 
     &--inline {
       flex: 0 0 auto;


### PR DESCRIPTION
- Corrige l'alignement des champs en ligne lorsque le nombre de lignes des labels est différent.