### PR TITLE
🐛 fix(quote): espaces insécables avant et après les guillemets

### DIFF
--- a/src/dsfr/component/quote/template/ejs/quote.ejs
+++ b/src/dsfr/component/quote/template/ejs/quote.ejs
@@ -41,7 +41,7 @@ if (size) sizeClasses = [prefix+'-text--'+size];
 
 <figure <%- includeAttrs(quoteAttrs) %> <%- includeClasses(quoteClasses) %>>
   <blockquote <%- includeAttrs(blockAttrs) %>>
-    <p <%- includeClasses(sizeClasses) %>>« <%= text %> »</p>
+    <p <%- includeClasses(sizeClasses) %>>«&nbsp;<%= text %>&nbsp;»</p>
   </blockquote>
   <figcaption>
     <% if (author) { %>


### PR DESCRIPTION
- Utilisation de l'espace insécable avant et après les guillemets