### PR TITLE
docs(checkbox): corrige l'exemple HTML de groupe

### DIFF
--- a/src/dsfr/component/checkbox/_part/doc/code/index.md
+++ b/src/dsfr/component/checkbox/_part/doc/code/index.md
@@ -97,7 +97,6 @@ Pour **regrouper plusieurs checkboxes liées**, utilisez un élément `<fieldset
             <label class="fr-label" for="checkboxes-3">
                 Libellé case à cocher
             </label>
-            </div>
         </div>
     </div>
     <div class="fr-messages-group" id="checkboxes-messages" aria-live="polite">


### PR DESCRIPTION
Bonjour,

En répondant dans #1261, j'ai trouvé une coquille dans l'exemple "[Groupe de checkboxes](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/case-a-cocher/code-de-la-case-a-cocher#groupe-de-checkboxes)".

Au plaisir.