### PR TITLE
:sparkles: feat(checkbox): ajoute l'état indéterminé

### DIFF
--- a/dsfr-sb/.storybook/main.js
+++ b/dsfr-sb/.storybook/main.js
@@ -25,7 +25,12 @@ const config = {
     options: {},
   },
 
-  staticDirs: ["./static", { from: "../../dist", to: "dist" }, { from: "../../tool/example/img", to: "img" }],
+  staticDirs: [
+    "./static", 
+    { from: "../../dist", to: "dist" }, 
+    { from: "../../tool/example/img", to: "img" },
+    { from: "../../src/dsfr/component/checkbox/example/js", to: "js/checkbox"},
+  ],
 
   docs: {}
 };

--- a/src/dsfr/component/checkbox/_part/doc/accessibility/index.md
+++ b/src/dsfr/component/checkbox/_part/doc/accessibility/index.md
@@ -120,8 +120,14 @@ Par défaut, les lecteurs d’écran restituent le **nom, la description, l’é
 L’attribut `disabled` est restitué différemment selon les lecteurs d’écran&nbsp;:
 
 - VoiceOver macOS et iOS&nbsp;: «&nbsp;estompé&nbsp;»
-- NVDA et JAWS&nbsp;: «&nbsp;bouton non disponible&nbsp;»
-- Narrateur et Talkback &nbsp;: «&nbsp;bouton désactivé&nbsp;»
+- NVDA et JAWS&nbsp;: «&nbsp;case à cocher non disponible&nbsp;»
+- Narrateur et Talkback &nbsp;: «&nbsp;case à cocher désactivée&nbsp;»
+
+La proriété du DOM `indeterminate` est aussi restituée différemment selon les lecteurs d’écran&nbsp;:
+
+- VoiceOver macOS et iOS&nbsp;: «&nbsp;mixé, case à chocé&nbsp;»
+- NVDA et JAWS&nbsp;: «&nbsp;case à cocher semi-coché&nbsp;»
+- Narrateur et Talkback &nbsp;: «&nbsp;case à cocher indéterminée&nbsp;»
 
 ---
 

--- a/src/dsfr/component/checkbox/_part/doc/code/index.md
+++ b/src/dsfr/component/checkbox/_part/doc/code/index.md
@@ -159,12 +159,13 @@ La checkbox est disponible en plusieurs variantes d'états :
 - La checkbox avec **erreur** : définie par la classe `fr-checkbox-group--error`.
 - La checkbox avec **succès** : définie par la classe `fr-checkbox-group--valid`.
 - La checkbox **désactivée** : définie par l'attribut `disabled` sur l'élément `<input>`.
+- La checkbox **indéterminée** : définie par la propriété du DOM `indeterminate` fixée à `true` sur l'élément `<input>` via du code JavaScript.
 
 Dans le cas d'utilisation d'un groupe de checkboxes, ces états sont définis sur le groupe (le fieldset), et non sur chaque checkbox.
 
 - Groupe en **erreur** : définie par la classe `fr-fieldset--error`.
 - Groupe en **succès** : définie par la classe `fr-fieldset--valid`.
-- Groupe **désactivée** : définie par l'attribut `disabled`.
+- Groupe **désactivée** : définie par l'attribut `disabled` sur l'élément `<fieldset>`.
 
 **Exemples de variantes d'états**
 

--- a/src/dsfr/component/checkbox/_part/doc/design/index.md
+++ b/src/dsfr/component/checkbox/_part/doc/design/index.md
@@ -102,8 +102,11 @@ L'état désactivé indique que l’utilisateur ne peut pas interagir avec la ca
 
 ::dsfr-doc-storybook{storyId=checkboxes-group--disabled}
 
-> [!NOTE]
-> L'état “Indeterminate” n’est pas géré actuellement par le Système de Design de l'Etat.
+**État indéterminé**
+
+L'état indéterminé peut être utilisé pour indiquer à l’utilisateur qu'un groupe de checkboxes avec une action commune est partiellement sélectionné. Typiquement, cet état pourra être utilisé lorsqu'un tableau proposera une case à cocher générale dans son en-tête et que l'ensemble des lignes ne seront pas sélectionnées.
+
+::dsfr-doc-storybook{storyId=checkboxe-indeterminate}
 
 ### Personnalisation
 

