### PR TITLE
:sparkles: feat(range): utilisation de la liaison for/id sur le curseur simple et coquilles doc

### DIFF
--- a/src/dsfr/component/range/_part/doc/code/index.md
+++ b/src/dsfr/component/range/_part/doc/code/index.md
@@ -61,7 +61,7 @@ Sa structure est la suivante :
         <span class="fr-hint-text">Texte de description additionnel, valeur de 0 à 100.</span>
     </label>
     <div class="fr-range">
-        <span class="fr-range__output">50</span>
+        <span class="fr-range__output" aria-hidden="true">50</span>
         <input id="range-1" name="range" type="range" max="100" value="50" aria-describedby="range-messages">
         <span class="fr-range__min" aria-hidden="true">0</span>
         <span class="fr-range__max" aria-hidden="true">100</span>
@@ -167,7 +167,7 @@ Un message d'erreur ou de succès doit être ajouté dans un bloc `fr-messages-g
         <span class="fr-hint-text">Texte de description additionnel, valeur de 0 à 100.</span>
     </label>
     <div class="fr-range">
-        <span class="fr-range__output">50</span>
+        <span class="fr-range__output" aria-hidden="true">50</span>
         <input id="range-error" name="range-error" type="range" max="100" value="50" aria-describedby="range-error-messages">
         <span class="fr-range__min" aria-hidden="true">0</span>
         <span class="fr-range__max" aria-hidden="true">100</span>
@@ -191,7 +191,7 @@ Un message d'erreur ou de succès doit être ajouté dans un bloc `fr-messages-g
         <span class="fr-hint-text">Texte de description additionnel, valeur de 0 à 100.</span>
     </label>
     <div class="fr-range">
-        <span class="fr-range__output">50</span>
+        <span class="fr-range__output" aria-hidden="true">50</span>
         <input id="range-succes" name="range-succes" type="range" max="100" value="50" aria-describedby="range-success-messages">
         <span class="fr-range__min" aria-hidden="true">0</span>
         <span class="fr-range__max" aria-hidden="true">100</span>
@@ -214,8 +214,8 @@ Un message d'erreur ou de succès doit être ajouté dans un bloc `fr-messages-g
         Libellé
         <span class="fr-hint-text">Texte de description additionnel, valeur de 0 à 100.</span>
     </label>
-    <div class="fr-range fr-range--double">
-        <span class="fr-range__output">20</span>
+    <div class="fr-range">
+        <span class="fr-range__output" aria-hidden="true">20</span>
         <input id="range-disabled" name="range-disabled" type="range" max="100" value="20" disabled aria-describedby="range-disabled-messages">
         <span class="fr-range__min" aria-hidden="true">0</span>
         <span class="fr-range__max" aria-hidden="true">100</span>
@@ -240,7 +240,7 @@ Le curseur double permet de disposer de deux poignées de selection pour les val
         <span class="fr-hint-text">Texte de description additionnel, valeur de 0 à 100.</span>
     </label>
     <div class="fr-range fr-range--double">
-        <span class="fr-range__output">25</span>
+        <span class="fr-range__output" aria-hidden="true">25 - 75</span>
         <input id="range-double" name="range-double" type="range" aria-label="Valeur minimale" aria-labelledby="range-double range-double-label" max="100" value="25" aria-describedby="range-double-messages">
         <input id="range-double-2" name="range-double-2" type="range" aria-label="Valeur maximale" aria-labelledby="range-double-2 range-double-label" max="100" value="75" aria-describedby="range-double-messages">
         <span class="fr-range__min" aria-hidden="true">0</span>

