### PR TITLE
:bug: fix(sidemenu): correction des éléments désactivés

### DIFF
--- a/src/dsfr/component/sidemenu/example/index.ejs
+++ b/src/dsfr/component/sidemenu/example/index.ejs
@@ -10,3 +10,9 @@
 
 <!-- Exemple de navigation latérale sans collapse -->
 <!-- <%- sample('Navigation latérale de base ouverte', './sample/sidemenu', {models: [ 'LLOLL', 'LOLLOLL', 'LLLLLL' ]}, true, './layout'); %> -->
+
+<%- sample('Navigation latérale de base ouverte', './sample/sidemenu', {models1: [ 'LÁLOLL', 'LOLL', 'LLL' ], models2: ['LÁLOLL', 'LÁLL', 'LLL']}, true, './layout'); %>
+
+<%- sample('Navigation latérale de base ouverte désactivée', './sample/sidemenu', {models1: [ 'LÁLoLl', 'LolL', 'LLl' ], models2: ['LÁLoLL', 'LÁLL', 'LLL']}, true, './layout'); %>
+
+<%- sample('Navigation latérale de base désactivée', './sample/sidemenu', {models1: [ 'LALmLl', 'LmlL', 'LLl' ], models2: ['LALmLL', 'LALL', 'LLL']}, true, './layout'); %>

--- a/src/dsfr/component/sidemenu/example/sample/sidemenu.ejs
+++ b/src/dsfr/component/sidemenu/example/sample/sidemenu.ejs
@@ -1,14 +1,15 @@
 <%
 let sidemenu = locals.sidemenu || {};
 const defaultModels = [ 'MALMMLMMLM', 'LMMLLLL', 'LLLLLL' ];
-const models1 = locals.models || defaultModels;
-const models2 = ['MALMMLMMLM', 'LMALLL', 'LLLL'];
+const models1 = locals.models1 || defaultModels;
+const models2 = locals.models2 || ['MALMMLMMLM', 'LMALLL', 'LLLL'];
 
-function link(level, active) {
+function link(level, active, disabled) {
   return {
     id: uniqueId('sidemenu-item'),
     type: 'link',
     active: active === true,
+    disabled: disabled === true,
     label: 'Accès direct' + (level > 1 ? ' niveau ' + level: '')
   }
 }
@@ -20,28 +21,45 @@ function items(level, active) {
   items.href = sidemenu.href || '#';
   for (let i = 0; i < model.length; i++) switch(model.charAt(i)) {
     case 'L': // 'L' pour Link
-      items.push(link(level + 1, active && i === 1));
+      items.push(link(level + 1, active && i === 1, false));
+      break;
+    
+    case 'l': // 'L barré' pour Link disabled
+      items.push(link(level + 1, active && i === 1, true));
       break;
 
     case 'M': // 'M' pour Menu
-      items.push(menu(level + 1, false, true));
+      items.push(menu(level + 1, false, false, true));
+      break;
+    
+    case 'm': // 'M tréma' pour Menu désactivé
+      items.push(menu(level + 1, false, true, true));
       break;
 
     case 'A': // 'A' pour Active
-      items.push(menu(level + 1, true, true));
+      items.push(menu(level + 1, true, false, true));
       break;
 
-    case 'O': // 'O' pour Open
-      items.push(menu(level + 1, false, false));
+    case 'Á': // 'A accent aigu' pour Active mais sans accordéon
+      items.push(menu(level + 1, true, false, false));
+      break;
+
+    case 'O': // 'O' pour Menu sans accordéon
+      items.push(menu(level + 1, false, false, false));
+      break;
+    
+    case 'o': // 'O tréma' pour Menu sans accordéon désactivé
+      items.push(menu(level + 1, false, true, false));
       break;
   }
   return items;
 }
 
-function menu(level, active, isCollapsible) {
+function menu(level, active, disabled, isCollapsible) {
   return {
     type: 'menu',
     active: active === true,
+    disabled: disabled === true,
     isExpanded: active === true,
     label: active === true ? 'Entrée menu active' : 'Niveau ' + level,
     collapseId: uniqueId('sidemenu'),

--- a/src/dsfr/component/sidemenu/style/_scheme.scss
+++ b/src/dsfr/component/sidemenu/style/_scheme.scss
@@ -7,6 +7,7 @@
 @use 'src/module/elevation';
 @use 'src/module/media-query';
 @use 'src/module/selector';
+@use 'src/module/disabled';
 
 @mixin _sidemenu-scheme($legacy: false) {
   #{ns(sidemenu)} {
@@ -74,6 +75,10 @@
         @include before {
           @include color.background(border active blue-france, (legacy:$legacy));
         }
+      }
+
+      @include selector.not-current {
+        @include disabled.selector((can-be-link: true), (legacy: $legacy, text: true,));
       }
     }
 

--- a/src/dsfr/component/sidemenu/style/module/_action.scss
+++ b/src/dsfr/component/sidemenu/style/module/_action.scss
@@ -5,6 +5,7 @@
 
 @use 'src/module/selector';
 @use 'src/module/preference';
+@use 'src/module/disabled';
 
 /**
  * Styles du bouton et du lien d'accès direct du sidemnu
@@ -41,6 +42,14 @@
     @include selector.current {
       pointer-events: none;
       cursor: default;
+    }
+
+    @include disabled.selector((can-be-link: true)) {
+      &:not([aria-current]) {
+        @include preference.forced-colors {
+          color: graytext;
+        }
+      }
     }
   }
 }

--- a/src/dsfr/component/sidemenu/style/module/_default.scss
+++ b/src/dsfr/component/sidemenu/style/module/_default.scss
@@ -11,10 +11,6 @@
   @include relative;
   @include margin-x(-4v);
 
-  a:not([href]) {
-    cursor: default;
-  }
-
   @include margin-x(0, md);
   @include padding-right(8v, md);
 

--- a/src/dsfr/component/sidemenu/template/ejs/sidemenu-menu.ejs
+++ b/src/dsfr/component/sidemenu/template/ejs/sidemenu-menu.ejs
@@ -15,6 +15,7 @@ Paramètres de sidemenu item
 let sidemenuItem = locals.sidemenuItem || {};
 const action = {
     label: sidemenuItem.label,
+    disabled: sidemenuItem.disabled,
     attributes: {},
     classes: []
 };


### PR DESCRIPTION
Bonjour,

Je me permets cette petite PR pour que le composant **Menu latéral** dispose des mêmes capacités que d'autres composants (Pagination, Accordéon, Onglet, Navigation tertiaire) pour identifier correctement les éléments désactivés.

Prévisualisation du rendu :

<img width="363" height="1183" alt="Prévisualisation du composant menu latéral avec des éléments désactivés" src="https://github.com/user-attachments/assets/52b6da6e-6fba-4dc1-be48-f7f555100194" />
