### PR TITLE
docs(notice): supprime un doublon de paragraphe

### DIFF
--- a/src/dsfr/component/notice/_part/doc/design/index.md
+++ b/src/dsfr/component/notice/_part/doc/design/index.md
@@ -19,8 +19,6 @@ mesh:
 
 Le bandeau d’information importante est un élément éditorial permettant d’attirer l’attention des usagers sur une information importante et temporaire.
 
-Le bandeau d’information importante est un élément éditorial permettant d’attirer l’attention des usagers sur une information importante et temporaire.
-
 :::dsfr-doc-tab-navigation
 
 - [Présentation](../index.md)


### PR DESCRIPTION
Bonjour,

Désolé de voir ça après la publication de la `1.14.2` mais en parcourant la documentation avec un développeur, nous avons trouvé un doublon de paragraphe pour le composant Bandeau d'information importante.