### PR TITLE
faute d'orthographe sur la page du composant Pagination

### DIFF
--- a/src/dsfr/component/pagination/_part/doc/index.md
+++ b/src/dsfr/component/pagination/_part/doc/index.md
@@ -48,4 +48,4 @@ Privilégier la pagination au rechargement automatique ou à un bouton “Voir p
 
 ### Règles éditoriales
 
-La pagination n’est régit par aucune règle éditoriale spécifique.
+La pagination n’est régie par aucune règle éditoriale spécifique.


### PR DESCRIPTION
La pagination n’est régit -> La pagination n’est régie