### PR TITLE
🐛 fix(legacy): changement de la media query de détection de IE

### DIFF
--- a/src/dsfr/core/_part/doc/icon/index.md
+++ b/src/dsfr/core/_part/doc/icon/index.md
@@ -59,7 +59,7 @@ Pour ajouter une icône qui ne serait pas présente dans le DSFR, il est possibl
 [Facultatif] Pour fonctionner sur Internet Explorer 11, il faudra également ajouter, de préférence dans un autre fichier CSS, la règle suivante :
 
 ```CSS
-@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+@media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
   .fr-icon-custom-icon::before,
   .fr-icon-custom-icon::after {
     background-image: url("../icons/custom-icon.svg");

--- a/src/dsfr/core/_part/doc/icon/index.md
+++ b/src/dsfr/core/_part/doc/icon/index.md
@@ -59,7 +59,7 @@ Pour ajouter une icône qui ne serait pas présente dans le DSFR, il est possibl
 [Facultatif] Pour fonctionner sur Internet Explorer 11, il faudra également ajouter, de préférence dans un autre fichier CSS, la règle suivante :
 
 ```CSS
-@supports (-ms-ime-align: auto) {
+@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
   .fr-icon-custom-icon::before,
   .fr-icon-custom-icon::after {
     background-image: url("../icons/custom-icon.svg");

--- a/src/dsfr/core/_part/doc/icon/index.md
+++ b/src/dsfr/core/_part/doc/icon/index.md
@@ -59,7 +59,7 @@ Pour ajouter une icône qui ne serait pas présente dans le DSFR, il est possibl
 [Facultatif] Pour fonctionner sur Internet Explorer 11, il faudra également ajouter, de préférence dans un autre fichier CSS, la règle suivante :
 
 ```CSS
-@media screen and (min-width: 0\0) and (min-resolution: 72dpi) {
+@supports (-ms-ime-align: auto) {
   .fr-icon-custom-icon::before,
   .fr-icon-custom-icon::after {
     background-image: url("../icons/custom-icon.svg");

--- a/src/module/legacy/mixin/_legacy.scss
+++ b/src/module/legacy/mixin/_legacy.scss
@@ -1,32 +1,16 @@
 /// Styles spécifiques pour les plateformes antérieures
 ///
-/// @example scss -
-///   legacy.is(ie11) {
-///     .foo {
-///     }
+/// legacy.is(ie11) {
+///   .foo {
 ///   }
+/// }
 @mixin is($target) {
   @if $target == ie11 {
-    @supports (-ms-ime-align: auto) {
+    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
       @content;
     }
   }
   @else {
     @content;
-  }
-}
-
-/// Styles spécifiques pour les plateformes modernes, excluant les plateformes antérieures
-///
-/// @example scss -
-///   legacy.is-not(ie11) {
-///     .foo {
-///     }
-///   }
-@mixin is-not($target) {
-  @if $target == ie11 {
-    @supports not (-ms-high-contrast: none) {
-      @content;
-    }
   }
 }

--- a/src/module/legacy/mixin/_legacy.scss
+++ b/src/module/legacy/mixin/_legacy.scss
@@ -1,13 +1,13 @@
 /// Styles spécifiques pour les plateformes antérieures
 ///
 /// @example scss -
-///   .foo {
-///     @include ie-hack() {
+///   legacy.is(ie11) {
+///     .foo {
 ///     }
 ///   }
 @mixin is($target) {
-  @if $target == ie10 or $target == ie11 {
-    @media screen and (min-width: 0\0) and (min-resolution: +72dpi) {
+  @if $target == ie11 {
+    @supports (-ms-ime-align: auto) {
       @content;
     }
   }
@@ -19,12 +19,12 @@
 /// Styles spécifiques pour les plateformes modernes, excluant les plateformes antérieures
 ///
 /// @example scss -
-///   .foo {
-///     @include ie-hack() {
+///   legacy.is-not(ie11) {
+///     .foo {
 ///     }
 ///   }
 @mixin is-not($target) {
-  @if $target == ie10 or $target == ie11 {
+  @if $target == ie11 {
     @supports not (-ms-high-contrast: none) {
       @content;
     }

--- a/src/module/legacy/mixin/_legacy.scss
+++ b/src/module/legacy/mixin/_legacy.scss
@@ -6,7 +6,7 @@
 /// }
 @mixin is($target) {
   @if $target == ie11 {
-    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+    @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
       @content;
     }
   }

--- a/src/module/preference/mixin/_forced-colors.scss
+++ b/src/module/preference/mixin/_forced-colors.scss
@@ -7,7 +7,7 @@
 /// }
 
 @mixin forced-colors($active: active) {
-  @media (-ms-high-contrast: $active), (forced-colors: $active) {
+  @media (forced-colors: $active) {
     @content;
   }
 }

--- a/tool/example/style.css.ejs
+++ b/tool/example/style.css.ejs
@@ -42,7 +42,7 @@ pre[class*="language-"] {
   right: 2rem;
 }
 
-@supports (-ms-ime-align: auto) {
+@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
   /* IE11 specific styles go here */
   .example-controls {
     display: none;

--- a/tool/example/style.css.ejs
+++ b/tool/example/style.css.ejs
@@ -42,8 +42,8 @@ pre[class*="language-"] {
   right: 2rem;
 }
 
-@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {  
-  /* IE10+ specific styles go here */
+@supports (-ms-ime-align: auto) {
+  /* IE11 specific styles go here */
   .example-controls {
     display: none;
   }

--- a/tool/example/style.css.ejs
+++ b/tool/example/style.css.ejs
@@ -42,8 +42,8 @@ pre[class*="language-"] {
   right: 2rem;
 }
 
-@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-  /* IE11 specific styles go here */
+@media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
+  /* IE specific styles go here */
   .example-controls {
     display: none;
   }


### PR DESCRIPTION
- Retire le support du Windows High Contrast mode sur IE
- Change la media-query de détection de IE ce qui permet d'éviter le crash des linter/compilateur
