### PR TITLE
:bug: fix(toggle): retrait css non conforme dans le fichier print

### DIFF
--- a/src/dsfr/component/toggle/style/_print.scss
+++ b/src/dsfr/component/toggle/style/_print.scss
@@ -1,10 +1,6 @@
 #{ns(toggle)} {
   page-break-inside: avoid;
 
-  @include before {
-    background-color: none !important;
-  }
-
   label {
     -webkit-print-color-adjust: exact;
     print-color-adjust: exact;


### PR DESCRIPTION
- Retire une propriété CSS non conforme et inutile dans print.scss #1264