--- a/src/dsfr/component/range/_part/doc/code/index.md
+++ b/src/dsfr/component/range/_part/doc/code/index.md
@@ -56,13 +56,13 @@ Sa structure est la suivante :
 
 ```HTML
 <div class="fr-range-group">
-    <label id="range-label" class="fr-label">
+    <label for="range-1" class="fr-label">
         Libellé
         <span class="fr-hint-text">Texte de description additionnel, valeur de 0 à 100.</span>
     </label>
     <div class="fr-range">
         <span class="fr-range__output">50</span>
-        <input name="range" type="range" aria-labelledby="range-label" max="100" value="50" aria-describedby="range-messages">
+        <input id="range-1" name="range" type="range" max="100" value="50" aria-describedby="range-messages">
         <span class="fr-range__min" aria-hidden="true">0</span>
         <span class="fr-range__max" aria-hidden="true">100</span>
     </div>
@@ -162,13 +162,13 @@ Un message d'erreur ou de succès doit être ajouté dans un bloc `fr-messages-g
 
 ```HTML
 <div class="fr-range-group fr-range-group--error">
-    <label id="range-error-label" class="fr-label">
+    <label for="range-error" class="fr-label">
         Libellé
         <span class="fr-hint-text">Texte de description additionnel, valeur de 0 à 100.</span>
     </label>
     <div class="fr-range">
         <span class="fr-range__output">50</span>
-        <input id="range-error" name="range-error" type="range" aria-labelledby="range-error-label" max="100" value="50" aria-describedby="range-error-messages">
+        <input id="range-error" name="range-error" type="range" max="100" value="50" aria-describedby="range-error-messages">
         <span class="fr-range__min" aria-hidden="true">0</span>
         <span class="fr-range__max" aria-hidden="true">100</span>
     </div>
@@ -186,13 +186,13 @@ Un message d'erreur ou de succès doit être ajouté dans un bloc `fr-messages-g
 
 ```HTML
 <div class="fr-range-group fr-range-group--succes">
-    <label id="range-error-label" class="fr-label">
+    <label for="range-succes" class="fr-label">
         Libellé
         <span class="fr-hint-text">Texte de description additionnel, valeur de 0 à 100.</span>
     </label>
     <div class="fr-range">
         <span class="fr-range__output">50</span>
-        <input name="range-error" type="range" aria-labelledby="range-error-label" max="100" value="50" aria-describedby="range-error-messages">
+        <input id="range-succes" name="range-succes" type="range" max="100" value="50" aria-describedby="range-success-messages">
         <span class="fr-range__min" aria-hidden="true">0</span>
         <span class="fr-range__max" aria-hidden="true">100</span>
     </div>
@@ -210,13 +210,13 @@ Un message d'erreur ou de succès doit être ajouté dans un bloc `fr-messages-g
 
 ```HTML
 <div class="fr-range-group fr-range-group--disabled">
-    <label id="range-disabled-label" class="fr-label">
+    <label for="range-disabled" class="fr-label">
         Libellé
         <span class="fr-hint-text">Texte de description additionnel, valeur de 0 à 100.</span>
     </label>
     <div class="fr-range fr-range--double">
         <span class="fr-range__output">20</span>
-        <input name="range-disabled" type="range" aria-labelledby="range-disabled-label" max="100" value="20" disabled aria-describedby="range-disabled-messages">
+        <input id="range-disabled" name="range-disabled" type="range" max="100" value="20" disabled aria-describedby="range-disabled-messages">
         <span class="fr-range__min" aria-hidden="true">0</span>
         <span class="fr-range__max" aria-hidden="true">100</span>
     </div>

--- a/src/dsfr/component/range/_part/doc/code/index.md
+++ b/src/dsfr/component/range/_part/doc/code/index.md
@@ -241,8 +241,8 @@ Le curseur double permet de disposer de deux poignées de selection pour les val
     </label>
     <div class="fr-range fr-range--double">
         <span class="fr-range__output">25</span>
-        <input name="range-double" type="range" aria-labelledby="range-double-label" max="100" value="25" aria-describedby="range-double-messages">
-        <input name="range-double-2" type="range" aria-labelledby="range-double-label" max="100" value="75" aria-describedby="range-double-messages">
+        <input id="range-double" name="range-double" type="range" aria-label="Valeur minimale" aria-labelledby="range-double range-double-label" max="100" value="25" aria-describedby="range-double-messages">
+        <input id="range-double-2" name="range-double-2" type="range" aria-label="Valeur maximale" aria-labelledby="range-double-2 range-double-label" max="100" value="75" aria-describedby="range-double-messages">
         <span class="fr-range__min" aria-hidden="true">0</span>
         <span class="fr-range__max" aria-hidden="true">100</span>
     </div>

--- a/src/dsfr/component/range/_part/doc/code/index.md
+++ b/src/dsfr/component/range/_part/doc/code/index.md
@@ -196,8 +196,8 @@ Un message d'erreur ou de succès doit être ajouté dans un bloc `fr-messages-g
         <span class="fr-range__min" aria-hidden="true">0</span>
         <span class="fr-range__max" aria-hidden="true">100</span>
     </div>
-    <div class="fr-messages-group" id="range-error-messages" aria-live="polite">
-        <p class="fr-message fr-message--valid" id="select-valid-message-valid">Texte de validation</p>
+    <div class="fr-messages-group" id="range-success-messages" aria-live="polite">
+        <p class="fr-message fr-message--valid" id="range-success-message-success">Texte de validation</p>
     </div>
 </div>
 ```

--- a/src/dsfr/component/range/example/sample/range.ejs
+++ b/src/dsfr/component/range/example/sample/range.ejs
@@ -16,6 +16,8 @@ if (range.size) data.size = range.size;
 if (range.step) data.step = range.step;
 if (range.prefix) data.prefix = range.prefix;
 if (range.suffix) data.suffix = range.suffix;
+if (range.minValueLabel) data.minValueLabel = range.minValueLabel;
+if (range.maxValueLabel) data.maxValueLabel = range.maxValueLabel;
 
 data.label = getText('label.default', 'range');
 data.hint = getText('hint.default', 'range');

--- a/src/dsfr/component/range/template/ejs/range.ejs
+++ b/src/dsfr/component/range/template/ejs/range.ejs
@@ -15,7 +15,7 @@
 
 * range.hint (string, optional) : texte de description sous le label
 
-* range.size (string, optional) : taille du curseur (valeur : 'sm')
+* range.size (string, optional) : taille du curseur (valeur : 'md')
 
 * range.inputAttributes (array, optional) : attributs de l'input
 
@@ -66,7 +66,7 @@ const rangeAttributes = {};
 if (range.prefix) rangeAttributes[`data-${prefix}-prefix`] = range.prefix;
 if (range.suffix) rangeAttributes[`data-${prefix}-suffix`] = range.suffix;
 const rangeClasses = [`${prefix}-range`];
-if (range.size) rangeClasses.push(`${prefix}-range--${range.size}`);
+if (range.size && range.size !== "md") rangeClasses.push(`${prefix}-range--${range.size}`);
 if (range.isDouble) rangeClasses.push(`${prefix}-range--double`);
 if (range.isStep) rangeClasses.push(`${prefix}-range--step`);
 

--- a/src/dsfr/component/range/template/ejs/range.ejs
+++ b/src/dsfr/component/range/template/ejs/range.ejs
@@ -59,6 +59,7 @@ const groupClasses = range.classes || [];
 groupClasses.push(`${prefix}-range-group`);
 
 const label = { label: range.label, hint: range.hint, attributes: { id: `${range.id}-label` } };
+if (!range.isDouble) label.for = range.id;
 
 const decorate = (value) => `${range.prefix ?? ''}${value}${range.suffix ?? ''}`;
 
@@ -74,7 +75,6 @@ const inputAttributes = range.inputAttributes || {};
 inputAttributes.id = range.id;
 inputAttributes.name = range.name;
 inputAttributes.type = 'range';
-inputAttributes['aria-labelledby'] = label.attributes.id;
 if (range.isDouble) {
   inputAttributes['aria-label'] = range.minValueLabel;
   inputAttributes['aria-labelledby'] = `${range.id} ${label.attributes.id}`;

--- a/src/dsfr/component/range/template/ejs/range.ejs
+++ b/src/dsfr/component/range/template/ejs/range.ejs
@@ -15,7 +15,7 @@
 
 * range.hint (string, optional) : texte de description sous le label
 
-* range.size (string, optional) : taille du curseur (valeur : 'md')
+* range.size (string, optional) : taille du curseur (valeurs possibles : 'md' | 'sm')
 
 * range.inputAttributes (array, optional) : attributs de l'input
 
@@ -117,7 +117,7 @@ if (builder.describedby.length > 0) {
   <%- include('../../../form/template/ejs/label', { label : label }); %>
 
   <div <%- includeClasses(rangeClasses); %> <%- includeAttrs(rangeAttributes); %>>
-    <span class="<%= prefix %>-range__output"><%= decorate(range.value) %></span>
+    <span class="<%= prefix %>-range__output" aria-hidden="true"><%= decorate(range.value) %></span>
 
     <input <%- includeAttrs(inputAttributes); %> >
 

--- a/src/dsfr/component/range/template/stories/range-arg-types.js
+++ b/src/dsfr/component/range/template/stories/range-arg-types.js
@@ -220,6 +220,7 @@ const rangeProps = (args) => {
     prefix: args.prefix || rangeArgs.prefix,
     suffix: args.suffix || rangeArgs.suffix,
     isDouble: args.isDouble || false,
+    size: args.size || rangeArgs.size,
     minValueLabel: args.isDouble ? args.minValueLabel || rangeArgs.minValueLabel : undefined,
     maxValueLabel: args.isDouble ? args.maxValueLabel || rangeArgs.maxValueLabel : undefined,
     isStep: args.isStep || false,


### PR DESCRIPTION
Hello,

Voici une petite PR pour : 
1. rendre fonctionnel le contrôle Storybook "size" du composant **Curseur**. 
    URL pour tester le dysfonctionnement actuel : https://www.systeme-de-design.gouv.fr/v1.14/storybook/index.html?path=/story/range--range-story&args=size:sm&globals=viewport:lg
2. utiliser la liaison for/id comme préconisé dans la partie accessibilité du composant.
3. corriger les exemples du curseur double.
4. corriger coquille nommage dans l'exemple avec succès.

Je profite de cette PR pour proposer deux améliorations :
1. cacher la valeur visible du curseur aux APIs d'accessibilité car celle-ci n'est pas vocalisée lors de sa mise à jour.
2. <s>privilégier l'utilisation d'un ensemble de champs via `role="group` au double aria-labelledby sur les éléments HTML `<input>`. Cela permet d’alléger la vocalisation et d'éviter de faire pointer le `aria-labelledby` sur son propre élément (je n'avais jamais vu ça avant).</s>