### PR TITLE
feat(grid): permet d'utiliser la grille sous forme de liste

### DIFF
--- a/src/dsfr/core/style/grid/module/_row.scss
+++ b/src/dsfr/core/style/grid/module/_row.scss
@@ -4,10 +4,20 @@
 ////
 
 #{ns(grid-row)} {
-  @include disable-list-style;
   @include display-flex(null, null, null, wrap);
   @include margin(0);
   @include padding(0);
+  list-style-type: none;
+  counter-reset: none;
+
+  > {
+    #{class-start-with(ns(col-, ''))},
+    #{ns(col)} {
+      counter-increment: none;
+      @include marker(none);
+      @include padding(0);
+    }
+  }
 
   // Vertical alignment
   &--top {

--- a/src/dsfr/core/style/grid/module/_row.scss
+++ b/src/dsfr/core/style/grid/module/_row.scss
@@ -4,6 +4,7 @@
 ////
 
 #{ns(grid-row)} {
+  @include disable-list-style;
   @include display-flex(null, null, null, wrap);
   @include margin(0);
   @include padding(0);


### PR DESCRIPTION
Bonjour,

Cette PR pour permettre l'utilisation de la grille avec les éléments HTML `<ul>`, `<ol>` et `<li>`.

La méthode utilisée est la même que celle présente pour le **Groupe de boutons** : [src/dsfr/component/button/style/module/_group.scss](https://github.com/GouvernementFR/dsfr/blob/main/src/dsfr/component/button/style/module/_group.scss#L7)

Je ne suis pas le premier à avoir eu cette idée : 
* https://www.legifrance.gouv.fr/ : éléments de la partie "Le Journal officiel de la République française (JORF)".
* https://code.travail.gouv.fr/ : éléments de la partie "Thèmes".