### PR TITLE
🐛 fix(modal): scroll au focus d'un élément caché sous le footer

### DIFF
--- a/src/dsfr/component/modal/example/index.ejs
+++ b/src/dsfr/component/modal/example/index.ejs
@@ -16,7 +16,7 @@ let dataForm = {
 let dataFooterButtons = {
     title: 'Titre de la modale',
     icon: 'arrow-right-line',
-    body: include('sample/body/text', { text: { paragraphs: 6 } }),
+    body: include('sample/body/form', { text: { paragraphs: 6 } }),
     footer: include('../example/sample/footer/buttons')
 }
 

--- a/src/dsfr/component/modal/index.js
+++ b/src/dsfr/component/modal/index.js
@@ -2,6 +2,7 @@ import api from './api.js';
 
 import { Modal } from './script/modal/modal.js';
 import { ModalButton } from './script/modal/modal-button.js';
+import { ModalFooter } from './script/modal/modal-footer.js';
 import { ModalsGroup } from './script/modal/modals-group.js';
 import { ModalBody } from './script/modal/modal-body.js';
 import { ModalSelector } from './script/modal/modal-selector.js';
@@ -9,6 +10,7 @@ import { ModalSelector } from './script/modal/modal-selector.js';
 api.modal = {
   Modal: Modal,
   ModalButton: ModalButton,
+  ModalFooter: ModalFooter,
   ModalBody: ModalBody,
   ModalsGroup: ModalsGroup,
   ModalSelector: ModalSelector

--- a/src/dsfr/component/modal/main.js
+++ b/src/dsfr/component/modal/main.js
@@ -2,6 +2,7 @@ import api from './index.js';
 
 api.internals.register(api.modal.ModalSelector.MODAL, api.modal.Modal);
 api.internals.register(api.modal.ModalSelector.BODY, api.modal.ModalBody);
+api.internals.register(api.modal.ModalSelector.FOOTER, api.modal.ModalFooter);
 api.internals.register(api.core.RootSelector.ROOT, api.modal.ModalsGroup);
 
 export default api;

--- a/src/dsfr/component/modal/script/modal/modal-footer.js
+++ b/src/dsfr/component/modal/script/modal/modal-footer.js
@@ -1,0 +1,22 @@
+import api from '../../api.js';
+
+class ModalFooter extends api.core.Instance {
+  static get instanceClassName () {
+    return 'ModalFooter';
+  }
+
+  init () {
+    this.isResizing = true;
+  }
+
+  resize () {
+    this.adjust();
+  }
+
+  adjust () {
+    const height = this.getRect().height;
+    this.node.parentNode.style.setProperty('--modal-scroll-padding-bottom', `${height}px`);
+  }
+}
+
+export { ModalFooter };

--- a/src/dsfr/component/modal/script/modal/modal-selector.js
+++ b/src/dsfr/component/modal/script/modal/modal-selector.js
@@ -2,6 +2,7 @@ import api from '../../api.js';
 
 export const ModalSelector = {
   MODAL: api.internals.ns.selector('modal'),
+  FOOTER: api.internals.ns.selector('modal__footer'),
   SCROLL_DIVIDER: api.internals.ns.selector('scroll-divider'),
   BODY: api.internals.ns.selector('modal__body'),
   TITLE: api.internals.ns.selector('modal__title')

--- a/src/dsfr/component/modal/style/_module.scss
+++ b/src/dsfr/component/modal/style/_module.scss
@@ -96,10 +96,12 @@
 
   @include body {
     --modal-max-height: calc(100vh - 2rem);
+    --modal-scroll-padding-bottom: #{space(-4v)};
     pointer-events: all;
     overflow-y: auto;
     flex: 1 1 auto;
     max-height: var(--modal-max-height);
+    scroll-padding-bottom: calc(var(--modal-scroll-padding-bottom) + #{space(4v)});
 
     @include respond-from(md) {
       max-height: 80vh;


### PR DESCRIPTION
- Lorsque le focus est placé sur un élément caché sous le footer sticky de la modal, on scroll pour qu'il soit visible
- Ajout de la propriété scroll-padding-bottom

#1381