### PR TITLE
⬆️ chore(Node): Change la version minimale de Node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "organisation": "@gouvfr"
   },
   "engines": {
-    "node": ">=22.14.0"
+    "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
   },
   "packageManager": "yarn@1.22.22",
   "scripts": {


### PR DESCRIPTION
- Pour permettre plus de souplesse, les versions de Node acceptées pour build le DSFR sont maintenant `"^20.19.0 || ^22.12.0 || >=24.0.0"` 