### PR TITLE
📝 docs(badge): titre en h2

### DIFF
--- a/src/dsfr/component/badge/_part/doc/accessibility/index.md
+++ b/src/dsfr/component/badge/_part/doc/accessibility/index.md
@@ -14,7 +14,7 @@ mesh:
   - component/tag
 ---
 
-# Badge
+## Badge
 
 Le badge est un élément d’indication permettant de valoriser une information liée à un élément précis du site.
 


### PR DESCRIPTION
- correction du niveau de titre de la page "accessibilité du badge"