### PR TITLE
feat(callout): ajoute espacement sur la classe de titre

### DIFF
--- a/src/dsfr/component/callout/style/_module.scss
+++ b/src/dsfr/component/callout/style/_module.scss
@@ -39,6 +39,7 @@
 
   @include title() {
     @include title-style(h4);
+    @include margin(var(--title-spacing));
   }
 
   &__text {


### PR DESCRIPTION
- ajoute l'espacement sous le titre sur la classe `.fr-callout__title`