### PR TITLE
🐛 fix: correction de la fonction sass space()

### DIFF
--- a/src/dsfr/core/style/grid/_setting.scss
+++ b/src/dsfr/core/style/grid/_setting.scss
@@ -16,4 +16,4 @@ $grid-settings: (
       max-width: 300v
     )
   )
-);
+) !default;

--- a/src/dsfr/core/style/spacing/function/_space.scss
+++ b/src/dsfr/core/style/spacing/function/_space.scss
@@ -9,7 +9,7 @@
 @use 'sass:list';
 @use 'src/module/string' as str;
 
-@function _space-join($value) {
+@function _join($value) {
   @if meta.type-of($value) != list {
     @return $value;
   }
@@ -109,12 +109,12 @@
       $end: unquote('');
 
       @if $c > 1 {
-        $start: _space-join(space(string.slice($value, 1, $c - 1)));
+        $start: _join(space(string.slice($value, 1, $c - 1)));
       }
 
       $l: str-length($value);
       @if $b < $l {
-        $end: _space-join(space(string.slice($value, $b + 1, $l)));
+        $end: _join(space(string.slice($value, $b + 1, $l)));
       }
 
       @return unquote('#{$start}(#{$middle})#{$end}');

--- a/src/dsfr/core/style/spacing/function/_space.scss
+++ b/src/dsfr/core/style/spacing/function/_space.scss
@@ -9,6 +9,19 @@
 @use 'sass:list';
 @use 'src/module/string' as str;
 
+@function _space-join($value) {
+  @if meta.type-of($value) != list {
+    @return $value;
+  }
+
+  $separator: ' ';
+  @if list.separator($value) == comma {
+    $separator: ', ';
+  }
+
+  @return str.join($value, $separator);
+}
+
 /// Return space value from type map and convert to rem.
 ///
 /// @param {Number} $value - valeur de l'espacement, permet de convertir cet espacement de v (4px) ou w (8px) en rem
@@ -96,12 +109,12 @@
       $end: unquote('');
 
       @if $c > 1 {
-        $start: space(string.slice($value, 1, $c - 1));
+        $start: _space-join(space(string.slice($value, 1, $c - 1)));
       }
 
       $l: str-length($value);
       @if $b < $l {
-        $end: space(string.slice($value, $b + 1, $l));
+        $end: _space-join(space(string.slice($value, $b + 1, $l)));
       }
 
       @return unquote('#{$start}(#{$middle})#{$end}');

--- a/src/module/media-query/variable/_breakpoints.scss
+++ b/src/module/media-query/variable/_breakpoints.scss
@@ -3,6 +3,7 @@
 /// @group media-query
 ////
 
+// L'ajout de breakpoints est entendable dans certaines situations, mais il interdit de modifier les valeurs existantes.
 $values: (
   xs: 0 35.98em,
   sm: 36em 47.98em,

--- a/src/module/spacing/function/_space.scss
+++ b/src/module/spacing/function/_space.scss
@@ -7,7 +7,7 @@
 $V: units.$V;
 $W: units.$W;
 
-@function _space-join($value) {
+@function _join($value) {
   @if meta.type-of($value) != list {
     @return $value;
   }
@@ -107,12 +107,12 @@ $W: units.$W;
       $end: string.unquote('');
 
       @if $c > 1 {
-        $start: _space-join(space(string.slice($value, 1, $c - 1)));
+        $start: _join(space(string.slice($value, 1, $c - 1)));
       }
 
       $l: string.length($value);
       @if $b < $l {
-        $end: _space-join(space(string.slice($value, $b + 1, $l)));
+        $end: _join(space(string.slice($value, $b + 1, $l)));
       }
 
       @return unquote('#{$start}(#{$middle})#{$end}');

--- a/src/module/spacing/function/_space.scss
+++ b/src/module/spacing/function/_space.scss
@@ -7,6 +7,19 @@
 $V: units.$V;
 $W: units.$W;
 
+@function _space-join($value) {
+  @if meta.type-of($value) != list {
+    @return $value;
+  }
+
+  $separator: ' ';
+  @if list.separator($value) == comma {
+    $separator: ', ';
+  }
+
+  @return string.join($value, $separator);
+}
+
 /// Return space value from type map and convert to rem.
 ///
 /// @param {Number} $value - valeur de l'espacement, permet de convertir cet espacement de v (4px) ou w (8px) en rem
@@ -94,12 +107,12 @@ $W: units.$W;
       $end: string.unquote('');
 
       @if $c > 1 {
-        $start: space(string.slice($value, 1, $c - 1));
+        $start: _space-join(space(string.slice($value, 1, $c - 1)));
       }
 
       $l: string.length($value);
       @if $b < $l {
-        $end: space(string.slice($value, $b + 1, $l));
+        $end: _space-join(space(string.slice($value, $b + 1, $l)));
       }
 
       @return unquote('#{$start}(#{$middle})#{$end}');


### PR DESCRIPTION
- corrige les espaces dans le css généré par la fonction sass `space`
- l'erreur était invisible car stylelint le corrige au build