### PR TITLE
🐛 fix(search): change l'attribut type du bouton à submit

### DIFF
--- a/src/dsfr/component/search/_part/doc/code/index.md
+++ b/src/dsfr/component/search/_part/doc/code/index.md
@@ -38,7 +38,7 @@ Sa structure est la suivante :
 - Le conteneur de la barre de recherche doit être un élément HTML `<div>` avec le rôle `search` défini par la classe `fr-search-bar`.
 - Le champ de recherche est un élément HTML `<input>` de type `search` défini par la classe `fr-input`.
 - Le champ de recherche doit être associée à un libellé `<label>` avec la classe `fr-label`.
-- Le bouton de recherche est un élément HTML `<button>` de type `button` défini par la classe `fr-btn` et dispose d'un attribut `title` indiquant son action.
+- Le bouton de recherche est un élément HTML `<button>` de type `button` défini par la classe `fr-btn` et dispose d'un attribut `title` indiquant son action. Son type doit être défini à `submit` si la barre de recherche est utilisée au sein d’un formulaire, ou à `button` si elle est utilisée de manière autonome.
 - Un message d'erreur ou de succès peut être associé au champ de recherche en utilisant un élément HTML `<div>` avec la classe `fr-messages-group` dans lequel on peut ajouter un message `fr-message`.
   - Son attribut`id` doit être associé à l'attribut `aria-describedby` du champ de recherche.
   - Ce bloc peut être placé vide et être rempli dynamiquement, auquel cas il doit être annoncé à l'utilisateur en utilisant l'attribut `aria-live="polite"`.
@@ -53,7 +53,7 @@ Sa structure est la suivante :
     <input class="fr-input" aria-describedby="search-input-messages" placeholder="Rechercher" id="search-input" type="search">
     <div class="fr-messages-group" id="search-input-messages" aria-live="polite">
     </div>
-    <button title="Rechercher" type="button" class="fr-btn">Rechercher</button>
+    <button title="Rechercher" type="submit" class="fr-btn">Rechercher</button>
 </div>
 ```
 

--- a/src/dsfr/component/search/_part/doc/code/index.md
+++ b/src/dsfr/component/search/_part/doc/code/index.md
@@ -38,7 +38,7 @@ Sa structure est la suivante :
 - Le conteneur de la barre de recherche doit être un élément HTML `<div>` avec le rôle `search` défini par la classe `fr-search-bar`.
 - Le champ de recherche est un élément HTML `<input>` de type `search` défini par la classe `fr-input`.
 - Le champ de recherche doit être associée à un libellé `<label>` avec la classe `fr-label`.
-- Le bouton de recherche est un élément HTML `<button>` défini par la classe `fr-btn` et dispose d'un attribut `title` indiquant son action. Son type doit être défini à `submit` si la barre de recherche est utilisée au sein d’un formulaire, ou à `button` si elle est utilisée de manière autonome.
+- Le bouton de recherche est un élément HTML `<button>` défini par la classe `fr-btn` et dispose d'un attribut `title` indiquant son action. Son type doit être défini à `submit` pour soumettre le formulaire au click ou avec la touche "entrée".
 - Un message d'erreur ou de succès peut être associé au champ de recherche en utilisant un élément HTML `<div>` avec la classe `fr-messages-group` dans lequel on peut ajouter un message `fr-message`.
   - Son attribut`id` doit être associé à l'attribut `aria-describedby` du champ de recherche.
   - Ce bloc peut être placé vide et être rempli dynamiquement, auquel cas il doit être annoncé à l'utilisateur en utilisant l'attribut `aria-live="polite"`.

--- a/src/dsfr/component/search/_part/doc/code/index.md
+++ b/src/dsfr/component/search/_part/doc/code/index.md
@@ -38,7 +38,7 @@ Sa structure est la suivante :
 - Le conteneur de la barre de recherche doit être un élément HTML `<div>` avec le rôle `search` défini par la classe `fr-search-bar`.
 - Le champ de recherche est un élément HTML `<input>` de type `search` défini par la classe `fr-input`.
 - Le champ de recherche doit être associée à un libellé `<label>` avec la classe `fr-label`.
-- Le bouton de recherche est un élément HTML `<button>` de type `button` défini par la classe `fr-btn` et dispose d'un attribut `title` indiquant son action. Son type doit être défini à `submit` si la barre de recherche est utilisée au sein d’un formulaire, ou à `button` si elle est utilisée de manière autonome.
+- Le bouton de recherche est un élément HTML `<button>` défini par la classe `fr-btn` et dispose d'un attribut `title` indiquant son action. Son type doit être défini à `submit` si la barre de recherche est utilisée au sein d’un formulaire, ou à `button` si elle est utilisée de manière autonome.
 - Un message d'erreur ou de succès peut être associé au champ de recherche en utilisant un élément HTML `<div>` avec la classe `fr-messages-group` dans lequel on peut ajouter un message `fr-message`.
   - Son attribut`id` doit être associé à l'attribut `aria-describedby` du champ de recherche.
   - Ce bloc peut être placé vide et être rempli dynamiquement, auquel cas il doit être annoncé à l'utilisateur en utilisant l'attribut `aria-live="polite"`.

--- a/src/dsfr/component/search/_part/doc/code/index.md
+++ b/src/dsfr/component/search/_part/doc/code/index.md
@@ -33,6 +33,8 @@ La barre de recherche est un système de navigation permettant à l'usager d’a
 #### Structure du composant
 
 Le composant **Barre de recherche** est un système de navigation qui permet à l'utilisateur d’accéder rapidement à un contenu en lançant une recherche sur un mot clé ou une expression.
+Le composant doit être utilisé dans un formulaire `<form>`, pour permettre un fonctionnement sans JS.
+
 Sa structure est la suivante :
 
 - Le conteneur de la barre de recherche doit être un élément HTML `<div>` avec le rôle `search` défini par la classe `fr-search-bar`.

--- a/src/dsfr/component/search/example/sample/search-default.ejs
+++ b/src/dsfr/component/search/example/sample/search-default.ejs
@@ -1,11 +1,11 @@
 <%
-let search = locals.search || {};
+let search = locals.search || {};
 
 let data = {
   id: uniqueId('search'),
   ...search,
   input: {placeholder: 'Rechercher', label:'Rechercher', ...search.input},
-  button: {id: uniqueId('search-btn'), label: 'Rechercher', title: 'Rechercher', ...search.button},
+  button: {id: uniqueId('search-btn'), label: 'Rechercher', type: 'submit', title: 'Rechercher', ...search.button},
 }
 %>
 

--- a/src/dsfr/component/search/template/stories/search-arg-types.js
+++ b/src/dsfr/component/search/template/stories/search-arg-types.js
@@ -78,7 +78,8 @@ const searchProps = (args) => {
     },
     button: {
       label: args.buttonLabel || searchArgs.buttonLabel,
-      title: args.buttonTitle || searchArgs.buttonTitle
+      title: args.buttonTitle || searchArgs.buttonTitle,
+      type: 'submit'
     }
   };
 


### PR DESCRIPTION
- Passe le type du bouton de la recherche à "submit" dans les exemples, la doc, et storybook puisque la barre de recherche est généralement intégrée au sein d'un formulaire