### PR TITLE
🐛 fix(navigation): fermeture au click sur un sous-élement html

### DIFF
--- a/src/dsfr/component/navigation/script/navigation/navigation.js
+++ b/src/dsfr/component/navigation/script/navigation/navigation.js
@@ -50,7 +50,8 @@ class Navigation extends api.core.CollapsesGroup {
   }
 
   handleClick (e) {
-    if (e.target.matches('a, button') && !e.target.matches('[aria-controls]') && !e.target.matches(api.core.DisclosureSelector.PREVENT_CONCEAL)) {
+    const linkOrButton = e.target.closest('a, button');
+    if (linkOrButton && linkOrButton !== this.node && !linkOrButton.matches('[aria-controls]') && !linkOrButton.matches(api.core.DisclosureSelector.PREVENT_CONCEAL)) {
       this.index = -1;
     }
   }


### PR DESCRIPTION
- corrige le clic sur un élément à l'intérieur d'un `nav__link `

Fix #1275