### PR TITLE
🐛 fix(modal): décale d'une scrollbar uniquement la modale ouverte

### DIFF
--- a/src/dsfr/component/modal/style/_module.scss
+++ b/src/dsfr/component/modal/style/_module.scss
@@ -22,7 +22,6 @@
   @include margin(0);
   @include display-flex(column, stretch, space-between);
   @include fixed(0, 0, 0, 0, 100%, 100%);
-  @include padding-right(var(--scrollbar-width), md);
   // transition in/out
   transition: opacity 0.3s, visibility 0.3s;
 
@@ -77,6 +76,7 @@
   }
 
   &--opened {
+    @include padding-right(var(--scrollbar-width), md);
     // transition in/out
     visibility: inherit;
     opacity: 1;


### PR DESCRIPTION
Bonsoir,

Cette correction permet de fixer le problème relevé par @SandraRinaldo76882124 dans l'issue #1412.

Le problème était également présent pour le composant **Transcription** quand l'accordéon était ouvert.

En espérant que cette correction puisse trouver sa place dans la 1.15.