### PR TITLE
:bug: fix(core): correction de sécurité sur le js des pictogrammes sur IE

### DIFF
--- a/src/dsfr/core/script/api/utilities/sanitize-svg.js
+++ b/src/dsfr/core/script/api/utilities/sanitize-svg.js
@@ -1,0 +1,95 @@
+/**
+ * Allowed SVG/HTML elements for inline SVG content.
+ * Only standard SVG presentational and structural elements are permitted.
+ */
+const ALLOWED_TAGS = new Set([
+  'svg', 'g', 'defs', 'symbol', 'use', 'title', 'desc',
+  'path', 'rect', 'circle', 'ellipse', 'line', 'polyline', 'polygon',
+  'text', 'tspan', 'textpath', 'image', 'clippath', 'mask',
+  'lineargradient', 'radialgradient', 'stop', 'pattern', 'marker',
+  'filter', 'fegaussianblur', 'fecolormatrix', 'feblend', 'fecomposite',
+  'feflood', 'femerge', 'femergenode', 'feoffset', 'view', 'switch'
+]);
+
+/**
+ * Attributes that must not start with "javascript:" or "data:" (URL-type attributes).
+ */
+const URL_ATTRIBUTES = new Set([
+  'href', 'xlink:href', 'src', 'action', 'formaction'
+]);
+
+const DANGEROUS_PROTOCOL = /^\s*(?:javascript|data|vbscript)\s*:/i;
+
+/**
+ * Recursively sanitize an SVG element in-place:
+ * - removes elements not in ALLOWED_TAGS
+ * - removes all event-handler attributes (on*)
+ * - removes dangerous protocol values from URL attributes
+ *
+ * @param {Element} element
+ */
+function sanitizeElement (element) {
+  for (const child of Array.from(element.childNodes)) {
+    if (child.nodeType === Node.ELEMENT_NODE) {
+      const tag = child.tagName.toLowerCase();
+      if (!ALLOWED_TAGS.has(tag)) {
+        element.removeChild(child);
+        continue;
+      }
+      // Remove dangerous attributes
+      for (const attr of Array.from(child.attributes)) {
+        const name = attr.name.toLowerCase();
+        if (name.startsWith('on')) {
+          child.removeAttribute(attr.name);
+          continue;
+        }
+        if (URL_ATTRIBUTES.has(name) && DANGEROUS_PROTOCOL.test(attr.value)) {
+          child.removeAttribute(attr.name);
+        }
+      }
+      sanitizeElement(child);
+    }
+  }
+}
+
+/**
+ * Sanitize an SVG DOM element and return it.
+ * Mutates the element in-place.
+ *
+ * @param {SVGElement} svg
+ * @returns {SVGElement}
+ */
+function sanitizeSvg (svg) {
+  // Remove dangerous attributes on the root <svg> element itself
+  for (const attr of Array.from(svg.attributes)) {
+    const name = attr.name.toLowerCase();
+    if (name.startsWith('on')) {
+      svg.removeAttribute(attr.name);
+      continue;
+    }
+    if (URL_ATTRIBUTES.has(name) && DANGEROUS_PROTOCOL.test(attr.value)) {
+      svg.removeAttribute(attr.name);
+    }
+  }
+  sanitizeElement(svg);
+  return svg;
+}
+
+/**
+ * Check whether a URL is same-origin as the current page.
+ * Relative URLs are always considered same-origin.
+ *
+ * @param {string} url
+ * @returns {boolean}
+ */
+function isSameOrigin (url) {
+  if (!url) return false;
+  try {
+    const parsed = new URL(url, window.location.href);
+    return parsed.origin === window.location.origin;
+  } catch {
+    return false;
+  }
+}
+
+export { sanitizeSvg, isSameOrigin };

