### PR TITLE
🐛 fix(tooltip): placement du focus a la fermeture clavier

### DIFF
--- a/src/dsfr/component/tooltip/script/tooltip/tooltip-referent.js
+++ b/src/dsfr/component/tooltip/script/tooltip/tooltip-referent.js
@@ -34,7 +34,7 @@ class TooltipReferent extends api.core.PlacementReferent {
   }
 
   _click () {
-    this.focus();
+    this.focusIn();
   }
 
   _clickOut (target) {
@@ -44,7 +44,6 @@ class TooltipReferent extends api.core.PlacementReferent {
   _keydown (keyCode) {
     switch (keyCode) {
       case api.core.KeyCodes.ESCAPE:
-        this.blur();
         this.close();
         break;
     }


### PR DESCRIPTION
- Corrige le retour du focus lorsque l'on ferme le tooltip via la touche échap. Problème constaté notamment au sein d'une modale.