### PR TITLE
:bug: fix(header, navigation): améliore l'affichage des éléments de l'en-tête et de la navigation en mobile

### DIFF
--- a/src/dsfr/component/header/style/module/_links.scss
+++ b/src/dsfr/component/header/style/module/_links.scss
@@ -69,7 +69,10 @@
     }
 
     &:last-child,
-    &:empty,
+    &:empty {
+      @include after(normal, null);
+    }
+
     &:not(:has(*)) {
       @include after(normal, null);
     }

--- a/src/dsfr/component/header/style/module/_links.scss
+++ b/src/dsfr/component/header/style/module/_links.scss
@@ -81,12 +81,14 @@
     }
 
     #{ns(translate)} {
-      @include margin-x(-2v);
-      @include margin-x(0, lg);
       @include margin-bottom(-4v, lg);
+      
+      &__language {
+        @include padding-left(10v);
+      }
 
-      &__btn {
-        @include padding-x(2v);
+      #{ns(menu)}__list {
+        @include margin-x(-4v);
       }
     }
 
@@ -94,19 +96,22 @@
       &:not(#{ns-group(btns)}--sm):not(#{ns-group(btns)}--lg) {
         @include class-not-start-with(#{ns(btns-group--icon-, '')}) {
           @include display-flex(column);
+          @include margin-x(0);
 
           #{ns(btn)} {
             @include has-icon {
               @include min-size(null, 12v);
-              @include padding-x(0);
+              @include padding-x(4v);
+              @include width(100%);
             }
 
             @include has-not-icon {
               @include min-size(null, 12v);
-              @include padding-x(0);
+              @include padding-x(4v);
+              @include width(100%);
             }
-
-            @include margin-bottom(0);
+            
+            @include margin(0);
           }
         }
       }

--- a/src/dsfr/component/header/style/module/_links.scss
+++ b/src/dsfr/component/header/style/module/_links.scss
@@ -68,6 +68,12 @@
       @include size(calc(100% + 8v), 1px);
     }
 
+    &:last-child,
+    &:empty,
+    &:not(:has(*)) {
+      @include after(normal, null);
+    }
+
     #{ns(btn)} {
       @include preference.forced-colors {
         border: none;

--- a/src/dsfr/component/header/template/ejs/header-tools.ejs
+++ b/src/dsfr/component/header/template/ejs/header-tools.ejs
@@ -28,7 +28,9 @@
             <% } %>
           </ul>
         <% } else { %>
-          <%- include('../../../button/template/ejs/button', {button:tools.links.buttons[0]}); %>
+          <div class="<%= prefix %>-btns-group">
+            <%- include('../../../button/template/ejs/button', {button:tools.links.buttons[0]}); %>
+          </div>
         <% } %>
       <% } %>
       <% if (tools.translate !== undefined) { %>

--- a/src/dsfr/component/navigation/style/module/_default.scss
+++ b/src/dsfr/component/navigation/style/module/_default.scss
@@ -81,6 +81,19 @@
     @include text-style(md);
     text-align: left;
 
+    @include selector.current {
+      position: relative;
+      @include before('', block) {
+        @include absolute(50%, null, null, 0, 2px, 6v);
+        @include margin-top(-3v);
+
+        @include preference.forced-colors {
+          background-color: highlight;
+          @include width(1v);
+        }
+      }
+    }
+
     @include respond-from(lg) {
       min-height: spacing.space(14v);
       @include padding(4v);
@@ -88,15 +101,13 @@
       font-weight: normal;
 
       @include selector.current {
-        @include relative;
-
         @include before('') {
           @include absolute(auto, null, 0, 0, 100%, 2px);
           @include margin-top(0);
 
           @include preference.forced-colors {
-            background-color: highlight;
             @include height(1v);
+            @include width(100%);
           }
         }
       }

--- a/src/dsfr/component/navigation/style/module/_mega-menu.scss
+++ b/src/dsfr/component/navigation/style/module/_mega-menu.scss
@@ -64,8 +64,8 @@
   &__leader {
     @include enable-underline;
     @include margin-top(-5v, lg);
-    @include padding-top(2v);
-    @include padding-top(0, lg);
+    @include padding(2v 0 4v);
+    @include padding(0, lg);
     @include set-text-margin(0 0 2v);
     @include set-title-margin(0 0 2v);
     @include nest-link(sm, null);


### PR DESCRIPTION
Bonjour,

Je souhaite à toute la communauté et toute l'équipe une belle année 2026 :bowtie:

Voici la PR pour l'issue #1265 concernant l'alignement des éléments de l'en-tête et la navigation en version "mobile".

#### 1. Uniformise les marges des raccourcis dans une liste

| Avant | Après |
|-------|-------|
| <img width="347" height="398" alt="Capture d&#39;écran 2026-01-13 075935" src="https://github.com/user-attachments/assets/033b84ae-9a0a-408f-ba77-ebd0d62fc9ce" />  | <img width="347" height="398" alt="Capture d&#39;écran 2026-01-13 080706" src="https://github.com/user-attachments/assets/4e56cbf2-c2fe-4850-ba9c-65bf2fffaebe" /> |

#### 2. Affiche un raccourci de la même façon avec ou sans liste

| Avant | Après |
|-------|-------|
| <img width="347" height="467" alt="Capture d&#39;écran 2026-01-13 080011" src="https://github.com/user-attachments/assets/aee127ff-0fa2-4e44-ab99-bad4e6a8390d" />  |  <img width="347" height="467" alt="Capture d&#39;écran 2026-01-13 082647" src="https://github.com/user-attachments/assets/2ea1016b-d10e-4750-b4ca-e89220b6d84c" /> |

#### 3. Cache le séparateur des raccourcis quand il n'y a pas de navigation 

| Avant | Après |
|-------|-------|
| <img width="347" height="467" alt="Capture d&#39;écran 2026-01-13 075852" src="https://github.com/user-attachments/assets/1c04a79a-e9ab-4e42-9491-409a4e0d5a2c" /> | <img width="347" height="467" alt="Capture d&#39;écran 2026-01-13 080624" src="https://github.com/user-attachments/assets/8447e03c-9788-4f87-98b0-1d7077a2eae9" /> |

#### 4. Identifie comme "actif" les N1 dépliants dans la navigation

| Avant | Après |
|-------|-------|
| <img width="347" height="467" alt="Capture d&#39;écran 2026-01-13 080142" src="https://github.com/user-attachments/assets/3bf9f608-0d33-4dd7-8972-41a884851e69" /> | <img width="347" height="467" alt="Group 3" src="https://github.com/user-attachments/assets/41804cda-393a-4cee-b618-429416a83e72" /> |

#### 5. Aligne pas tous les éléments uniformément dans l'en-tête

| Avant | Après |
|-------|-------|
| <img width="347" height="542" alt="Capture d&#39;écran 2026-01-13 100600" src="https://github.com/user-attachments/assets/7da6dc6d-bbbc-430e-af7d-44945eb26771" /> | <img width="347" height="542" alt="Capture d&#39;écran 2026-01-16 160415" src="https://github.com/user-attachments/assets/1fe141c2-e457-4aa4-8c83-58e15693b055" /> |

Sur ce dernier correctif je suis très partagé car la navigation N2 n'est aligné avec rien. Dans un des fichiers, elle est alignée avec le N1 mais il est très difficile de distinguer la séparation d'une catégorie  et ses enfants N2  du N1 suivant s'il n'est pas "dépliant". 
L'autre possibilité serait d'aligner les N2 sur le sélecteur de langue mais à ce moment là on aurait un espacement différent à gauche des N1... :confounded:
 
Tous vos retours sont les bienvenus pour améliorer cette PR.