### PR TITLE
🐛 fix(tab): ajoute un fond blanc au tab panel

### DIFF
--- a/src/dsfr/component/tab/script/tab/tabs-group.js
+++ b/src/dsfr/component/tab/script/tab/tabs-group.js
@@ -148,7 +148,8 @@ class TabsGroup extends api.core.DisclosuresGroup {
     const paneHeight = Math.round(this.current.node.offsetHeight);
     if (this.panelHeight === paneHeight) return;
     this.panelHeight = paneHeight;
-    this.style.setProperty('--tabs-height', (this.panelHeight + this.listHeight) + 'px');
+    const offsetNegativeMargin = 4;
+    this.style.setProperty('--tabs-height', (this.panelHeight + this.listHeight - offsetNegativeMargin) + 'px');
   }
 }
 

--- a/src/dsfr/component/tab/style/_scheme.scss
+++ b/src/dsfr/component/tab/style/_scheme.scss
@@ -8,10 +8,11 @@
 
 @mixin _tab-scheme($legacy: false) {
   #{ns(tabs)} {
-    @include color.box-shadow(default grey, (legacy: $legacy), bottom-1-in);
+    @include color.box-shadow(default grey, (legacy: $legacy), bottom-1-out);
 
     @include before {
       @include color.box-shadow(default grey, (legacy: $legacy), top-1-in left-1-in right-1-in);
+      @include color.background(default grey, (legacy: $legacy));
     }
 
     /**

--- a/src/dsfr/component/tab/style/module/_default.scss
+++ b/src/dsfr/component/tab/style/module/_default.scss
@@ -41,6 +41,7 @@
   @include before('', block) {
     @include size(100%, 100%);
     @include margin-top(-1px);
+    pointer-events: none;
     order: 2;
 
     @include preference.forced-colors {
@@ -73,7 +74,6 @@
     @include relative;
     overflow: visible;
     font-weight: font-weight(bold);
-    @include z-index(over);
     @include margin(0 1v);
     @include height(100%);
     white-space: nowrap;


### PR DESCRIPTION
- Corrige le fond transparent du panel #1300 
- Corrige la hauteur du panel (4px en trop)