--- a/src/dsfr/core/script/api/utilities/sanitize-svg.js
+++ b/src/dsfr/core/script/api/utilities/sanitize-svg.js
@@ -3,7 +3,7 @@
  * Only standard SVG presentational and structural elements are permitted.
  */
 const ALLOWED_TAGS = new Set([
-  'svg', 'g', 'defs', 'symbol', 'use', 'title', 'desc',
+  'svg', 'g', 'defs', 'symbol', 'use', 'title', 'desc', 'style',
   'path', 'rect', 'circle', 'ellipse', 'line', 'polyline', 'polygon',
   'text', 'tspan', 'textpath', 'image', 'clippath', 'mask',
   'lineargradient', 'radialgradient', 'stop', 'pattern', 'marker',
@@ -19,6 +19,9 @@ const URL_ATTRIBUTES = new Set([
 ]);
 
 const DANGEROUS_PROTOCOL = /^\s*(?:javascript|data|vbscript)\s*:/i;
+const DANGEROUS_CSS = /@import|expression\s*\(|url\s*\(\s*['"]?\s*(?:javascript|data|vbscript):|behavior\s*:|-moz-binding/i;
+
+const CSS_ESCAPE_REGEXP = /^-?\d|^-$|[^a-zA-Z0-9_-]/g;
 
 /**
  * Recursively sanitize an SVG element in-place:
@@ -45,11 +48,45 @@ function sanitizeElement (element) {
         }
         if (URL_ATTRIBUTES.has(name) && DANGEROUS_PROTOCOL.test(attr.value)) {
           child.removeAttribute(attr.name);
+          continue;
+        }
+        if (URL_ATTRIBUTES.has(name) && !isAllowedUrlAttributeValue(attr.value)) {
+          child.removeAttribute(attr.name);
+          continue;
+        }
+        if (name === 'style') {
+          const sanitizedStyle = sanitizeCssContent(attr.value);
+          if (sanitizedStyle) child.setAttribute(attr.name, sanitizedStyle);
+          else child.removeAttribute(attr.name);
         }
       }
+
+      if (tag === 'style') {
+        const sanitizedStyleContent = sanitizeCssContent(child.textContent);
+        if (!sanitizedStyleContent) {
+          element.removeChild(child);
+          continue;
+        }
+        child.textContent = sanitizedStyleContent;
+      }
+
       sanitizeElement(child);
     }
   }
+}
+
+/**
+ * Remove CSS payloads commonly used for script execution.
+ * Returns an empty string when the CSS contains dangerous patterns.
+ *
+ * @param {string} css
+ * @returns {string}
+ */
+function sanitizeCssContent (css) {
+  const content = String(css || '').trim();
+  if (!content) return '';
+  if (DANGEROUS_CSS.test(content)) return '';
+  return content;
 }
 
 /**
@@ -69,6 +106,10 @@ function sanitizeSvg (svg) {
     }
     if (URL_ATTRIBUTES.has(name) && DANGEROUS_PROTOCOL.test(attr.value)) {
       svg.removeAttribute(attr.name);
+      continue;
+    }
+    if (URL_ATTRIBUTES.has(name) && !isAllowedUrlAttributeValue(attr.value)) {
+      svg.removeAttribute(attr.name);
     }
   }
   sanitizeElement(svg);
@@ -76,8 +117,22 @@ function sanitizeSvg (svg) {
 }
 
 /**
+ * Validate URL-valued attributes for inline SVG usage.
+ * Allows same-document fragments (#id) and same-origin URLs only.
+ *
+ * @param {string} value
+ * @returns {boolean}
+ */
+function isAllowedUrlAttributeValue (value) {
+  const url = String(value || '').trim();
+  if (!url) return true;
+  if (url.charAt(0) === '#') return true;
+  return isSameOrigin(url);
+}
+
+/**
  * Check whether a URL is same-origin as the current page.
- * Relative URLs are always considered same-origin.
+ * Non-empty relative URLs are considered same-origin.
  *
  * @param {string} url
  * @returns {boolean}
@@ -85,11 +140,36 @@ function sanitizeSvg (svg) {
 function isSameOrigin (url) {
   if (!url) return false;
   try {
-    const parsed = new URL(url, window.location.href);
-    return parsed.origin === window.location.origin;
-  } catch {
+    const link = document.createElement('a');
+    link.href = url;
+
+    const protocol = (link.protocol || window.location.protocol).toLowerCase();
+    if (protocol !== 'http:' && protocol !== 'https:') return false;
+
+    const hostname = link.hostname || window.location.hostname;
+    const port = link.port || (protocol === 'https:' ? '443' : '80');
+    const currentPort = window.location.port || (window.location.protocol === 'https:' ? '443' : '80');
+
+    return protocol === window.location.protocol && hostname === window.location.hostname && port === currentPort;
+  } catch (e) {
     return false;
   }
 }
 
-export { sanitizeSvg, isSameOrigin };
+/**
+ * Escape a CSS identifier safely.
+ * Uses native CSS.escape when available, with an IE11-compatible fallback.
+ *
+ * @param {string} value
+ * @returns {string}
+ */
+function escapeCssIdentifier (value) {
+  const input = String(value || '');
+  if (window.CSS && typeof window.CSS.escape === 'function') {
+    return window.CSS.escape(input);
+  }
+
+  return input.replace(CSS_ESCAPE_REGEXP, character => `\\${character}`);
+}
+
+export { sanitizeSvg, isSameOrigin, escapeCssIdentifier };

--- a/src/dsfr/core/script/artwork/artwork.js
+++ b/src/dsfr/core/script/artwork/artwork.js
@@ -1,4 +1,5 @@
 import { Instance } from '../api/modules/register/instance.js';
+import { sanitizeSvg, isSameOrigin } from '../api/utilities/sanitize-svg';
 
 class Artwork extends Instance {
   static get instanceClassName () {
@@ -24,14 +25,17 @@ class Artwork extends Instance {
     this.svgUrl = splitUrl[0];
     this.svgName = splitUrl[1];
 
+    if (!isSameOrigin(this.svgUrl)) return;
+
     const xhr = new XMLHttpRequest();
     xhr.onload = () => {
       const parser = new DOMParser();
       const xmlDoc = parser.parseFromString(xhr.responseText, 'text/html');
       this.realSvgContent = xmlDoc.getElementById(this.svgName);
       if (this.realSvgContent) {
+        sanitizeSvg(this.realSvgContent);
         if (this.realSvgContent.tagName === 'symbol') {
-          this.use = xmlDoc.querySelector('use[href="#' + this.svgName + '"]');
+          this.use = xmlDoc.querySelector('use[href="#' + CSS.escape(this.svgName) + '"]');
           if (this.use) this.node.parentNode.insertBefore(this.use, this.node);
         } else {
           // deprecated svg structure

--- a/src/dsfr/core/script/artwork/artwork.js
+++ b/src/dsfr/core/script/artwork/artwork.js
@@ -35,8 +35,21 @@ class Artwork extends Instance {
       if (this.realSvgContent) {
         sanitizeSvg(this.realSvgContent);
         if (this.realSvgContent.tagName === 'symbol') {
-          this.use = xmlDoc.querySelector('use[href="#' + CSS.escape(this.svgName) + '"]');
-          if (this.use) this.node.parentNode.insertBefore(this.use, this.node);
+          const expectedHref = `#${this.svgName}`;
+          const uses = xmlDoc.getElementsByTagName('use');
+          this.use = null;
+          for (let i = 0; i < uses.length; i++) {
+            const use = uses[i];
+            const href = use.getAttribute('href') || use.getAttribute('xlink:href');
+            if (href === expectedHref) {
+              this.use = use;
+              break;
+            }
+          }
+          if (this.use) {
+            sanitizeSvg(this.use);
+            this.node.parentNode.insertBefore(this.use, this.node);
+          }
         } else {
           // deprecated svg structure
           this.realSvgContent.classList.add(this.node.classList);

--- a/src/dsfr/core/script/inject/inject-svg.js
+++ b/src/dsfr/core/script/inject/inject-svg.js
@@ -1,5 +1,6 @@
 import { Instance } from '../api/modules/register/instance.js';
 import { setAttributes } from '../api/utilities/attribute';
+import { sanitizeSvg, isSameOrigin } from '../api/utilities/sanitize-svg';
 
 class InjectSvg extends Instance {
   static get instanceClassName () {
@@ -30,14 +31,17 @@ class InjectSvg extends Instance {
       this.imgClass = this.img.getAttribute('class');
       this.imgURL = this.img.getAttribute('src');
 
+      if (!isSameOrigin(this.imgURL)) return;
+
       fetch(this.imgURL)
         .then(data => data.text())
         .then(response => {
           const parser = new DOMParser();
           const xmlDoc = parser.parseFromString(response, 'text/html');
-          this.svg = xmlDoc.querySelector('svg');
+          const rawSvg = xmlDoc.querySelector('svg');
 
-          if (this.svg) {
+          if (rawSvg) {
+            this.svg = sanitizeSvg(rawSvg);
             this.replace();
           }
         });


### PR DESCRIPTION
Correction de sécurité — Chargement SVG inline (v1.14.x)

Suite à un signalement de vulnérabilité (DOM XSS), le mécanisme de remplacement d'images par des SVG inline a été renforcé :

Les SVG sont désormais sanitizés avant insertion dans le DOM (suppression des attributs d'événements, des balises non autorisées et des protocoles dangereux).
Le chargement est restreint à la même origine (same-origin) : tout SVG servi depuis un domaine externe ne sera plus injecté.
Le sélecteur CSS utilisé dans artwork.js.
Ce que cela peut impliquer pour vous

Si vos SVG sont hébergés sur un domaine ou un CDN tiers, ils ne seront plus chargés par ces composants. Il est nécessaire de les rapatrier sur la même origine que votre application, ou de les référencer en chemin relatif.