--- a/src/dsfr/component/checkbox/_part/doc/design/index.md
+++ b/src/dsfr/component/checkbox/_part/doc/design/index.md
@@ -106,7 +106,7 @@ L'état désactivé indique que l’utilisateur ne peut pas interagir avec la ca
 
 L'état indéterminé peut être utilisé pour indiquer à l’utilisateur qu'un groupe de checkboxes avec une action commune est partiellement sélectionné. Typiquement, cet état pourra être utilisé lorsqu'un tableau proposera une case à cocher générale dans son en-tête et que l'ensemble des lignes ne seront pas sélectionnées.
 
-::dsfr-doc-storybook{storyId=checkboxe-indeterminate}
+::dsfr-doc-storybook{storyId=checkbox-indeterminate}
 
 ### Personnalisation
 

--- a/src/dsfr/component/checkbox/example/index.ejs
+++ b/src/dsfr/component/checkbox/example/index.ejs
@@ -1,24 +1,30 @@
 <% const sample = getSample(include); %>
 
+<script type="module">
+    <%- include('./js/init-indeterminate.js'); %>
+</script>
+
 <%- sample('Case à cocher seule', './sample/checkbox.ejs', {checkbox: {id:'checkbox'}}, true); %>
 
 <%- sample('Case à cocher seule, exemple avec indice et exposant', './sample/checkbox.ejs', {checkbox: {id:'checkbox-sup-sub', label:'<span>Libellé checkbox <sub>sub</sub> et <sup>sup</sup></span>'}}, true); %>
 
-<%- sample('Case à cocher avec texte d‘aide', './sample/checkbox.ejs', {checkbox: {id:'checkbox-hint', hint:true}}, true); %>
+<%- sample('Case à cocher avec texte d’aide', './sample/checkbox.ejs', {checkbox: {id:'checkbox-hint', hint:true}}, true); %>
 
 <%- sample('Case à cocher seule, validée', './sample/checkbox.ejs', {checkbox: {id:'checkbox-valid', valid:true}}, true); %>
 
 <%- sample('Case à cocher seule avec erreur', './sample/checkbox.ejs', {checkbox: {id:'checkbox-error', error:true}}, true); %>
 
-<%- sample('Ensemble de cases à cocher', './sample/checkboxes.ejs', {checkboxes: {id:'checkboxes', checked: true}}, true); %>
+<%- sample('Case à cocher seule, indéterminée', './sample/checkbox.ejs', {checkbox: {id:'checkbox-mixed', indeterminate:true}}, true); %>
 
-<%- sample('Ensemble de cases à cocher, petite taille', './sample/checkboxes.ejs', {checkboxes: {id:'checkboxes-small', checked: true}, checkbox: {size: 'sm'}}, true); %>
+<%- sample('Ensemble de cases à cocher', './sample/checkboxes.ejs', {checkboxes: {id:'checkboxes', checked: true, indeterminate:true}}, true); %>
 
-<%- sample('Ensemble de cases à cocher désactivées', './sample/checkboxes.ejs', {checkboxes: {id:'checkboxes-disabled', checked: true}, checkbox: {disabled:true}}, true); %>
+<%- sample('Ensemble de cases à cocher, petite taille', './sample/checkboxes.ejs', {checkboxes: {id:'checkboxes-small', checked: true, indeterminate:true}, checkbox: {size: 'sm'}}, true); %>
+
+<%- sample('Ensemble de cases à cocher désactivées', './sample/checkboxes.ejs', {checkboxes: {id:'checkboxes-disabled', checked: true, indeterminate:true}, checkbox: {disabled:true}}, true); %>
 
 <%- sample('Ensemble de cases à cocher en ligne', './sample/checkboxes.ejs', {checkboxes: {id:'checkboxes-inline', inline: true}}, true); %>
 
