### PR TITLE
✨ feat(analytics): ajout proxy méthode actionee act() [DSFR-95]

### DIFF
--- a/src/dsfr/analytics/script/integration/core/actionee.js
+++ b/src/dsfr/analytics/script/integration/core/actionee.js
@@ -49,6 +49,9 @@ class Actionee extends api.core.Instance {
       },
       get node () {
         return scope.node; // TODO: remove in v2
+      },
+      get act () {
+        return scope.act.bind(scope);
       }
     };
 


### PR DESCRIPTION
- Ajout de la possibilité d'envoyer l'action d'un élément actionee en js via la méthode act().
exemple : 
`dsfr(element).buttonActionnee.act();`
`dsfr(element).buttonActionnee.act({objet de données supplémentaires});`