### PR TITLE
📝 docs(*): corrige les liens vers la documentation des composants

### DIFF
--- a/src/dsfr/component/form/.package.yml
+++ b/src/dsfr/component/form/.package.yml
@@ -1,7 +1,7 @@
 id: form
 title: Formulaire
 description: Ce package permet de mettre en forme les différents champs d'un formulaire, notamment en ce qui concerne les espacements et texte d'aide et d'erreur.
-doc:
+doc: https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/formulaire
 wrapper: col-8
 style:
   - core

--- a/src/dsfr/component/input/.package.yml
+++ b/src/dsfr/component/input/.package.yml
@@ -1,7 +1,7 @@
 id: input
 title: Champ de saisie
 description: Les champs permettent à un utilisateur d'entrer du contenu et données.
-doc: https://www.systeme-de-design.gouv.fr/version-courante/fr/modeles/blocs-fonctionnels/adresse-electronique
+doc: https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/champ-de-saisie
 wrapper: col-8
 style:
   - core

--- a/src/dsfr/component/logo/.package.yml
+++ b/src/dsfr/component/logo/.package.yml
@@ -1,7 +1,7 @@
 id: logo
 title: Bloc marque
 description: Bloc marque de l'état
-doc:
+doc: https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/bloc-marque
 wrapper: col-8
 style:
   - core

--- a/src/dsfr/utility/colors/.package.yml
+++ b/src/dsfr/utility/colors/.package.yml
@@ -1,7 +1,7 @@
 id: colors
 title: Utilitaires de couleur
 description:
-doc: https://www.systeme-de-design.gouv.fr/version-courante/fr/fondamentaux/couleurs-palette
+doc: https://www.systeme-de-design.gouv.fr/version-courante/fr/fondamentaux/couleur
 wrapper: col-8
 style:
   - core

--- a/src/dsfr/utility/colors/.package.yml
+++ b/src/dsfr/utility/colors/.package.yml
@@ -1,7 +1,7 @@
 id: colors
 title: Utilitaires de couleur
 description:
-doc:
+doc: https://www.systeme-de-design.gouv.fr/version-courante/fr/fondamentaux/couleurs-palette
 wrapper: col-8
 style:
   - core


### PR DESCRIPTION
As the title says, it fixes some missing or wrong links in components packages.yml (present and correct in all other components)