### PR TITLE
🐛 fix(core): corrige liste à puce désactivée sur safari/voiceOver [DSFR-133]

### DIFF
--- a/src/dsfr/core/style/typography/module/_list.scss
+++ b/src/dsfr/core/style/typography/module/_list.scss
@@ -31,6 +31,8 @@ ul {
         color: graytext;
       }
     }
+
+    @include before("\200B"); /* fix screen reader when list-style-type none */
   }
 }
 
@@ -45,6 +47,8 @@ ol {
       font-size: var(--xl-size);
       font-weight: bold;
     }
+
+    @include before("\200B"); /* fix screen reader when list-style-type none */
   }
 }
 

--- a/src/dsfr/core/style/typography/tool/_list.scss
+++ b/src/dsfr/core/style/typography/tool/_list.scss
@@ -80,12 +80,6 @@
     #{$ol} {
       @include padding-left(0);
       @include margin-y(0);
-
-      & > li {
-        @include before {
-          content: "\200B"; /* zero-width space to fix screen reader */
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
- Sur safari/voiceOver lorsque le style des puces d'une liste est désactivé, voiceOver n'annonce pas les puces. 
- L'ajout d'un espace dans le before des `<li>` corrige le problème

https://medium.com/@gerardkcohen/solving-voiceover-and-list-style-type-none-dd362ea26532

#1261