### PR TITLE
🐛 fix(navigation): correction bordure navigation mobile avec 1 seul item

### DIFF
--- a/src/dsfr/component/navigation/style/module/_default.scss
+++ b/src/dsfr/component/navigation/style/module/_default.scss
@@ -73,6 +73,7 @@
   &__link,
   &__btn {
     @include display-flex(row, center, space-between);
+    @include enable-tint;
     font-weight: bold;
     @include padding(3v 4v);
     @include margin(0);
@@ -85,7 +86,6 @@
       @include padding(4v);
       @include text-style(sm);
       font-weight: normal;
-      @include enable-tint;
 
       @include selector.current {
         @include relative;

--- a/src/dsfr/component/navigation/style/module/_default.scss
+++ b/src/dsfr/component/navigation/style/module/_default.scss
@@ -46,6 +46,12 @@
       pointer-events: none;
     }
 
+    &:first-child:last-child {
+      @include before {
+        box-shadow: none;
+      }
+    }
+
     #{ns(btn)},
     #{ns(link)} {
       @include min-height(12v);

--- a/src/dsfr/component/navigation/style/scheme/_default.scss
+++ b/src/dsfr/component/navigation/style/scheme/_default.scss
@@ -5,6 +5,7 @@
 
 @use 'src/module/color';
 @use 'src/module/selector';
+@use 'src/module/disabled';
 
 @mixin _navigation-scheme-nav($legacy: false) {
   #{ns(nav)} {
@@ -21,9 +22,14 @@
     }
 
     &__btn {
-      &[aria-expanded="true"]:not(:disabled) {
+      &[aria-expanded="true"] {
         @include color.background(open blue-france, (legacy: $legacy));
         @include color.text(action-high blue-france, (legacy: $legacy));
+
+        @include disabled.selector {
+          @include color.text(disabled grey, (legacy: $legacy));
+          @include color.background(disabled grey, (legacy: $legacy));
+        }
       }
     }
 


### PR DESCRIPTION
- Correction de la bordure du menu mobile lorsqu'il ne contient qu'un seul élément #1170 