-<%- sample('Ensemble de cases à cocher avec texte d‘aide', './sample/checkboxes.ejs', {checkboxes: {id:'checkboxes-hint'}, checkbox: {hint:true}}, true); %>
+<%- sample('Ensemble de cases à cocher avec texte d’aide', './sample/checkboxes.ejs', {checkboxes: {id:'checkboxes-hint'}, checkbox: {hint:true}}, true); %>
 
 <%- sample('Ensemble de cases à cocher avec erreur', './sample/checkboxes.ejs', {checkboxes: {id:'checkboxes-error', error: true}}, true); %>
 
@@ -28,6 +34,6 @@
 
 <%- sample('Ensemble de cases à cocher validées, en ligne', './sample/checkboxes.ejs', {checkboxes: {id:'checkboxes-valid-inline', valid: true, inline:true}}, true); %>
 
-<%- sample('Ensemble de cases à cocher avec texte d‘aide spécifique', './sample/checkboxes.ejs', {checkboxes: {id:'checkboxes-hint-element'}, checkbox: {hint:'Texte de description additionnel'}}, true); %>
+<%- sample('Ensemble de cases à cocher avec texte d’aide spécifique', './sample/checkboxes.ejs', {checkboxes: {id:'checkboxes-hint-element'}, checkbox: {hint:'Texte de description additionnel'}}, true); %>
 
-<%- sample('Ensemble de cases à cocher avec texte d‘aide spécifique,  petite taille', './sample/checkboxes.ejs', {checkboxes: {id:'checkboxes-hint-el-sm'}, checkbox: {size: 'sm', hint:'Texte de description additionnel'}}, true); %>
+<%- sample('Ensemble de cases à cocher avec texte d’aide spécifique,  petite taille', './sample/checkboxes.ejs', {checkboxes: {id:'checkboxes-hint-el-sm'}, checkbox: {size: 'sm', hint:'Texte de description additionnel'}}, true); %>

--- a/src/dsfr/component/checkbox/example/js/init-indeterminate.js
+++ b/src/dsfr/component/checkbox/example/js/init-indeterminate.js
@@ -1,0 +1,4 @@
+const $indeterminates = document.querySelectorAll('[id*="indeterminate"]');
+for (const $indeterminate of $indeterminates) {
+  $indeterminate.indeterminate = true;
+}

--- a/src/dsfr/component/checkbox/example/sample/checkboxes.ejs
+++ b/src/dsfr/component/checkbox/example/sample/checkboxes.ejs
@@ -16,7 +16,7 @@ for (let i = 1; i < 4; i++) elements.push({
   inline: checkboxes.inline || undefined,
   data: {
     ...checkbox,
-    id: `${id}-${i}`,
+    id: `${id}-${i}${i === 1 && checkboxes.indeterminate ? '-indeterminate' : ''}`,
     name: `${id}-${i}`,
     checked: i === 2 && checkboxes.checked
   }

--- a/src/dsfr/component/checkbox/style/_scheme.scss
+++ b/src/dsfr/component/checkbox/style/_scheme.scss
@@ -16,12 +16,20 @@
         }
       }
 
-      &:checked {
+      &:checked,
+      &:indeterminate {
         + label {
           @include before {
             @include color.background(active blue-france);
             @include color.background-image(border active blue-france, (), checkbox-background-image());
             @include color.data-uri-svg(text inverted blue-france, (), $checkbox-svg, false);
+          }
+        }
+      }
+      &:indeterminate {
+        + label {
+          @include before {
+            @include color.data-uri-svg(text inverted blue-france, (), $checkbox-indeterminate-svg, false);
           }
         }
       }
@@ -34,11 +42,19 @@
           }
         }
 
