### PR TITLE
docs: uniformisation du formatage des groupes de boutons

### DIFF
--- a/src/dsfr/component/button/_part/doc/code/index.md
+++ b/src/dsfr/component/button/_part/doc/code/index.md
@@ -48,20 +48,24 @@ Le composant **Bouton** est un élément interactif permettant de déclencher de
 
 #### Groupes de boutons
 
-Les boutons peuvent être regroupés pour former des ensembles d'actions. Le groupe est formé par la succession de boutons enveloppés par l'élément HTML `<div>` et la classe `fr-btns-group`.
+Les boutons peuvent être regroupés pour former des ensembles d'actions. Le groupe est formé par la succession de boutons structurés sous forme de liste par l'élément HTML `<ul>` et la classe `fr-btns-group`.
 Un groupe est dit **hiérarchisé** s'il dispose d'un bouton primaire et de boutons secondaires. Sauf cas exceptionnel, n'utiliser qu'un seul bouton primaire dans un groupe. Un groupe **non hiérarchisé** est lui constitué uniquement de boutons secondaires, tertiaires, et/ou tertiaires sans contours.
 
 **Exemple de groupe de boutons**
 
 ```HTML
-<div class="fr-btns-group">
+<ul class="fr-btns-group">
+  <li>
     <button class="fr-btn" type="button">
         Bouton 1
     </button>
+  </li>
+  <li>
     <button class="fr-btn fr-btn--secondary" type="button">
         Bouton 2
     </button>
-</div>
+  </li>
+</ul>
 ```
 
 ---

--- a/src/dsfr/component/modal/_part/doc/code/index.md
+++ b/src/dsfr/component/modal/_part/doc/code/index.md
@@ -170,10 +170,14 @@ La modale avec une **zone d’action** permet de guider l’utilisateur vers des
                     </div>
                     <!-- Zone d'action de la modale -->
                     <div class="fr-modal__footer">
-                        <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
-                            <button type="button" class="fr-btn fr-icon-checkbox-circle-line fr-btn--icon-left">Libellé bouton</button>
-                            <button type="button" class="fr-btn fr-icon-checkbox-circle-line fr-btn--icon-left fr-btn--secondary">Libellé bouton</button>
-                        </div>
+                        <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <li>
+                                <button type="button" class="fr-btn fr-icon-checkbox-circle-line fr-btn--icon-left">Libellé bouton</button>
+                            </li>
+                            <li>
+                                <button type="button" class="fr-btn fr-icon-checkbox-circle-line fr-btn--icon-left fr-btn--secondary">Libellé bouton</button>
+                            <li>
+                        </ul>
                     </div>
                 </div>
             </div>

--- a/src/dsfr/component/modal/template/stories/modal-arg-types.js
+++ b/src/dsfr/component/modal/template/stories/modal-arg-types.js
@@ -1,7 +1,11 @@
-const footer = `<div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+const footer = `<ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-lg fr-btns-group--icon-left">
+<li>
 <button class="fr-btn fr-icon-checkbox-circle-line fr-btn--icon-left">Libellé bouton</button>
+</li>
+<li>
 <button class="fr-btn fr-icon-checkbox-circle-line fr-btn--icon-left fr-btn--secondary">Libellé bouton</button>
-</div>`;
+</li>
+</ul>`;
 
 const body = `<p>Lorem ipsum dolor sit amet, consectetur adipiscing, incididunt, ut labore et dolore magna aliqua. Vitae sapien pellentesque habitant morbi tristique senectus et. Diam maecenas sed enim ut. Accumsan lacus vel facilisis volutpat est. Ut aliquam purus sit amet luctus. Lorem ipsum dolor sit amet consectetur adipiscing elit ut.</p>
 <p>Lorem ipsum dolor sit amet, consectetur adipiscing, incididunt, ut labore et dolore magna aliqua. Vitae sapien pellentesque habitant morbi tristique senectus et. Diam maecenas sed enim ut. Accumsan lacus vel facilisis volutpat est. Ut aliquam purus sit amet luctus. Lorem ipsum dolor sit amet consectetur adipiscing elit ut.</p>


### PR DESCRIPTION
Bonjour,

Suite à un échange avec l'une des équipes que j'accompagne, nous nous sommes rendu compte que les groupes de boutons n'étaient pas formatés de la même façon dans le Storybook et l'onglet "Code" de la documentation du composant "Bouton" :
* Storybook utilise des éléments HTML `<ul>`, `<li>` : [template/ejs/buttons-group.ejs#L49](https://github.com/GouvernementFR/dsfr/blob/main/src/dsfr/component/button/template/ejs/buttons-group.ejs#L49).
* Onglet "Code" utilise un élément HTML `<div>` : [_part/doc/code/index.md?plain=1#L57-L64](https://github.com/GouvernementFR/dsfr/blob/main/src/dsfr/component/button/_part/doc/code/index.md?plain=1#L57-L64).


De même, le composant "Modale" ([modal/_part/doc/code/index.md?plain=1#L173-L176](https://github.com/GouvernementFR/dsfr/blob/main/src/dsfr/component/modal/_part/doc/code/index.md?plain=1#L173-L176)) n'utilise pas une sémantique de liste lors de l'utilisation de ce composant alors que c'est bien le cas pour le composant "Gestionnaire de consentement" ([consent/_part/doc/code/index.md?plain=1#L61-L77](https://github.com/GouvernementFR/dsfr/blob/main/src/dsfr/component/consent/_part/doc/code/index.md?plain=1#L61-L77)) ou le composant "Partage" ([share/_part/doc/code/index.md?plain=1#L51-L68](https://github.com/GouvernementFR/dsfr/blob/main/src/dsfr/component/share/_part/doc/code/index.md?plain=1#L51-L68)).

Cette PR est là pour aligner tous les composants sur l'utilisation d'une liste avec l'élément HTML `<ul>` à travers tous les composants du DSFR.

J'ai volontairement laissé de côté le cas ["Exemple de bloc newsletter avec bouton"](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/lettre-d-information-et-reseaux-sociaux/code-de-la-lettre-d-information-et-des-reseaux-sociaux) qui utilise le groupe de bouton pour gérer la taille de l'action en fonction des points de rupture (acceptable selon moi).

A votre dispo pour adapter la PR si besoin.