### PR TITLE
🐛 fix(navigation): mega menu leader toujours visible

### DIFF
--- a/src/dsfr/component/navigation/_part/doc/code/index.md
+++ b/src/dsfr/component/navigation/_part/doc/code/index.md
@@ -284,7 +284,7 @@ Sa structure est conçue pour s’adapter aux écrans mobiles et comprend les é
                         <div class="fr-col-12 fr-col-lg-8 fr-col-offset-lg-4--right">
                             <div class="fr-mega-menu__leader">
                                 <h4 class="fr-h4 fr-mb-2v">Titre éditorialisé</h4>
-                                <p class="fr-hidden fr-displayed-lg">Lorem [...] elit ut.</p>
+                                <p>Lorem [...] elit ut.</p>
                                 <a class="fr-link fr-fi-arrow-right-line fr-link--icon-right fr-link--align-on-content" href="#">Voir toute la rubrique</a>
                             </div>
                         </div>

--- a/src/dsfr/component/navigation/example/sample/navigation.ejs
+++ b/src/dsfr/component/navigation/example/sample/navigation.ejs
@@ -66,7 +66,7 @@ const getMega = (active = false, leader = false) => {
     close: 'Fermer le menu',
     ...(leader && {leader: {
       title: 'Titre éditorialisé',
-      text: lorem(),
+      text: lorem(false, 40),
       link: {
         id: uniqueId('link'),
         label: 'Voir toute la rubrique',

--- a/src/dsfr/component/navigation/template/ejs/navigation-leader.ejs
+++ b/src/dsfr/component/navigation/template/ejs/navigation-leader.ejs
@@ -21,7 +21,7 @@
       <h4 class="<%= prefix %>-h4 <%= prefix %>-mb-2v"><%= leader.title %></h4>
     <% } %>
 
-    <p class="<%= prefix %>-hidden <%= prefix %>-unhidden-lg"><%- leader.text %></p>
+    <p><%- leader.text %></p>
 
     <%
     if (leader.link !== undefined) {


### PR DESCRIPTION
- Retrait des classes hidden mobile sur le texte dans le leader des exemples de mega-menu #1271 