### PR TITLE
🐛 fix(modal): correction warning header

### DIFF
--- a/src/dsfr/component/header/script/header/header-modal.js
+++ b/src/dsfr/component/header/script/header/header-modal.js
@@ -21,8 +21,8 @@ class HeaderModal extends api.core.Instance {
       this.request(this.activateModal.bind(this));
       return;
     }
-    modal.isActive = true;
     this.restoreAria();
+    modal.isActive = true;
     this.listenClick({ capture: true });
   }
 

--- a/src/dsfr/component/modal/script/modal/modal.js
+++ b/src/dsfr/component/modal/script/modal/modal.js
@@ -98,6 +98,15 @@ class Modal extends api.core.Disclosure {
     this._isDialog = value;
   }
 
+  get isActive () {
+    return super.isActive;
+  }
+
+  set isActive (value) {
+    super.isActive = value;
+    if (value) this._ensureAccessibleName();
+  }
+
   decorateDialog () {
     if (this._isDecorated) return;
     this._isDecorated = true;

--- a/src/dsfr/component/modal/script/modal/modal.js
+++ b/src/dsfr/component/modal/script/modal/modal.js
@@ -118,7 +118,7 @@ class Modal extends api.core.Disclosure {
   }
 
   _ensureAccessibleName () {
-    if (!this.isEnabled || (this.isEnabled && (this.hasAttribute('aria-labelledby') || this.hasAttribute('aria-label')))) return;
+    if (!this.isActive || !this.isEnabled || (this.isEnabled && (this.hasAttribute('aria-labelledby') || this.hasAttribute('aria-label')))) return;
     this.warn('missing accessible name');
     const title = this.node.querySelector(ModalSelector.TITLE);
     const primary = this.primaryButtons[0];


### PR DESCRIPTION
- Lorsque le header est désactivé en desktop, le js de header retire l'aria-label de la modal car inutile. Le message d'avertissement dans la console indique alors que la modal ne contient pas d'attribut aria. Cette vérification ne doit être faite que si la modale est active. https://github.com/GouvernementFR/dsfr/issues/1120