### PR TITLE
🐛 fix(display): désactive le composant quand l'attribut HTML `data-fr-scheme` est absent

### DIFF
--- a/src/dsfr/component/display/index.scss
+++ b/src/dsfr/component/display/index.scss
@@ -1,0 +1,6 @@
+////
+/// Display
+/// @group display
+////
+
+@import '../../core/index';

--- a/src/dsfr/component/display/main.scss
+++ b/src/dsfr/component/display/main.scss
@@ -1,0 +1,17 @@
+////
+/// Display Main
+/// @group display
+////
+
+/* ¯¯¯¯¯¯¯¯¯ *\
+  DISPLAY
+\* ˍˍˍˍˍˍˍˍˍ */
+
+@use 'src/module/path';
+@use 'src/module/shame/media-query';
+
+@include path.to-dist(2);
+@include media-query.order;
+
+@import 'index';
+@import 'style/module';

--- a/src/dsfr/component/display/script/display/display.js
+++ b/src/dsfr/component/display/script/display/display.js
@@ -10,12 +10,16 @@ class Display extends api.core.Instance {
     this.radios = this.querySelectorAll(DisplaySelector.RADIO_BUTTONS);
 
     if (api.scheme) {
-      this.changing = this.change.bind(this);
-      for (const radio of this.radios) radio.addEventListener('change', this.changing);
-      this.addDescent(api.scheme.SchemeEmission.SCHEME, this.apply.bind(this));
-      this.ascend(api.scheme.SchemeEmission.ASK);
+      if (!document.documentElement.hasAttribute(api.scheme.SchemeAttribute.SCHEME)) {
+        this.disableChoices();
+      } else {
+        this.changing = this.change.bind(this);
+        for (const radio of this.radios) radio.addEventListener('change', this.changing);
+        this.addDescent(api.scheme.SchemeEmission.SCHEME, this.apply.bind(this));
+        this.ascend(api.scheme.SchemeEmission.ASK);
+      }
     } else {
-      this.querySelector(DisplaySelector.FIELDSET).setAttribute('disabled', '');
+      this.disableChoices();
     }
   }
 
@@ -53,6 +57,10 @@ class Display extends api.core.Instance {
 
   dispose () {
     for (const radio of this.radios) radio.removeEventListener('change', this.changing);
+  }
+
+  disableChoices () {
+    this.querySelector(DisplaySelector.FIELDSET).setAttribute('disabled', '');
   }
 }
 

--- a/src/dsfr/component/display/script/display/display.js
+++ b/src/dsfr/component/display/script/display/display.js
@@ -9,15 +9,11 @@ class Display extends api.core.Instance {
   init () {
     this.radios = this.querySelectorAll(DisplaySelector.RADIO_BUTTONS);
 
-    if (api.scheme) {
-      if (!document.documentElement.hasAttribute(api.scheme.SchemeAttribute.SCHEME)) {
-        this.disableChoices();
-      } else {
-        this.changing = this.change.bind(this);
-        for (const radio of this.radios) radio.addEventListener('change', this.changing);
-        this.addDescent(api.scheme.SchemeEmission.SCHEME, this.apply.bind(this));
-        this.ascend(api.scheme.SchemeEmission.ASK);
-      }
+    if (api.scheme && document.documentElement.hasAttribute(api.scheme.SchemeAttribute.SCHEME)) {
+      this.changing = this.change.bind(this);
+      for (const radio of this.radios) radio.addEventListener('change', this.changing);
+      this.addDescent(api.scheme.SchemeEmission.SCHEME, this.apply.bind(this));
+      this.ascend(api.scheme.SchemeEmission.ASK);
     } else {
       this.disableChoices();
     }

--- a/src/dsfr/component/display/style/_module.scss
+++ b/src/dsfr/component/display/style/_module.scss
@@ -1,0 +1,10 @@
+////
+/// Display Module
+/// @group display
+////
+
+#{ns(display)} {
+  #{ns(fieldset__element)}:last-child {
+    @include margin-bottom(0);
+  }
+}

--- a/src/dsfr/component/main.scss
+++ b/src/dsfr/component/main.scss
@@ -50,6 +50,7 @@
 @import 'consent/main';
 @import 'follow/main';
 @import 'password/main';
+@import 'display/main';
 @import 'translate/main';
 @import 'table/main';
 @import 'transcription/main';

--- a/src/dsfr/scheme/index.js
+++ b/src/dsfr/scheme/index.js
@@ -2,6 +2,7 @@ import api from './api.js';
 import { Scheme } from './script/scheme/scheme.js';
 import { SchemeValue } from './script/scheme/scheme-value.js';
 import { SchemeSelector } from './script/scheme/scheme-selector.js';
+import { SchemeAttribute } from './script/scheme/scheme-attribute.js';
 import { SchemeEmission } from './script/scheme/scheme-emission.js';
 import { SchemeTheme } from './script/scheme/scheme-theme.js';
 import { SchemeEvent } from './script/scheme/scheme-event';
@@ -10,6 +11,7 @@ api.scheme = {
   Scheme: Scheme,
   SchemeValue: SchemeValue,
   SchemeSelector: SchemeSelector,
+  SchemeAttribute: SchemeAttribute,
   SchemeEmission: SchemeEmission,
   SchemeTheme: SchemeTheme,
   SchemeEvent: SchemeEvent

--- a/tool/example/example.ejs
+++ b/tool/example/example.ejs
@@ -1,6 +1,6 @@
 <% eval(include(root + 'src/dsfr/core/index.ejs')); %>
 <!doctype html>
-<html lang="fr" data-<%= prefix %>-theme>
+<html lang="fr" data-<%= prefix %>-scheme>
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">


### PR DESCRIPTION
Bonjour,

Voici une PR pour suivre la documentation :
> Afin d’activer la gestion du thème, il est nécessaire d’ajouter l’attribut data-fr-scheme sur la balise <html>. Si l’attribut n’est pas présent, le site s’affichera en mode clair (thème par défaut) et le composant paramètre d'affichage ne fonctionnera pas. 

Jusque là, le composant était uniquement désactivé quand l'API scheme était absente (cf. #1269)

J'en ai profité pour :
1. corriger la marge basse dans la modale car l'élément HTML `<fieldset class="fr-fieldset">` étant en `display: flex` la marge en bas du dernier choix ne se fusionnait pas avec celle de ` <div class="fr-modal__content">`.
2. appliquer le bon attribut HTML `data-fr-scheme` dans les exemples.

Au plaisir :bowtie: