### PR TITLE
🐛 fix(storybook): propriété type du bouton et retrait blocage scroll modal [DSFR-85]

### DIFF
--- a/dsfr-sb/.storybook/preview.css
+++ b/dsfr-sb/.storybook/preview.css
@@ -2,6 +2,16 @@
   background-color: var(--background-default-grey);
 }
 
+#storybook-preview-wrapper {
+  padding-top: 2rem;
+}
+
+[data-fr-scrolling] body.sb-show-main {
+  overflow: auto;
+  position: relative;
+  top: auto !important;
+}
+
 .hide-src-toggle .docblock-code-toggle {
   display: none !important;
 }
@@ -17,7 +27,7 @@
 #story--modal--size-sm-story button[data-fr-opened="true"],
 #story--modal--size-md-story button[data-fr-opened="true"],
 #story--modal--size-lg-story button[data-fr-opened="true"],
-#story--modal--footer button[data-fr-opened="true"] {
+#story--modal--footer-story button[data-fr-opened="true"] {
   margin-bottom: calc(100vh - 40px);
 }
 

--- a/src/dsfr/component/button/template/ejs/button.ejs
+++ b/src/dsfr/component/button/template/ejs/button.ejs
@@ -42,9 +42,10 @@ valeurs :
 const button = locals.button || {};
 let btnClasses = button.classes || [];
 let btnAttrs = button.attributes || {};
-const type = button.type || button.markup !== 'a' ? 'button' : undefined;
-btnClasses.push(prefix + '-btn');
 const markup = button.markup || 'button';
+let type = button.type;
+if (!type && markup !== 'a') type = 'button';
+btnClasses.push(prefix + '-btn');
 
 switch(button.size) {
   case 'sm':
@@ -91,8 +92,7 @@ if (button.tooltip && button.tooltip.id) btnAttrs['aria-describedby'] = button.t
 %>
 
 <% if (button.comments) { %><!-- <%= button.comments %> --><% } %>
-<%- include('../../../../core/template/ejs/action/action', {action: {...button, classes: btnClasses, attributes: btnAttrs, type: type, markup: markup}}) %>
-
+<%- include('../../../../core/template/ejs/action/action', {action: {...button, classes: btnClasses, attributes: btnAttrs, toto: 'toto', type: type, markup: markup}}) %>
 
 <% if (button.tooltip) { %>
   <%- include('../../../tooltip/template/ejs/tooltip.ejs', {tooltip: button.tooltip}); %>

--- a/src/dsfr/component/button/template/ejs/button.ejs
+++ b/src/dsfr/component/button/template/ejs/button.ejs
@@ -92,7 +92,7 @@ if (button.tooltip && button.tooltip.id) btnAttrs['aria-describedby'] = button.t
 %>
 
 <% if (button.comments) { %><!-- <%= button.comments %> --><% } %>
-<%- include('../../../../core/template/ejs/action/action', {action: {...button, classes: btnClasses, attributes: btnAttrs, toto: 'toto', type: type, markup: markup}}) %>
+<%- include('../../../../core/template/ejs/action/action', {action: {...button, classes: btnClasses, attributes: btnAttrs, type: type, markup: markup}}) %>
 
 <% if (button.tooltip) { %>
   <%- include('../../../tooltip/template/ejs/tooltip.ejs', {tooltip: button.tooltip}); %>

--- a/src/dsfr/component/button/template/stories/button-arg-types.js
+++ b/src/dsfr/component/button/template/stories/button-arg-types.js
@@ -147,7 +147,7 @@ const buttonProps = (args) => {
     title: args.title || undefined,
     disabled: args.disabled,
     markup: args.markup || buttonArgs.markup,
-    type: args.type || buttonArgs.type,
+    type: args.markup !== 'a' ? args.type : undefined,
     href: args.href || undefined,
     blank: args.target === 'blank',
     self: args.target === 'self',

--- a/src/dsfr/core/template/ejs/action/action.ejs
+++ b/src/dsfr/core/template/ejs/action/action.ejs
@@ -1,23 +1,23 @@
 <%#
 # paramètres action
 
-* action.kind (string, optional) : type d'action [button/input/link]
+* action.markup (string, optional) : balise HTML de l'action
 valeurs :
   ** button (default) : bouton
-  ** input : input
-  ** link : lien
+  ** input : champ de saisie de type [button, reset, ou submit]
+  ** a : lien
 
 * action.id (string, optional) : id de l'élément d'action
 
 * action.label (string, required) : libellé de l'élément d'action
 
-* action.href (string, optional) : adresse url du lien si action.kind = link
+* action.href (string, optional) : adresse url du lien si action.markup = a
 
-* action.type (string, optional) : attribut type de l'élément d'action si action.kind = input ou button [button/submit/reset]
+* action.type (string, optional) : attribut type de l'élément d'action si action.markup = input ou button [button/submit/reset]
 
-* action.blank (bool, optional) : si true, target prend la valeur _blank, si action.kind = link
+* action.blank (bool, optional) : si true, target prend la valeur _blank, si action.markup = a
 
-* action.self (bool, optional) : si true, target prend la valeur _self, si action.kind = link
+* action.self (bool, optional) : si true, target prend la valeur _self, si action.markup = a
 
 * action.disabled (boolean, optional) : si valeur true, action désactivée
 


### PR DESCRIPTION
- Correction de la propriété "type" sur le composant bouton
- Correction de la hauteur de l'exemple modal avec footer
- Retrait du blocage du scroll à l'ouverture d'une modale.