### PR TITLE
✨ feat(core): ajout classe utilitaire fr-text--medium [DSFR-83]

### DIFF
--- a/src/dsfr/core/variables.scss
+++ b/src/dsfr/core/variables.scss
@@ -47,7 +47,7 @@ $variables: (
     title: true,
     font-weight: (
       // values: 100 200 300 400 500 600 700 800 900 = 'all'
-      values: 300 400 700 900
+      values: 300 400 500 700 900
     )
   ),
   spacing: (


### PR DESCRIPTION
- Ajout de la classe utilitaire `fr-text--medium` pour passer la graisse en `font-weight: 500`.