### PR TITLE
:bug: fix(pa11y): corrections des tests automatiques Pa11y

### DIFF
--- a/src/dsfr/component/checkbox/template/ejs/checkbox.ejs
+++ b/src/dsfr/component/checkbox/template/ejs/checkbox.ejs
@@ -26,6 +26,7 @@ let attributes = checkbox.attributes || {};
 if (checkbox.checked === true) attributes.checked = "";
 if (checkbox.disabled === true) attributes.disabled = "";
 if (checkbox.name) attributes.name = checkbox.name;
+if (checkbox.indeterminate === true) checkbox.id += "-indeterminate";
 attributes.id = checkbox.id;
 attributes.type = "checkbox";
 const describedby = [];

--- a/src/dsfr/component/notice/example/sample/sample-header.ejs
+++ b/src/dsfr/component/notice/example/sample/sample-header.ejs
@@ -13,7 +13,7 @@ const skiplinks = [
 
 <%- include('../../../../component/skiplink/template/ejs/skiplinks', { skiplink: {items: skiplinks} }, true); %>
 
-<%- include('../../../../component/header/example/sample/header.ejs', {header: { logo:{ title: 'Intitulé<br>officiel'}, service:true, links:true, navigation: true }}, true); %>
+<%- include('../../../../component/header/example/sample/header.ejs', {header: { logo:{ title: 'Intitulé<br>officiel'}, service:true, links:true, navigation: true, menu: { modalId: 'header-navigation' }}}, true); %>
 
 <div id="content">
   <%- include('../../template/ejs/notice.ejs', {notice: {type: 'info', title: 'Information importante'}}); %>

--- a/src/dsfr/component/table/example/data/data-complex-tbody.json.ejs
+++ b/src/dsfr/component/table/example/data/data-complex-tbody.json.ejs
@@ -5,25 +5,25 @@ const tbody = [
   [
     {
       attributes: {
-        headers: 'complex-row-0 complex-thead-0-col-1 complex-thead-1-col-1'
+        headers: 'complex-row-0 complex-thead-0-col-1 complex-thead-1-col-0'
       },
       content: 'Français'
     },
     {
       attributes: {
-        headers: 'complex-row-0 complex-thead-0-col-2 complex-thead-1-col-2'
+        headers: 'complex-row-0 complex-thead-0-col-2 complex-thead-1-col-1'
       },
       content: 'Mathématiques'
     },
     {
       attributes: {
-        headers: 'complex-row-0 complex-thead-0-col-3 complex-thead-1-col-3'
+        headers: 'complex-row-0 complex-thead-0-col-3 complex-thead-1-col-2'
       },
       content: 'LV1'
     },
     {
       attributes: {
-        headers: 'complex-row-0 complex-thead-0-col-3 complex-thead-1-col-4'
+        headers: 'complex-row-0 complex-thead-0-col-3 complex-thead-1-col-3'
       },
       content: 'Histoire - Géographie'
     },
@@ -38,7 +38,7 @@ const tbody = [
     {
       attributes: {
         colspan: 5,
-        headers: 'complex-row-1 complex-thead-0-col-1 complex-thead-0-col-2 complex-thead-0-col-3 complex-thead-0-col-4 complex-thead-1-col-1 complex-thead-1-col-2 complex-thead-1-col-3 complex-thead-1-col-4 complex-thead-1-col-4'
+        headers: 'complex-row-1 complex-thead-0-col-1 complex-thead-0-col-2 complex-thead-0-col-3 complex-thead-0-col-4 complex-thead-1-col-0 complex-thead-1-col-1 complex-thead-1-col-2 complex-thead-1-col-3 complex-thead-1-col-4'
       },
       content: 'Etude dirigée<br><i>Exemple de colspan sur toute la ligne</i>'
     }
@@ -46,26 +46,26 @@ const tbody = [
   [
       {
       attributes: {
-        headers: 'complex-row-2 complex-thead-0-col-1 complex-thead-1-col-1'
+        headers: 'complex-row-2 complex-thead-0-col-1 complex-thead-1-col-0'
       },
       content: 'Mathématiques'
     },
       {
       attributes: {
-        headers: 'complex-row-2 complex-thead-0-col-2 complex-thead-1-col-2'
+        headers: 'complex-row-2 complex-thead-0-col-2 complex-thead-1-col-1'
       },
       content: 'Histoire - Géographie'
     },
     {
       attributes: {
         rowspan: 2,
-        headers: 'complex-row-2 complex-row-3 complex-thead-0-col-3 complex-thead-1-col-3'
+        headers: 'complex-row-2 complex-row-3 complex-thead-0-col-3 complex-thead-1-col-2'
       },
       content: `Arts appliqués<br>${getPictogram({name: 'environment'})}`
     },
     {
       attributes: {
-        headers: 'complex-row-2 complex-thead-0-col-3 complex-thead-1-col-4'
+        headers: 'complex-row-2 complex-thead-0-col-3 complex-thead-1-col-3'
       },
       content: 'LV2'
     },
@@ -79,19 +79,19 @@ const tbody = [
   [
     {
       attributes: {
-        headers: 'complex-row-3 complex-thead-0-col-1 complex-thead-1-col-1'
+        headers: 'complex-row-3 complex-thead-0-col-1 complex-thead-1-col-0'
       },
       content: 'Français'
     },
     {
       attributes: {
-        headers: 'complex-row-3 complex-thead-0-col-2 complex-thead-1-col-2'
+        headers: 'complex-row-3 complex-thead-0-col-2 complex-thead-1-col-1'
       },
       content: 'EPS'
     },
     {
       attributes: {
-        headers: 'complex-row-3 complex-thead-0-col-3 complex-thead-1-col-4'
+        headers: 'complex-row-3 complex-thead-0-col-3 complex-thead-1-col-3'
       },
       content: 'Histoire - Géographie'
     },
@@ -105,20 +105,20 @@ const tbody = [
   [
     {
       attributes: {
-        headers: 'complex-row-4 complex-thead-0-col-1 complex-thead-1-col-1'
+        headers: 'complex-row-4 complex-thead-0-col-1 complex-thead-1-col-0'
       },
       content: 'Sciences'
     },
     {
       attributes: {
-        headers: 'complex-row-4 complex-thead-0-col-2 complex-thead-1-col-2'
+        headers: 'complex-row-4 complex-thead-0-col-2 complex-thead-1-col-1'
       },
       content: 'LV1'
     },
     {
       attributes: {
         colspan: 2,
-        headers: 'complex-row-4 complex-thead-0-col-3 complex-thead-1-col-3 complex-thead-1-col-4'
+        headers: 'complex-row-4 complex-thead-0-col-3 complex-thead-1-col-2 complex-thead-1-col-3'
       },
       content: 'EPS<br><i>Exemple de colspan sur 2 cellules</i>'
     },

--- a/src/dsfr/component/table/example/data/data-miscellaneous.json.ejs
+++ b/src/dsfr/component/table/example/data/data-miscellaneous.json.ejs
@@ -18,48 +18,78 @@ const thead = [
   [
     {
       attributes: {
-        role: 'columnheader'
+        role: 'columnheader',
+        scope: 'col'
       },
       classes: [`${prefix}-cell--fixed`],
       content: getSrOnlyCell(getText('data.cell.action.select', 'table'))
     },
     {
+      attributes: {
+        scope: 'col'
+      },
       content: getTitleCell()
     },
     {
+      attributes: {
+        scope: 'col'
+      },
       content: getTitleCell('div') + getTextCell('div')
     },
     {
+      attributes: {
+        scope: 'col'
+      },
       content: `<div class="${prefix}-cell--sort">${getTitleCell()} ${getButton({id: `${table.id}-thead-sort-asc-desc`, label: `${getText('data.cell.action.sort', 'table')}`, classes: [`${prefix}-btn--sort`]})}</div>`
     },
     {
       attributes: {
-        'aria-sort': 'descending'
+        'aria-sort': 'descending',
+        scope: 'col'
       },
       content: getButton({id: `${table.id}-thead-sort-descending`, label: `${getText('data.cell.action.sort', 'table')}`, classes: [`${prefix}-btn--sort-desc`], attributes: {}})
     },
     {
+      attributes: {
+        scope: 'col'
+      },
       content: `${getTextCell()} ${getButton({label: getText('data.cell.text', 'table'), classes: [`${prefix}-ml-2v`, `${prefix}-btn--tooltip`], tooltip: {id: `${table.id}-thead-tooltip`, content: lorem()}})}`
     },
     {
       attributes: {
-        'aria-sort': 'ascending'
+        'aria-sort': 'ascending',
+        scope: 'col'
       },
       content: getButton({id: `${table.id}-thead-sort-ascending`, label: `${getText('data.cell.action.sort', 'table')}`, classes: [`${prefix}-btn--sort-asc`], attributes: {}})
     },
     {
+      attributes: {
+        scope: 'col'
+      },
       content: getBadge({id: `${table.id}-thead-badge`, type: 'info', label: getText('data.cell.label', 'table')})
     },
     {
+      attributes: {
+        scope: 'col'
+      },
       content: getTextCell()
     },
     {
+      attributes: {
+        scope: 'col'
+      },
       content: getTitleCell()
     },
     {
+      attributes: {
+        scope: 'col'
+      },
       content: getTitleCell() + getTextCell('span', `${prefix}-cell__desc ${prefix}-ml-2v`)
     },
     {
+      attributes: {
+        scope: 'col'
+      },
       content: getIcon({name: 'arrow-right-s-line', size: 'sm', classes: [`${prefix}-mr-2v`]}) + getText('data.cell.text', 'table')
     }
   ]

--- a/src/dsfr/component/table/example/data/data-simple.json.ejs
+++ b/src/dsfr/component/table/example/data/data-simple.json.ejs
@@ -23,7 +23,8 @@ if (table.selectable) {
   thead.forEach((row) => {
     row.unshift({
       attributes: {
-        role: 'columnheader'
+        role: 'columnheader',
+        scope: 'col'
       },
       classes: [`${prefix}-cell--fixed${fixedBp}`],
       content: getSrOnlyCell(getText('data.cell.action.select', 'table'))
@@ -45,7 +46,8 @@ if (table.doubleEntry) {
   thead.forEach((row) => {
     row.unshift({
       attributes: {
-        role: 'columnheader'
+        role: 'columnheader',
+        scope: 'col'
       },
       classes: [`${prefix}-cell--fixed${fixedBp}`],
       content: getSrOnlyCell(getText('data.cell.doubleEntry', 'table'))


### PR DESCRIPTION
Hello,

En exécutant la commande `npm test`, j'ai trouvé quelques erreurs.

Composant **Notice**
====
Les liens d'évitement de l'exemple "Mise en situation du placement du bandeau" n'avaient pas tous une référence dans le DOM.

Composant **Checkbox**
====
Désolé pour celle là, c'est ma faute...

La liaison for/id pour la checkbox avec un état indéterminé était incorrecte.

Composant **Table**
====

Dans l'exemple "Tableau complexe (comportant des cellules fusionnées)", les valeurs des attributs `headers` n'étaient pas correctes. La deuxième ligne d'en-tête commence ses indexes à 0 même si sa première colonne est occupée.

Dans certains exemples, la première colonne avec un intitulé caché n'avait pas d'attribut HTML `scope` et un autre exemple l'attribut HTML `scope` était totalement absent alors que des en-têtes sur les lignes étaient aussi présentes.