### PR TITLE
🐛 fix(tooltip): corrige la fermeture sur IOS et la fermeture au tab

### DIFF
--- a/src/dsfr/component/tooltip/script/tooltip/tooltip-referent.js
+++ b/src/dsfr/component/tooltip/script/tooltip/tooltip-referent.js
@@ -10,6 +10,7 @@ class TooltipReferent extends api.core.PlacementReferent {
   constructor () {
     super();
     this._state = 0;
+    this._isShownOnInteraction = null;
   }
 
   static get instanceClassName () {
@@ -29,13 +30,35 @@ class TooltipReferent extends api.core.PlacementReferent {
       this.placement.listen('mouseout', mouseout);
     }
     this.addEmission(api.core.RootEmission.KEYDOWN, this._keydown.bind(this));
+    this.listen('pointerdown', this._interactionStart.bind(this));
+    this.listen('mousedown', this._interactionStart.bind(this));
+    this.listen('touchstart', this._interactionStart.bind(this));
     this.listen('click', this._click.bind(this));
     this.addEmission(api.core.RootEmission.CLICK, this._clickOut.bind(this));
     this.addEmission(api.core.RootEmission.INTERACTION, this._clickOut.bind(this)); // IOS
   }
 
+  _interactionStart () {
+    this._isShownOnInteraction = this.state > 0;
+  }
+
   _click () {
+    const isButtonTooltip = this.matches(TooltipSelector.BUTTON);
+
+    if (isButtonTooltip && (this._isShownOnInteraction === true || (this._isShownOnInteraction === null && this.state > 0))) {
+      this.close();
+      this._isShownOnInteraction = null;
+      return;
+    }
+
+    if (!isButtonTooltip) {
+      this.focusOut();
+      this._isShownOnInteraction = null;
+      return;
+    }
+
     this.focusIn();
+    this._isShownOnInteraction = null;
   }
 
   _clickOut (target) {

--- a/src/dsfr/component/tooltip/script/tooltip/tooltip-referent.js
+++ b/src/dsfr/component/tooltip/script/tooltip/tooltip-referent.js
@@ -31,6 +31,7 @@ class TooltipReferent extends api.core.PlacementReferent {
     this.addEmission(api.core.RootEmission.KEYDOWN, this._keydown.bind(this));
     this.listen('click', this._click.bind(this));
     this.addEmission(api.core.RootEmission.CLICK, this._clickOut.bind(this));
+    this.addEmission(api.core.RootEmission.INTERACTION, this._clickOut.bind(this)); // IOS
   }
 
   _click () {
@@ -47,7 +48,16 @@ class TooltipReferent extends api.core.PlacementReferent {
       case api.core.KeyCodes.ESCAPE:
         this.close();
         break;
+
+      case api.core.KeyCodes.TAB:
+        this.request(this._tab.bind(this));
+        break;
     }
+  }
+
+  _tab () {
+    if (this.node.contains(document.activeElement) || this.placement.node.contains(document.activeElement)) return;
+    this.focusOut();
   }
 
   close () {

--- a/src/dsfr/core/script/api/modules/stage/root-emission.js
+++ b/src/dsfr/core/script/api/modules/stage/root-emission.js
@@ -2,6 +2,7 @@ import ns from '../../utilities/namespace.js';
 
 export const RootEmission = {
   CLICK: ns.emission('root', 'click'),
+  INTERACTION: ns.emission('root', 'interaction'),
   KEYDOWN: ns.emission('root', 'keydown'),
   KEYUP: ns.emission('root', 'keyup')
 };

--- a/src/dsfr/core/script/api/modules/stage/root.js
+++ b/src/dsfr/core/script/api/modules/stage/root.js
@@ -13,12 +13,17 @@ class Root extends Element {
   listen () {
     // TODO v2 => listener au niveau des éléments qui redistribuent aux instances.
     document.documentElement.addEventListener('click', this.click.bind(this), { capture: true });
+    document.documentElement.addEventListener(window.PointerEvent ? 'pointerdown' : 'touchstart', this.interaction.bind(this), { capture: true }); // IOS
     document.documentElement.addEventListener('keydown', this.keydown.bind(this), { capture: true });
     document.documentElement.addEventListener('keyup', this.keyup.bind(this), { capture: true });
   }
 
   click (e) {
     this.emit(RootEmission.CLICK, e.target);
+  }
+
+  interaction (e) {
+    this.emit(RootEmission.INTERACTION, e.target);
   }
 
   keydown (e) {

--- a/src/dsfr/core/script/api/modules/stage/root.js
+++ b/src/dsfr/core/script/api/modules/stage/root.js
@@ -13,7 +13,7 @@ class Root extends Element {
   listen () {
     // TODO v2 => listener au niveau des éléments qui redistribuent aux instances.
     document.documentElement.addEventListener('click', this.click.bind(this), { capture: true });
-    document.documentElement.addEventListener(window.PointerEvent ? 'pointerdown' : 'touchstart', this.interaction.bind(this), { capture: true }); // IOS
+    document.documentElement.addEventListener(window.PointerEvent ? 'pointerdown' : 'touchstart', this.interaction.bind(this), { capture: true, passive: true }); // IOS
     document.documentElement.addEventListener('keydown', this.keydown.bind(this), { capture: true });
     document.documentElement.addEventListener('keyup', this.keyup.bind(this), { capture: true });
   }


### PR DESCRIPTION
- Sur safari et IOS le tooltip ouvert au clic ne se referme pas lors d'un clic dans la page
- Un tooltip ouvert au clic ne se referme pas au changement de focus au 'tab'