### PR TITLE
🐛 fix(tab): corrige la marge du variant viewport-width

### DIFF
--- a/src/dsfr/component/tab/style/module/_default.scss
+++ b/src/dsfr/component/tab/style/module/_default.scss
@@ -34,7 +34,7 @@
 
   // retire le padding du container en mobile
   &--viewport-width {
-    @include margin-x(calc(50% - 50vw));
+    @include margin-x(-4v);
     @include margin-x(0, md);
   }
 


### PR DESCRIPTION
Bonjour,

en travaillant sur un autre sujet pour le composant **Onglets**, j'ai découvert le modificateur `.fr-tab--viewport-width` et identifier deux bugs le concernant :
1. Sous Chrome, il faut apparaitre une scrollbar horizontal en dessous de 767px.
   - Ouvrir Chrome
   - Aller sur la page https://main--ds-gouv.netlify.app/example/component/tab/
   - Réduire l'affichage en dessous de 767px.
   - **Résultat** : une scrollbar horizontale apparait. 

2. Sous Firefox, la bordure de droite n'est pas dessinée au bon endroit et ne se voit pas.
   - Ouvrir Firefox
   - Aller sur la page https://main--ds-gouv.netlify.app/example/component/tab/
   - Basculer en thème sombre
   - Modifier la propriété CSS `box-shadow` du sélecteur `.fr-tab::before` avec la valeur : `inset 0 1px 0 0 orange, inset 1px 0 0 0 yellow, inset -1px 0 0 0 cyan`
   - Réduire l'affichage en dessous de 767px.
   - **Résultat**: on ne voit pas la bordure droite de couleur cyan.

Pour la correction du bug Firefox, il y a tellement d'issues ouvertes concernant la propriété CSS `box-shadow` : https://bugzilla.mozilla.org/buglist.cgi?quicksearch=box+shadow que je ne me lance pas dans l'ouverture d'un nouveau bug.

Je ne sais pas comment vous appréhendez ce genre de situations dans votre codebase. Selon moi, même si cette valeur magique de `99.9%` n'est pas idéale, le plus important est que l'utilisateur dispose d'un affichage correct dans tous les navigateurs.

A votre dispo pour adapter ma contribution si besoin.