### PR TITLE
🐛 fix(sidemenu, accordion): collapses ouverts au chargement [DSFR-96]

### DIFF
--- a/src/dsfr/component/accordion/example/index.ejs
+++ b/src/dsfr/component/accordion/example/index.ejs
@@ -4,4 +4,8 @@
 
 <%- sample('Groupe d‘accordéons', './sample/accordions-group', {}, true); %>
 
+<%- sample('Groupe d‘accordéons ouvert au chargement', './sample/accordions-group', {accordionsGroup: {isExpanded: true}}, true); %>
+
 <%- sample('Groupe d‘accordéons dissociés', './sample/accordions-group', {accordionsGroup: {group: false}}, true); %>
+
+<%- sample('Groupe d‘accordéons dissociés ouvert au chargement', './sample/accordions-group', {accordionsGroup: {group: false, isExpanded: true}}, true); %>

--- a/src/dsfr/component/accordion/example/sample/accordions-group.ejs
+++ b/src/dsfr/component/accordion/example/sample/accordions-group.ejs
@@ -1,11 +1,13 @@
 <%
 let accordionsGroup = locals.accordionsGroup || {};
+const isExpanded = accordionsGroup.isExpanded || false;
 
 const accordions = [];
 for (let i = 0; i < 6; i++) accordions.push({
   label: 'Libellé accordéon',
   content: randomContent(),
   id: uniqueId('accordion'),
+  isExpanded: isExpanded && (i === 0 || accordionsGroup.group === false),
 });
 
 accordionsGroup = {

--- a/src/dsfr/component/accordion/template/ejs/accordion.ejs
+++ b/src/dsfr/component/accordion/template/ejs/accordion.ejs
@@ -15,15 +15,17 @@
 
 <%
   let accordion = locals.accordion || {}
- const isExpanded = accordion.isExpanded === true;
-  const collapseAttributes = { ...accordion.collapseAttributes ?? {}, id: accordion.id, class: `${prefix}-collapse` };
+  const isExpanded = accordion.isExpanded === true;
+  const collpaseClasses = [`${prefix}-collapse`];
+  if (isExpanded) collpaseClasses.push(`${prefix}-collapse--expanded`);
+  const collapseAttributes = { ...accordion.collapseAttributes ?? {}, id: accordion.id };
  %>
 
 <section class="<%= prefix %>-accordion">
   <h3 class="<%= prefix %>-accordion__title">
     <button type="button" class="<%= prefix %>-accordion__btn" aria-expanded="<%= isExpanded %>" aria-controls="<%= accordion.id %>" ><%- accordion.label %></button>
   </h3>
-  <div <%- includeAttrs(collapseAttributes); %>>
+  <div <%- includeClasses(collpaseClasses) %> <%- includeAttrs(collapseAttributes); %>>
     <% if (accordion.content !== undefined) { %>
       <%- accordion.content %>
     <% } %>

--- a/src/dsfr/component/sidemenu/example/sample/sidemenu.ejs
+++ b/src/dsfr/component/sidemenu/example/sample/sidemenu.ejs
@@ -42,6 +42,7 @@ function menu(level, active, isCollapsible) {
   return {
     type: 'menu',
     active: active === true,
+    isExpanded: active === true,
     label: active === true ? 'Entrée menu active' : 'Niveau ' + level,
     collapseId: uniqueId('sidemenu'),
     isCollapsible: isCollapsible === true,

--- a/src/dsfr/component/sidemenu/template/ejs/sidemenu-menu.ejs
+++ b/src/dsfr/component/sidemenu/template/ejs/sidemenu-menu.ejs
@@ -31,6 +31,7 @@ switch (sidemenuItem.isCollapsible) {
         action.attributes['aria-expanded'] = sidemenuItem.isExpanded === true;
         action.attributes['aria-controls'] = sidemenuItem.collapseId;
         sidemenuClasses.push(`${prefix}-collapse`);
+        if (sidemenuItem.isExpanded) sidemenuClasses.push(`${prefix}-collapse--expanded`);
         sidemenuAttrs.id = sidemenuItem.collapseId;
         break;
     default:


### PR DESCRIPTION
- Ajout de la classe `fr-collapse--expanded` en html, sur les collapse ouverts par défaut, pour éviter l'ouverture après le chargement du js.
- Ajout d'exemples d'accordéon et sidemenu avec collapses ouverts au chargement