### PR TITLE
🐛 fix(sidemenu): corrige l'affichage mobile lors d'une utilisation sans accordéon

### DIFF
--- a/src/dsfr/component/sidemenu/style/module/_list.scss
+++ b/src/dsfr/component/sidemenu/style/module/_list.scss
@@ -8,8 +8,8 @@
     font-weight: font-weight('bold');
 
     #{ns(sidemenu__list)} {
-      @include margin(0 4v 4v);
-      @include margin(0 4v 4v, md);
+      @include padding(0 4v 4v);
+      @include padding(0 4v 4v, md);
       font-weight: font-weight();
 
       #{ns(sidemenu__link)},

--- a/src/dsfr/component/sidemenu/style/module/_list.scss
+++ b/src/dsfr/component/sidemenu/style/module/_list.scss
@@ -40,6 +40,10 @@
       }
     }
 
+    &:first-child:last-child {
+      @include before(none);
+    }
+
     & & & {
       @include before(none);
     }


### PR DESCRIPTION
Hello,

S'il reste un peu de place dans le v1.15, voici une petite correction du composant **Menu latéral** lorsque l'on utilise celui-ci sans accordéon (cf. https://github.com/GouvernementFR/dsfr/issues/1365#issuecomment-3719806386).

Sans accordéon, le composant est rendu avec deux erreurs :
1. Les éléments de premier niveau sont séparés par deux bordures car sans la classe HTML `.fr-collapse` (qui redéfinit la propriété CSS `overflow)`, il n'y a pas de création d'un nouveau contexte de formatage de blocs (block formatting context) et les marges extérieurs ne sont pas gérées de la même façon.<br />**Solution** : remplacer par des marges intérieures.

2. Quand il n'y a qu'un sous-élément, une bordure est dessinée entre celui-ci et le premier niveau.<br />**Solution** : supprimer la bordure lorsqu'il n'y a qu'un sous-élément.


<img width="598" height="918" alt="Capture d&#39;écran 2026-03-10 211923" src="https://github.com/user-attachments/assets/4015f430-da41-4c25-a957-4d8952f55f96" />
<br /><br />

Je vous laisse également le CodePen pour exemple : https://codepen.io/7studio/pen/ogzzmZO?editors=1100

