### PR TITLE
🐛 fix(core): enlarge link background hover

### DIFF
--- a/src/dsfr/core/style/action/module/_enlarge.scss
+++ b/src/dsfr/core/style/action/module/_enlarge.scss
@@ -24,7 +24,7 @@
       #{$markup} {
         &:hover,
         &:active {
-          background: none;
+          background-image: none;
         }
       }
 


### PR DESCRIPTION
- Correction du background d'un élément d'action étendu au hover. Permet de surcharger le background du a ou button.