### PR TITLE
✨ feat(analytics): ajout de l'attribut action reduce

### DIFF
--- a/src/dsfr/analytics/_part/doc/code/actions/component-actions/index.md
+++ b/src/dsfr/analytics/_part/doc/code/actions/component-actions/index.md
@@ -97,5 +97,10 @@ Vous trouverez pour chaque composant une colonne :
 
 * * *
 
+> [!TIP]
+> Il est possible de retirer des actions à remonter, en utilisant l'attribut `data-fr-analytics-action` sur un élément instancié d’un composant.
+> - Avec `data-fr-analytics-action="false"`, l'action est initialisée mais non activée. L'élément est traqué, mais aucune action n'est envoyée à Eulérian lors de l'interaction.
+> - Avec `data-fr-analytics-action="reduce"`, l'action n'est pas initialisée. L'élément n'est pas traqué, et aucune action n'est envoyée à Eulérian lors de l'interaction.
+
 > [!NOTE]
 > Il reste possible d’ajouter plus d’actions à remonter, en utilisant les attributs utilitaires `data-fr-analytics-{action}` sur un élément HTML d’un composant (voir : [Actions d’interaction hors composant](../custom-actions/index.md)).

--- a/src/dsfr/analytics/_part/doc/code/actions/index.md
+++ b/src/dsfr/analytics/_part/doc/code/actions/index.md
@@ -55,10 +55,16 @@ exemple d’actionName : `(click)_titre_niveau_2_›_titre_niveau_3_›_label_de
 
 Par défaut, l'envoi des actions est désactivé. Le paramètre de configuration `isActionEnabled` permet de l'activer. (voir [isActionEnabled dans Analytics](../collector/analytics/index.md#isActionEnabled)).
 Il est possible de d'activer l'envoi sporadiquement sur un élément particulier en utilisant l'attribut `data-fr-analytics-action`, qui permet également de donner une valeur spécifique au title de l'[ActionName](#ActionName).
-À l'inverse, il est possible de désactiver l'envoi d'actions sur un élément particulier en utilisant l'attribut `data-fr-analytics-action="false"` lorsque l'envoi d'actions est activé au global.
 
 > [!NOTE]
 > Dans le cas spécifique où la présence de nombreux éléments dans le DOM pourrait générer de la latence et qu'une optimisation des instances de tracking est nécessaire, il est possible de passer la valeur `reduce` à la propriété `isActionEnabled` pour que seules les instances ayant l'attribut `data-fr-analytics-action` soient générées par l'API.
+
+#### Désactiver les actions
+
+À l'inverse, il est possible de désactiver l'envoi d'actions lorsque le paramètre de configuration `isActionEnabled` est activé, en utilisant l'attribut `data-fr-analytics-action` sur un élément qui est automatiquement traqué par l'API analytics (par exemple, un bouton avec la classe `.fr-btn`).
+
+- L'attribut `data-fr-analytics-action="false"` permet de désactiver l'envoi d'actions sur l'élément, tout en laissant l'instance de tracking associée à cet élément initialisée. L'élément est traqué, mais aucune action n'est envoyée à Eulérian lors de l'interaction. Ce qui peut permettre de l'activer plus tard, de manière conditionnelle.
+- L'attribut `data-fr-analytics-action="reduce"` permet de désactiver l'envoi d'actions sur un élément particulier, en empêchant l'initialisation de l'instance de tracking associée à cet élément. L'élément n'est pas traqué, et aucune action n'est envoyée à Eulérian lors de l'interaction. Cette option est à privilégier lorsque l'élément n'est pas pertinent à tracker, ou que la présence de nombreux éléments dans le DOM pourrait générer de la latence et qu'une optimisation des instances de tracking est nécessaire.
 
 #### Taux d'interaction
 

--- a/src/dsfr/analytics/example/action/index.ejs
+++ b/src/dsfr/analytics/example/action/index.ejs
@@ -1,14 +1,23 @@
 <div class="<%= prefix %>-container" >
   <div>
     <h4>action activée</h4>
+    <p>Avec l'attribut data-<%= prefix %>-analytics-action="libellé envoyé à l'analytics", l'action est initialisée et activée. Le libellé envoyé à l'analytics correspond à la valeur de l'attribut.</p>
     <div class="<%= prefix %>-mb-6v">
       <button type="button" class="<%= prefix %>-btn" data-<%= prefix %>-analytics-action="libellé envoyé à l'analytics" id="action-true" >libellé du bouton</button>
     </div>
   </div>
   <div>
     <h4>action prévenue</h4>
+    <p>Avec l'attribut data-<%= prefix %>-analytics-action="false", l'action est initialisée mais non activée.</p>
     <div class="<%= prefix %>-mb-6v">
       <button type="button" class="<%= prefix %>-btn" data-<%= prefix %>-analytics-action="false" id="action-false" >libellé du bouton</button>
+    </div>
+  </div>
+  <div>
+    <h4>action retirée</h4>
+    <p>Avec l'attribut data-<%= prefix %>-analytics-action="reduce", l'action n'est pas initialisée. Et ne peut pas être activée.</p>
+    <div class="<%= prefix %>-mb-6v">
+      <button type="button" class="<%= prefix %>-btn" data-<%= prefix %>-analytics-action="reduce" id="action-reduce" >libellé du bouton</button>
     </div>
   </div>
 </div>

--- a/src/dsfr/analytics/script/integration/component/accordion/accordion-selector.js
+++ b/src/dsfr/analytics/script/integration/component/accordion/accordion-selector.js
@@ -2,5 +2,6 @@ import api from '../../../../api';
 
 export const AccordionSelector = {
   ACCORDION: api.internals.ns.selector('accordion'),
-  TITLE: api.internals.ns.selector('accordion__title')
+  TITLE: api.internals.ns.selector('accordion__title'),
+  COLLAPSE: `${api.accordion.AccordionSelector.COLLAPSE}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`
 };

--- a/src/dsfr/analytics/script/integration/component/accordion/integrate.js
+++ b/src/dsfr/analytics/script/integration/component/accordion/integrate.js
@@ -1,10 +1,11 @@
 import api from '../../../../api';
 import { AccordionActionee } from './accordion-actionee';
 import { joinSelector } from '../../join-selector';
+import { AccordionSelector } from './accordion-selector';
 
 const integrateAccordion = (selector = '') => {
   if (api.accordion) {
-    api.internals.register(joinSelector(api.accordion.AccordionSelector.COLLAPSE, selector), AccordionActionee);
+    api.internals.register(joinSelector(AccordionSelector.COLLAPSE, selector), AccordionActionee);
   }
 };
 

--- a/src/dsfr/analytics/script/integration/component/alert/alert-selector.js
+++ b/src/dsfr/analytics/script/integration/component/alert/alert-selector.js
@@ -1,6 +1,6 @@
 import api from '../../../../api';
 
 export const AlertSelector = {
-  ALERT: api.internals.ns.selector('alert'),
+  ALERT: `${api.internals.ns.selector('alert')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`,
   TITLE: api.internals.ns.selector('alert__title')
 };

--- a/src/dsfr/analytics/script/integration/component/badge/badge-selector.js
+++ b/src/dsfr/analytics/script/integration/component/badge/badge-selector.js
@@ -1,5 +1,5 @@
 import api from '../../../../api';
 
 export const BadgeSelector = {
-  BADGE: api.internals.ns.selector('badge')
+  BADGE: `${api.internals.ns.selector('badge')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`
 };

--- a/src/dsfr/analytics/script/integration/component/breadcrumb/breadcrumb-selector.js
+++ b/src/dsfr/analytics/script/integration/component/breadcrumb/breadcrumb-selector.js
@@ -1,6 +1,6 @@
 import api from '../../../../api';
 
 export const BreadcrumbSelector = {
-  LINK: `${api.internals.ns.selector('breadcrumb__link')}:not([aria-current])`,
-  COLLAPSE: `${api.internals.ns.selector('breadcrumb')} ${api.internals.ns.selector('collapse')}`
+  LINK: `${api.internals.ns.selector('breadcrumb__link')}:not([aria-current]):not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`,
+  COLLAPSE: `${api.internals.ns.selector('breadcrumb')} ${api.internals.ns.selector('collapse')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`
 };

--- a/src/dsfr/analytics/script/integration/component/button/button-selector.js
+++ b/src/dsfr/analytics/script/integration/component/button/button-selector.js
@@ -1,5 +1,5 @@
 import api from '../../../../api.js';
 
 export const ButtonSelector = {
-  BUTTON: `${api.internals.ns.selector('btn')}:not(${api.internals.ns.selector('btn--close')})`
+  BUTTON: `${api.internals.ns.selector('btn')}:not(${api.internals.ns.selector('btn--close')}):not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`
 };

--- a/src/dsfr/analytics/script/integration/component/callout/callout-selector.js
+++ b/src/dsfr/analytics/script/integration/component/callout/callout-selector.js
@@ -1,6 +1,6 @@
 import api from '../../../../api';
 
 export const CalloutSelector = {
-  CALLOUT: api.internals.ns.selector('callout'),
+  CALLOUT: `${api.internals.ns.selector('callout')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`,
   TITLE: api.internals.ns.selector('callout__title')
 };

--- a/src/dsfr/analytics/script/integration/component/card/card-selector.js
+++ b/src/dsfr/analytics/script/integration/component/card/card-selector.js
@@ -1,7 +1,7 @@
 import api from '../../../../api';
 
 export const CardSelector = {
-  CARD: api.internals.ns.selector('card'),
+  CARD: `${api.internals.ns.selector('card')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`,
   LINK: `${api.internals.ns.selector('card__title')} a, ${api.internals.ns.selector('card__title')} button`,
   TITLE: api.internals.ns.selector('card__title')
 };

--- a/src/dsfr/analytics/script/integration/component/checkbox/checkbox-selector.js
+++ b/src/dsfr/analytics/script/integration/component/checkbox/checkbox-selector.js
@@ -1,5 +1,5 @@
 import api from '../../../../api';
 
 export const CheckboxSelector = {
-  INPUT: api.internals.ns.selector('checkbox-group [type="checkbox"]')
+  INPUT: `${api.internals.ns.selector('checkbox-group [type="checkbox"]')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`
 };

--- a/src/dsfr/analytics/script/integration/component/connect/connect-selector.js
+++ b/src/dsfr/analytics/script/integration/component/connect/connect-selector.js
@@ -1,6 +1,6 @@
 import api from '../../../../api.js';
 
 export const ConnectSelector = {
-  CONNECT: api.internals.ns.selector('connect'),
-  LINK: api.internals.ns.selector('connect + * a, connect + a')
+  CONNECT: `${api.internals.ns.selector('connect')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`,
+  LINK: `${api.internals.ns.selector('connect + * a, connect + a')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`
 };

--- a/src/dsfr/analytics/script/integration/component/consent/consent-selector.js
+++ b/src/dsfr/analytics/script/integration/component/consent/consent-selector.js
@@ -1,5 +1,5 @@
 import api from '../../../../api';
 
 export const ConsentSelector = {
-  BANNER: api.internals.ns.selector('consent-banner')
+  BANNER: `${api.internals.ns.selector('consent-banner')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`
 };

--- a/src/dsfr/analytics/script/integration/component/content/content-selector.js
+++ b/src/dsfr/analytics/script/integration/component/content/content-selector.js
@@ -1,6 +1,6 @@
 import api from '../../../../api';
 
 export const ContentSelector = {
-  CONTENT: api.internals.ns.selector('content-media'),
+  CONTENT: `${api.internals.ns.selector('content-media')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`,
   IMG: api.internals.ns.selector('content-media__img')
 };

--- a/src/dsfr/analytics/script/integration/component/download/download-selector.js
+++ b/src/dsfr/analytics/script/integration/component/download/download-selector.js
@@ -1,5 +1,5 @@
 import api from '../../../../api';
 
 export const DownloadSelector = {
-  LINK: api.internals.ns.selector('download__link')
+  LINK: `${api.internals.ns.selector('download__link')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`
 };

--- a/src/dsfr/analytics/script/integration/component/follow/follow-selector.js
+++ b/src/dsfr/analytics/script/integration/component/follow/follow-selector.js
@@ -1,6 +1,6 @@
 import api from '../../../../api';
 
 export const FollowSelector = {
-  FOLLOW: api.internals.ns.selector('follow'),
-  NEWSLETTER_INPUT_GROUP: api.internals.ns.selector('follow__newsletter') + ' ' + api.internals.ns.selector('input-group')
+  FOLLOW: `${api.internals.ns.selector('follow')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`,
+  NEWSLETTER_INPUT_GROUP: `${api.internals.ns.selector('follow__newsletter')} ${api.internals.ns.selector('input-group')}`
 };

--- a/src/dsfr/analytics/script/integration/component/footer/footer-selector.js
+++ b/src/dsfr/analytics/script/integration/component/footer/footer-selector.js
@@ -1,6 +1,6 @@
 import api from '../../../../api';
 
 export const FooterSelector = {
-  FOOTER: api.internals.ns.selector('footer'),
-  FOOTER_LINKS: `${api.internals.ns.selector('footer')} a[href], ${api.internals.ns.selector('footer')} button`
+  FOOTER: `${api.internals.ns.selector('footer')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`,
+  FOOTER_LINKS: `${api.internals.ns.selector('footer')} a[href]:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')}), ${api.internals.ns.selector('footer')} button:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`
 };

--- a/src/dsfr/analytics/script/integration/component/header/header-selector.js
+++ b/src/dsfr/analytics/script/integration/component/header/header-selector.js
@@ -1,6 +1,8 @@
 import api from '../../../../api.js';
 
 export const HeaderSelector = {
-  TOOLS_BUTTON: `${api.internals.ns.selector('header__tools-links')} ${api.internals.ns.selector('btns-group')} ${api.internals.ns.selector('btn')}`,
-  MENU_BUTTON: `${api.internals.ns.selector('header__menu-links')} ${api.internals.ns.selector('btns-group')} ${api.internals.ns.selector('btn')}`
+  HEADER: `${api.header.HeaderSelector.HEADER}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`,
+  MODALS: `${api.header.HeaderSelector.MODALS}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`,
+  TOOLS_BUTTON: `${api.internals.ns.selector('header__tools-links')} ${api.internals.ns.selector('btns-group')} ${api.internals.ns.selector('btn')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`,
+  MENU_BUTTON: `${api.internals.ns.selector('header__menu-links')} ${api.internals.ns.selector('btns-group')} ${api.internals.ns.selector('btn')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`
 };

--- a/src/dsfr/analytics/script/integration/component/header/integrate.js
+++ b/src/dsfr/analytics/script/integration/component/header/integrate.js
@@ -8,8 +8,8 @@ import { joinSelector } from '../../join-selector';
 
 const integrateHeader = (selector = '') => {
   if (api.header) {
-    api.internals.register(joinSelector(api.header.HeaderSelector.HEADER, selector), HeaderActionee);
-    api.internals.register(joinSelector(api.header.HeaderSelector.MODALS, selector), HeaderModalActionee);
+    api.internals.register(joinSelector(HeaderSelector.HEADER, selector), HeaderActionee);
+    api.internals.register(joinSelector(HeaderSelector.MODALS, selector), HeaderModalActionee);
     api.internals.register(joinSelector(HeaderSelector.TOOLS_BUTTON, selector), HeaderToolsButtonActionee);
     api.internals.register(joinSelector(HeaderSelector.MENU_BUTTON, selector), HeaderMenuButtonActionee);
   }

--- a/src/dsfr/analytics/script/integration/component/highlight/highlight-selector.js
+++ b/src/dsfr/analytics/script/integration/component/highlight/highlight-selector.js
@@ -1,5 +1,5 @@
 import api from '../../../../api';
 
 export const HighlightSelector = {
-  HIGHLIGHT: api.internals.ns.selector('highlight')
+  HIGHLIGHT: `${api.internals.ns.selector('highlight')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`
 };

--- a/src/dsfr/analytics/script/integration/component/input/input-selector.js
+++ b/src/dsfr/analytics/script/integration/component/input/input-selector.js
@@ -1,5 +1,5 @@
 import api from '../../../../api';
 
 export const InputSelector = {
-  INPUT: api.internals.ns.selector('input-group')
+  INPUT: `${api.internals.ns.selector('input-group')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`
 };

--- a/src/dsfr/analytics/script/integration/component/link/link-selector.js
+++ b/src/dsfr/analytics/script/integration/component/link/link-selector.js
@@ -1,5 +1,5 @@
 import api from '../../../../api';
 
 export const LinkSelector = {
-  LINK: api.internals.ns.selector('link')
+  LINK: `${api.internals.ns.selector('link')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`
 };

--- a/src/dsfr/analytics/script/integration/component/modal/integrate.js
+++ b/src/dsfr/analytics/script/integration/component/modal/integrate.js
@@ -1,10 +1,11 @@
 import api from '../../../../api';
 import { ModalActionee } from './modal-actionee';
 import { joinSelector } from '../../join-selector';
+import { ModalSelector } from './modal-selector';
 
 const integrateModal = (selector = '') => {
   if (api.modal) {
-    api.internals.register(joinSelector(api.modal.ModalSelector.MODAL, selector), ModalActionee);
+    api.internals.register(joinSelector(ModalSelector.MODAL, selector), ModalActionee);
   }
 };
 

--- a/src/dsfr/analytics/script/integration/component/modal/modal-selector.js
+++ b/src/dsfr/analytics/script/integration/component/modal/modal-selector.js
@@ -1,5 +1,6 @@
 import api from '../../../../../core/api.js';
 
 export const ModalSelector = {
+  MODAL: `${api.modal.ModalSelector.MODAL}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`,
   TITLE: api.internals.ns.selector('modal__title')
 };

--- a/src/dsfr/analytics/script/integration/component/navigation/integrate.js
+++ b/src/dsfr/analytics/script/integration/component/navigation/integrate.js
@@ -7,9 +7,9 @@ import { joinSelector } from '../../join-selector';
 
 const integrateNavigation = (selector = '') => {
   if (api.navigation) {
-    api.internals.register(joinSelector(api.navigation.NavigationSelector.NAVIGATION, selector), NavigationActionee);
+    api.internals.register(joinSelector(NavigationSelector.NAVIGATION, selector), NavigationActionee);
     api.internals.register(joinSelector(NavigationSelector.LINK, selector), NavigationLinkActionee);
-    api.internals.register(joinSelector(api.navigation.NavigationSelector.COLLAPSE, selector), NavigationSectionActionee);
+    api.internals.register(joinSelector(NavigationSelector.COLLAPSE, selector), NavigationSectionActionee);
   }
 };
 

--- a/src/dsfr/analytics/script/integration/component/navigation/navigation-selector.js
+++ b/src/dsfr/analytics/script/integration/component/navigation/navigation-selector.js
@@ -1,6 +1,8 @@
 import api from '../../../../api';
 
 export const NavigationSelector = {
-  LINK: api.internals.ns.selector('nav__link'),
+  NAVIGATION: `${api.navigation.NavigationSelector.NAVIGATION}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`,
+  COLLAPSE: `${api.navigation.NavigationSelector.COLLAPSE}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`,
+  LINK: `${api.internals.ns.selector('nav__link')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`,
   BUTTON: api.internals.ns.selector('nav__btn')
 };

--- a/src/dsfr/analytics/script/integration/component/notice/notice-selector.js
+++ b/src/dsfr/analytics/script/integration/component/notice/notice-selector.js
@@ -1,7 +1,7 @@
 import api from '../../../../api';
 
 export const NoticeSelector = {
-  NOTICE: api.internals.ns.selector('notice'),
+  NOTICE: `${api.internals.ns.selector('notice')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`,
   TITLE: api.internals.ns.selector('notice__title'),
-  LINK: api.internals.ns.selector('notice a')
+  LINK: `${api.internals.ns.selector('notice a')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`
 };

--- a/src/dsfr/analytics/script/integration/component/pagination/pagination-selector.js
+++ b/src/dsfr/analytics/script/integration/component/pagination/pagination-selector.js
@@ -1,8 +1,8 @@
 import api from '../../../../api.js';
 
 export const PaginationSelector = {
-  PAGINATION: api.internals.ns.selector('pagination'),
-  LINK: api.internals.ns.selector('pagination__link'),
+  PAGINATION: `${api.internals.ns.selector('pagination')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`,
+  LINK: `${api.internals.ns.selector('pagination__link')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`,
   NEXT_LINK: api.internals.ns.selector('pagination__link--next'),
   LAST_LINK: api.internals.ns.selector('pagination__link--last'),
   ANALYTICS_TOTAL: api.internals.ns.attr('analytics-page-total'),

--- a/src/dsfr/analytics/script/integration/component/quote/quote-selector.js
+++ b/src/dsfr/analytics/script/integration/component/quote/quote-selector.js
@@ -1,5 +1,5 @@
 import api from '../../../../api';
 
 export const QuoteSelector = {
-  QUOTE: api.internals.ns.selector('quote')
+  QUOTE: `${api.internals.ns.selector('quote')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`
 };

--- a/src/dsfr/analytics/script/integration/component/radio/radio-selector.js
+++ b/src/dsfr/analytics/script/integration/component/radio/radio-selector.js
@@ -1,5 +1,5 @@
 import api from '../../../../api';
 
 export const RadioSelector = {
-  INPUT: api.internals.ns.selector('radio-group [type="radio"]')
+  INPUT: `${api.internals.ns.selector('radio-group [type="radio"]')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`
 };

--- a/src/dsfr/analytics/script/integration/component/search/search-selector.js
+++ b/src/dsfr/analytics/script/integration/component/search/search-selector.js
@@ -1,5 +1,5 @@
 import api from '../../../../api';
 
 export const SearchSelector = {
-  SEARCH_BAR: api.internals.ns.selector('search-bar')
+  SEARCH_BAR: `${api.internals.ns.selector('search-bar')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`
 };

--- a/src/dsfr/analytics/script/integration/component/select/select-selector.js
+++ b/src/dsfr/analytics/script/integration/component/select/select-selector.js
@@ -1,5 +1,5 @@
 import api from '../../../../api';
 
 export const SelectSelector = {
-  SELECT: api.internals.ns.selector('select')
+  SELECT: `${api.internals.ns.selector('select')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`
 };

--- a/src/dsfr/analytics/script/integration/component/share/share-selector.js
+++ b/src/dsfr/analytics/script/integration/component/share/share-selector.js
@@ -1,6 +1,6 @@
 import api from '../../../../api';
 
 export const ShareSelector = {
-  SHARE: api.internals.ns.selector('share'),
+  SHARE: `${api.internals.ns.selector('share')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`,
   TITLE: api.internals.ns.selector('share__title')
 };

--- a/src/dsfr/analytics/script/integration/component/sidemenu/integrate.js
+++ b/src/dsfr/analytics/script/integration/component/sidemenu/integrate.js
@@ -9,7 +9,7 @@ const integrateSidemenu = (selector) => {
   if (api.sidemenu) {
     api.internals.register(joinSelector(SidemenuSelector.SIDEMENU, selector), SidemenuActionee);
     api.internals.register(joinSelector(SidemenuSelector.LINK, selector), SidemenuLinkActionee);
-    api.internals.register(joinSelector(api.sidemenu.SidemenuSelector.COLLAPSE, selector), SidemenuSectionActionee);
+    api.internals.register(joinSelector(SidemenuSelector.COLLAPSE, selector), SidemenuSectionActionee);
   }
 };
 

--- a/src/dsfr/analytics/script/integration/component/sidemenu/sidemenu-selector.js
+++ b/src/dsfr/analytics/script/integration/component/sidemenu/sidemenu-selector.js
@@ -1,9 +1,10 @@
 import api from '../../../../api';
 
 export const SidemenuSelector = {
-  SIDEMENU: api.internals.ns.selector('sidemenu'),
+  SIDEMENU: `${api.internals.ns.selector('sidemenu')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`,
   ITEM: api.internals.ns.selector('sidemenu__item'),
-  LINK: api.internals.ns.selector('sidemenu__link'),
+  LINK: `${api.internals.ns.selector('sidemenu__link')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`,
   BUTTON: api.internals.ns.selector('sidemenu__btn'),
-  TITLE: api.internals.ns.selector('sidemenu__title')
+  TITLE: api.internals.ns.selector('sidemenu__title'),
+  COLLAPSE: `${api.sidemenu.SidemenuSelector.COLLAPSE}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`
 };

--- a/src/dsfr/analytics/script/integration/component/stepper/stepper-selector.js
+++ b/src/dsfr/analytics/script/integration/component/stepper/stepper-selector.js
@@ -1,5 +1,5 @@
 import api from '../../../../api';
 
 export const StepperSelector = {
-  STEPPER: api.internals.ns.selector('stepper')
+  STEPPER: `${api.internals.ns.selector('stepper')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`
 };

--- a/src/dsfr/analytics/script/integration/component/summary/summary-selector.js
+++ b/src/dsfr/analytics/script/integration/component/summary/summary-selector.js
@@ -1,8 +1,8 @@
 import api from '../../../../api';
 
 export const SummarySelector = {
-  SUMMARY: api.internals.ns.selector('summary'),
-  LINK: api.internals.ns.selector('summary__link'),
+  SUMMARY: `${api.internals.ns.selector('summary')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`,
+  LINK: `${api.internals.ns.selector('summary__link')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`,
   TITLE: api.internals.ns.selector('summary__title'),
-  ITEM: `${api.internals.ns.selector('summary')} li`
+  ITEM: `${api.internals.ns.selector('summary')} li:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`
 };

--- a/src/dsfr/analytics/script/integration/component/tab/integrate.js
+++ b/src/dsfr/analytics/script/integration/component/tab/integrate.js
@@ -1,10 +1,11 @@
 import api from '../../../../api';
 import { TabActionee } from './tab-actionee';
 import { joinSelector } from '../../join-selector';
+import { TabSelector } from './tab-selector';
 
 const integrateTab = (selector = '') => {
   if (api.tab) {
-    api.internals.register(joinSelector(api.tab.TabSelector.PANEL, selector), TabActionee);
+    api.internals.register(joinSelector(TabSelector.PANEL, selector), TabActionee);
   }
 };
 

--- a/src/dsfr/analytics/script/integration/component/tab/tab-selector.js
+++ b/src/dsfr/analytics/script/integration/component/tab/tab-selector.js
@@ -1,0 +1,5 @@
+import api from '../../../../api';
+
+export const TabSelector = {
+  PANEL: `${api.tab.TabSelector.PANEL}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`
+};

--- a/src/dsfr/analytics/script/integration/component/table/table-selector.js
+++ b/src/dsfr/analytics/script/integration/component/table/table-selector.js
@@ -1,5 +1,5 @@
 import api from '../../../../api';
 
 export const TableSelector = {
-  TABLE: api.internals.ns.selector('table')
+  TABLE: `${api.internals.ns.selector('table')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`
 };

--- a/src/dsfr/analytics/script/integration/component/tag/tag-selector.js
+++ b/src/dsfr/analytics/script/integration/component/tag/tag-selector.js
@@ -1,7 +1,7 @@
 import api from '../../../../api';
 
 export const TagSelector = {
-  TAG: api.internals.ns.selector('tag'),
+  TAG: `${api.internals.ns.selector('tag')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`,
   PRESSABLE: '[aria-pressed]',
   DISMISSIBLE: `${api.internals.ns.selector('tag--dismiss', '')}`
 };

--- a/src/dsfr/analytics/script/integration/component/tile/tile-selector.js
+++ b/src/dsfr/analytics/script/integration/component/tile/tile-selector.js
@@ -1,7 +1,7 @@
 import api from '../../../../api';
 
 export const TileSelector = {
-  TILE: api.internals.ns.selector('tile'),
+  TILE: `${api.internals.ns.selector('tile')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`,
   LINK: `${api.internals.ns.selector('tile__title')} a, ${api.internals.ns.selector('tile__title')} button`,
   TITLE: api.internals.ns.selector('tile__title')
 };

--- a/src/dsfr/analytics/script/integration/component/toggle/toggle-selector.js
+++ b/src/dsfr/analytics/script/integration/component/toggle/toggle-selector.js
@@ -1,5 +1,5 @@
 import api from '../../../../api';
 
 export const ToggleSelector = {
-  INPUT: api.internals.ns.selector('toggle [type="checkbox"]')
+  INPUT: `${api.internals.ns.selector('toggle [type="checkbox"]')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`
 };

--- a/src/dsfr/analytics/script/integration/component/tooltip/integrate.js
+++ b/src/dsfr/analytics/script/integration/component/tooltip/integrate.js
@@ -1,10 +1,11 @@
 import api from '../../../../api';
 import { TooltipActionee } from './tooltip-actionee';
 import { joinSelector } from '../../join-selector';
+import { TooltipSelector } from './tooltip-selector';
 
 const integrateTooltip = (selector = '') => {
   if (api.tooltip) {
-    api.internals.register(joinSelector(api.tooltip.TooltipSelector.TOOLTIP, selector), TooltipActionee);
+    api.internals.register(joinSelector(TooltipSelector.INPUT, selector), TooltipActionee);
   }
 };
 

--- a/src/dsfr/analytics/script/integration/component/tooltip/tooltip-selector.js
+++ b/src/dsfr/analytics/script/integration/component/tooltip/tooltip-selector.js
@@ -1,0 +1,5 @@
+import api from '../../../../api';
+
+export const TooltipSelector = {
+  INPUT: `${api.tooltip.TooltipSelector.TOOLTIP}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`
+};

--- a/src/dsfr/analytics/script/integration/component/transcription/transcription-selector.js
+++ b/src/dsfr/analytics/script/integration/component/transcription/transcription-selector.js
@@ -2,10 +2,11 @@ import api from '../../../../api';
 
 const TRANSCRIPTION = api.internals.ns.selector('transcription');
 const COLLAPSE = api.internals.ns.selector('collapse');
+const NO_REDUCE = `:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`;
 
 export const TranscriptionSelector = {
   TRANSCRIPTION: TRANSCRIPTION,
-  COLLAPSE: `${TRANSCRIPTION} > ${COLLAPSE}, ${TRANSCRIPTION} > *:not(${TRANSCRIPTION}):not(${COLLAPSE}) > ${COLLAPSE}, ${TRANSCRIPTION} > *:not(${TRANSCRIPTION}):not(${COLLAPSE}) > *:not(${TRANSCRIPTION}):not(${COLLAPSE}) > ${COLLAPSE}`,
+  COLLAPSE: `${TRANSCRIPTION} > ${COLLAPSE}${NO_REDUCE}, ${TRANSCRIPTION} > *:not(${TRANSCRIPTION}):not(${COLLAPSE}) > ${COLLAPSE}${NO_REDUCE}, ${TRANSCRIPTION} > *:not(${TRANSCRIPTION}):not(${COLLAPSE}) > *:not(${TRANSCRIPTION}):not(${COLLAPSE}) > ${COLLAPSE}${NO_REDUCE}`,
   COLLAPSE_LEGACY: `${TRANSCRIPTION} ${COLLAPSE}`,
   TITLE: `${TRANSCRIPTION}__title`
 };

--- a/src/dsfr/analytics/script/integration/component/translate/translate-selector.js
+++ b/src/dsfr/analytics/script/integration/component/translate/translate-selector.js
@@ -2,9 +2,10 @@ import api from '../../../../api';
 
 const TRANSLATE = api.internals.ns.selector('translate');
 const COLLAPSE = api.internals.ns.selector('collapse');
+const NO_REDUCE = `:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`;
 
 export const TranslateSelector = {
-  BUTTON: `${TRANSLATE}__btn`,
-  COLLAPSE: `${TRANSLATE} > ${COLLAPSE}, ${TRANSLATE} > *:not(${TRANSLATE}):not(${COLLAPSE}) > ${COLLAPSE}, ${TRANSLATE} > *:not(${TRANSLATE}):not(${COLLAPSE}) > *:not(${TRANSLATE}):not(${COLLAPSE}) > ${COLLAPSE}`,
+  BUTTON: `${TRANSLATE}__btn${NO_REDUCE}`,
+  COLLAPSE: `${TRANSLATE} > ${COLLAPSE}${NO_REDUCE}, ${TRANSLATE} > *:not(${TRANSLATE}):not(${COLLAPSE}) > ${COLLAPSE}${NO_REDUCE}, ${TRANSLATE} > *:not(${TRANSLATE}):not(${COLLAPSE}) > *:not(${TRANSLATE}):not(${COLLAPSE}) > ${COLLAPSE}${NO_REDUCE}`,
   COLLAPSE_LEGACY: `${TRANSLATE} ${COLLAPSE}`
 };

--- a/src/dsfr/analytics/script/integration/component/upload/upload-selector.js
+++ b/src/dsfr/analytics/script/integration/component/upload/upload-selector.js
@@ -1,5 +1,5 @@
 import api from '../../../../api';
 
 export const UploadSelector = {
-  UPLOAD: api.internals.ns.selector('upload')
+  UPLOAD: `${api.internals.ns.selector('upload')}:not(${api.internals.ns.attr.selector('analytics-action', 'reduce')})`
 };


### PR DESCRIPTION
- Ajout de l'attribut `data-fr-analytics-action="reduce"` qui permet de désactiver l'envoi d'actions sur un élément particulier, en empêchant l'initialisation de l'instance de tracking associée à cet élément.
- Mise à jour de la documentation analytics