-        &:checked {
+        &:checked,
+        &:indeterminate {
           & + label {
             @include before {
               @include disabled.colors((background: true));
               @include color.data-uri-svg(text disabled grey, (), $checkbox-svg, false);
+            }
+          }
+        }
+        &:indeterminate {
+          & + label {
+            @include before {
+              @include color.data-uri-svg(text disabled grey, (), $checkbox-indeterminate-svg, false);
             }
           }
         }
@@ -47,7 +63,8 @@
 
     &--error {
       input[type="checkbox"],
-      input[type="checkbox"]:checked {
+      input[type="checkbox"]:checked,
+      input[type="checkbox"]:indeterminate {
         & + label {
           @include color.text(default error, (legacy:$legacy));
 
@@ -64,7 +81,8 @@
 
     &--valid {
       input[type="checkbox"],
-      input[type="checkbox"]:checked {
+      input[type="checkbox"]:checked,
+      input[type="checkbox"]:indeterminate {
         & + label {
           @include color.text(default success, (legacy:$legacy));
 

--- a/src/dsfr/component/checkbox/style/_setting.scss
+++ b/src/dsfr/component/checkbox/style/_setting.scss
@@ -4,3 +4,4 @@
 ////
 
 $checkbox-svg: "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='$COLOR' d='M10 15.17l9.2-9.2 1.4 1.42L10 18l-6.36-6.36 1.4-1.42z'/></svg>";
+$checkbox-indeterminate-svg: "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path fill='$COLOR' d='M5 11h14v2H5v-2Z'/></svg>";

--- a/src/dsfr/component/checkbox/template/ejs/checkbox.ejs
+++ b/src/dsfr/component/checkbox/template/ejs/checkbox.ejs
@@ -17,6 +17,8 @@
 
 * checkbox.checked (boolean, optional) : si true, la checkbox est cochée
 
+* checkbox.indeterminate (boolean, optional) : si true, l'état de la checkbox est indéterminé
+
 %>
 <% eval(include('../../../../core/index.ejs')); %>
 <% eval(include('../../../form/template/ejs/message/builder.js.ejs')); %>
@@ -28,6 +30,7 @@ if (checkbox.disabled === true) attributes.disabled = "";
 if (checkbox.name) attributes.name = checkbox.name;
 attributes.id = checkbox.id;
 attributes.type = "checkbox";
+if (checkbox.indeterminate === true) attributes.id += "-indeterminate";
 const describedby = [];
 const label = {
   label: checkbox.label,

--- a/src/dsfr/component/checkbox/template/stories/checkbox.stories.js
+++ b/src/dsfr/component/checkbox/template/stories/checkbox.stories.js
@@ -23,6 +23,23 @@ export const DefaultStory = {
   }
 };
 
+export const IndeterminateStory = {
+  tags: ['autodocs', '!dev'],
+  args: {
+    id: 'checkbox-indeterminate'
+  },
+  decorators: [
+    (Story) => {
+      const script = document.createElement('script');
+      script.src = '/js/checkbox/init-indeterminate.js';
+      script.type = 'module';
+      document.head.appendChild(script);
+
+      return Story();
+    }
+  ]
+};
+
 export const SizeSmStory = {
   tags: ['autodocs', '!dev'],
   args: {


### PR DESCRIPTION
Bonjour,

Ne sachant pas pourquoi l'[état "Indeterminate"](https://developer.mozilla.org/fr/docs/Web/CSS/Reference/Selectors/:indeterminate) sur le composant **Checkbox** n'a pas été géré jusque là, je me permets de le pousser  :bowtie:

<img width="596" height="227" alt="Capture d&#39;écran 2025-12-23 111926" src="https://github.com/user-attachments/assets/40cf5b48-4795-4a31-809c-8b9daacae2d6" />
<img width="597" height="225" alt="Capture d&#39;écran 2025-12-23 111950" src="https://github.com/user-attachments/assets/bdba723f-f0f7-43f5-b186-fb80bad08f1c" />

Par contre, je ne sais pas pourquoi le rendu avec le thème claire semble "plus gris" que la virgule de l'état "checked"... Si on zoome à 200% le rendu de couleur est identique donc ça pourrait être un problème de tracer du SVG.

Joyeuses fêtes à toutes et tous  :santa::christmas_tree::gift: