### PR TITLE
feat(grid): autorise la surcharge de $grid-settings

### DIFF
--- a/src/dsfr/core/style/grid/_module.scss
+++ b/src/dsfr/core/style/grid/_module.scss
@@ -8,4 +8,4 @@
 @import 'module/container';
 
 // Génère les conteneurs, les colonnes et les écarts de colonnes
-@include grid($grid-settings);
+@include grid();

--- a/src/dsfr/core/style/grid/_setting.scss
+++ b/src/dsfr/core/style/grid/_setting.scss
@@ -2,8 +2,11 @@
 /// Core Setting : Grid
 /// @group core
 ////
+@use 'sass:map';
 
-$grid-settings: (
+$grid-settings: null;
+
+$grid-settings-default: (
   columns: 12,
   breakpoints: (
     first: (
@@ -17,3 +20,24 @@ $grid-settings: (
     )
   )
 );
+
+@mixin set-breakpoints($v) {
+  $dsfr-breakpoints-v:  map.get($grid-settings-default, breakpoints);
+  $v: (breakpoints: map.deep-merge($v, $dsfr-breakpoints-v));
+
+  $grid-settings: map.deep-merge($grid-settings-default, $v) !global;
+}
+
+@function get($name: null) {
+  $settings: if($grid-settings == null, $grid-settings-default, $grid-settings);
+
+  @if $name == null {
+    @return $settings;
+  } @else {
+    @if map.has-key($settings, $name) == false {
+      @error 'Unknown property `#{$name}` into $grid-settings.';
+    }
+
+    @return map.get($settings, $name);
+  }
+}

--- a/src/dsfr/core/style/grid/tool/_col.scss
+++ b/src/dsfr/core/style/grid/tool/_col.scss
@@ -14,7 +14,10 @@
 ///   .foo {
 ///     @include grid-col(6);
 ///   }
-@mixin grid-col($size, $columns: 12) {
+
+@use '../setting';
+
+@mixin grid-col($size, $columns: setting.get(columns)) {
   $percent: #{100% * $size};
   $calc: 'calc(#{$percent} / #{$columns})';
   flex: 0 0 #{$calc};
@@ -33,7 +36,7 @@
 ///   .foo {
 ///     @include grid-col-offset(2);
 ///   }
-@mixin grid-col-offset($size, $columns: 12) {
+@mixin grid-col-offset($size, $columns: setting.get(columns)) {
   $percent: #{100% * $size};
   $calc: 'calc(#{$percent} / #{$columns})';
 

--- a/src/dsfr/core/style/grid/tool/_grid.scss
+++ b/src/dsfr/core/style/grid/tool/_grid.scss
@@ -5,7 +5,7 @@
 
 /// Génère les classes de colonne pour la grille ainsi que les offsets (optionnel)
 ///
-/// @param {Map} $columns [$grid-settings] - configuration de la grille
+/// @param {Map} $columns [null] - configuration de la grille
 /// @param {Bool} $with-container [true] - si true, définit les containers
 /// @param {Bool} $with-offsets [true] - si true, définit les offsets
 ///
@@ -13,9 +13,12 @@
 ///
 /// @example scss - Génère les colonnes
 ///   @include grid-generator();
-@mixin grid($settings: $grid-settings, $with-container: true, $with-offsets: true) {
+
+@use '../setting';
+
+@mixin grid($settings: setting.get(), $with-container: true, $with-offsets: true) {
   $columns: map-get($settings, columns);
-  $breakpoints-settings: map-get($grid-settings, breakpoints);
+  $breakpoints-settings: map-get($settings, breakpoints);
   $last-gutter: 0;
   $last-max-width: null;
   $containers: ();

--- a/src/dsfr/core/style/selector/setting/_breakpoint.scss
+++ b/src/dsfr/core/style/selector/setting/_breakpoint.scss
@@ -3,10 +3,6 @@
 /// @group core
 ////
 
-$breakpoints: (
-  xs: 0 35.98em,
-  sm: 36em 47.98em,
-  md: 48em 61.98em,
-  lg: 62em 77.98em,
-  xl: 78em,
-) !default;
+@use 'src/module/media-query';
+
+$breakpoints: media-query.breakpoints();

--- a/src/module/media-query/_index.scss
+++ b/src/module/media-query/_index.scss
@@ -1,2 +1,3 @@
 @forward 'mixin/respond-from';
 @forward 'mixin/contrast';
+@forward 'function/breakpoints'

--- a/src/module/media-query/function/_breakpoints.scss
+++ b/src/module/media-query/function/_breakpoints.scss
@@ -1,0 +1,5 @@
+@use '../variable/breakpoints';
+
+@function breakpoints() {
+  @return if(breakpoints.$values == null, breakpoints.$defaults, breakpoints.$values);
+}

--- a/src/module/media-query/mixin/_respond-from.scss
+++ b/src/module/media-query/mixin/_respond-from.scss
@@ -1,4 +1,4 @@
-@use '../variable/breakpoints';
+@use '../function/breakpoints';
 
 /// Set media query styles
 ///
@@ -10,7 +10,7 @@
 ///     }
 ///   }
 @mixin respond-from($media) {
-  $limits: map_get(breakpoints.$values, $media);
+  $limits: map_get(breakpoints.breakpoints(), $media);
 
   @if $limits != null {
     @media (min-width: nth($limits, 1)) {

--- a/src/module/media-query/variable/_breakpoints.scss
+++ b/src/module/media-query/variable/_breakpoints.scss
@@ -9,4 +9,4 @@ $values: (
   md: 48em 61.98em,
   lg: 62em 77.98em,
   xl: 78em,
-) !default;
+);

--- a/src/module/media-query/variable/_breakpoints.scss
+++ b/src/module/media-query/variable/_breakpoints.scss
@@ -3,10 +3,31 @@
 /// @group media-query
 ////
 
-$values: (
+@use 'sass:map';
+@use 'sass:list';
+
+$defaults: (
   xs: 0 35.98em,
   sm: 36em 47.98em,
   md: 48em 61.98em,
   lg: 62em 77.98em,
   xl: 78em,
 );
+
+$values: null;
+
+@mixin set($v) {
+  // retire les points de rupture qui ne peuvent pas être surchargés
+  $v: map.remove($v, xs, sm, md, lg);
+
+  @if(map.has-key($v, xl)) {
+    $dsfr-xl-v: map.get($defaults, xl);
+    $xl-v: map.get($v, xl);
+    // vérifie que le point de rupture "xl" commence bien avec la valeur définie par le DSFR
+    @if(list.index($xl-v, $dsfr-xl-v) != 1) {
+     @error('xl breakpoint does not start with the correct value: #{$dsfr-xl-v} and cannot be overrided.');
+    }
+  }
+  
+  $values: map.deep-merge($defaults, $v) !global;
+};

--- a/src/module/shame/media-query/mixin/_order.scss
+++ b/src/module/shame/media-query/mixin/_order.scss
@@ -1,8 +1,7 @@
-@use 'src/module/media-query/variable/breakpoints';
 @use 'src/module/media-query';
 
 @mixin order () {
-  @each $bp, $limits in breakpoints.$values {
+  @each $bp, $limits in media-query.breakpoints() {
     @if $bp != xs {
       @include media-query.respond-from($bp) {
         /*! media #{$bp} */


### PR DESCRIPTION
Hello,

Afin d'offrir quelques super-pouvoirs supplémentaires au DSFR, il pourrait être intéressant que la variable `$grid-settings` soit "libérée" comme c'est déjà le cas pour `$breakpoints`.

L'objectif de cette demande est de permettre de définir des points de rupture au-delà de `XL` et de lever la limite des `1200px` du contenu dans des environnements métiers maitrisés. Le tout sans faire du CSS inmaintenable/interminable évidemment.

J'en profite pour vous partager mon implémentation afin d'avoir votre retour : 
```scss
$prj-breakpoints: (
  xl: 78em NN.NNem,
  xxl: NNem NNN.NNem,
  xxxl: NNNem
);
$prj-grid-settings: (
  breakpoints: (
    xxl: (
      max-width: NNNv // 1NNN
    ),
    xxxl: (
      max-width: NNNv // 1NNN
    )
  )
);

@use 'sass:map';
@use '@gouvfr/dsfr/src/module/path';
@use '@gouvfr/dsfr/src/module/path/variable/dist' as path-var;
@use '@gouvfr/dsfr/src/module/shame/media-query' as shame-mq;
@use '@gouvfr/dsfr/src/dsfr/core/style/setting' as style-setting;

$breakpoints: map.deep-merge(style-setting.$breakpoints, $prj-breakpoints);
$grid-settings: map.deep-merge(style-setting.$grid-settings, $prj-grid-settings);

@include path-var.set('/assets/vendor/dsfr/');
@include path.to-dist(0);
@include shame-mq.order;

@import '@gouvfr/dsfr/src/dsfr/core/main';
@import '@gouvfr/dsfr/src/dsfr/scheme/main';
@import '@gouvfr/dsfr/src/dsfr/component/main';
@import '@gouvfr/dsfr/src/dsfr/utility/main';
```

En espérant que cette modification soit possible 🤞🏻 