### PR TITLE
🐛 fix(transcription): corrige la démo et ajoute le titre de la modale

### DIFF
--- a/src/dsfr/component/transcription/_part/doc/accessibility/index.md
+++ b/src/dsfr/component/transcription/_part/doc/accessibility/index.md
@@ -49,7 +49,7 @@ Voir les interactions au clavier pour le [composant Accordéon](../../../../acco
   - Si la modale est visible, le bouton a l'attribut `data-fr-opened` défini sur true. Si la modale n'est pas visible, `data-fr-opened` est défini sur false.
 - La modale de transcription est un élément HTML "dialog" et dispose d'un attribut `aria-modal="true"` pour indiquer aux lecteurs d'écran que l'élément est une modale lorsqu'il est affiché.
   - La modale dispose d'un attribut `aria-labelledby` défini sur l'ID du titre de la modale.
-- La modale de transcription contient un titre de niveau `H1`.
+- La modale de transcription doit contenir un titre de niveau `Hx` en fonction de la structure de la page. Il peut être caché visuellement mais doit être présent dans le DOM pour les lecteurs d'écran.
 - La modale de transcription contient un bouton de fermeture de type="button".
   - Le bouton de fermeture de la modale dispose d'un attribut `aria-controls` défini sur l'ID de la modale.
 

--- a/src/dsfr/component/transcription/_part/doc/accessibility/index.md
+++ b/src/dsfr/component/transcription/_part/doc/accessibility/index.md
@@ -49,7 +49,7 @@ Voir les interactions au clavier pour le [composant Accordéon](../../../../acco
   - Si la modale est visible, le bouton a l'attribut `data-fr-opened` défini sur true. Si la modale n'est pas visible, `data-fr-opened` est défini sur false.
 - La modale de transcription est un élément HTML "dialog" et dispose d'un attribut `aria-modal="true"` pour indiquer aux lecteurs d'écran que l'élément est une modale lorsqu'il est affiché.
   - La modale dispose d'un attribut `aria-labelledby` défini sur l'ID du titre de la modale.
-- La modale de transcription doit contenir un titre de niveau `Hx` en fonction de la structure de la page. Il peut être caché visuellement mais doit être présent dans le DOM pour les lecteurs d'écran.
+  - La modale de transcription doit contenir un titre de niveau `Hx` en fonction de la structure de la page. Il peut être caché visuellement mais doit être présent dans le DOM pour les lecteurs d'écran.
 - La modale de transcription contient un bouton de fermeture de type="button".
   - Le bouton de fermeture de la modale dispose d'un attribut `aria-controls` défini sur l'ID de la modale.
 

--- a/src/dsfr/component/transcription/template/stories/transcription-arg-types.js
+++ b/src/dsfr/component/transcription/template/stories/transcription-arg-types.js
@@ -26,11 +26,18 @@ const transcriptionArgTypes = {
       value: 'string'
     }
   },
+  modalTitle: {
+    control: 'text',
+    description: 'Titre de la modale de transcription (s\'affiche uniquement si la transcription est ouverte en plein écran)',
+    type: {
+      value: 'string'
+    }
+  },
   isExpanded: {
     control: 'boolean',
     description: 'Transcription ouverte par défaut',
     type: {
-      value: 'string'
+      value: 'boolean'
     }
   }
 };
@@ -39,7 +46,8 @@ const transcriptionArgs = {
   fullscreen: 'Agrandir',
   fullscreenArialLabel: 'Agrandir la transcription',
   isExpanded: false,
-  id: 'transcription-id'
+  id: 'transcription-id',
+  modalTitle: 'Titre de la transcription'
 };
 
 const transcriptionProps = (args) => {
@@ -48,6 +56,7 @@ const transcriptionProps = (args) => {
     isExpanded: args.isExpanded || transcriptionArgs.isExpanded,
     fullscreen: args.fullscreen || transcriptionArgs.fullscreen,
     fullscreenArialLabel: args.fullscreenArialLabel || transcriptionArgs.fullscreenArialLabel,
+    title: args.modalTitle || transcriptionArgs.modalTitle,
     content: content
   };
 

--- a/src/dsfr/component/transcription/template/stories/transcription-arg-types.js
+++ b/src/dsfr/component/transcription/template/stories/transcription-arg-types.js
@@ -19,7 +19,7 @@ const transcriptionArgTypes = {
       value: 'string'
     }
   },
-  fullscreenArialLabel: {
+  fullscreenAriaLabel: {
     control: 'text',
     description: 'Texte alternatif du bouton plein écran',
     type: {
@@ -44,7 +44,7 @@ const transcriptionArgTypes = {
 
 const transcriptionArgs = {
   fullscreen: 'Agrandir',
-  fullscreenArialLabel: 'Agrandir la transcription',
+  fullscreenAriaLabel: 'Agrandir la transcription',
   isExpanded: false,
   id: 'transcription-id',
   modalTitle: 'Titre de la transcription'
@@ -55,7 +55,7 @@ const transcriptionProps = (args) => {
     id: args.id || transcriptionArgs.id,
     isExpanded: args.isExpanded || transcriptionArgs.isExpanded,
     fullscreen: args.fullscreen || transcriptionArgs.fullscreen,
-    fullscreenArialLabel: args.fullscreenArialLabel || transcriptionArgs.fullscreenArialLabel,
+    fullscreenAriaLabel: args.fullscreenAriaLabel || transcriptionArgs.fullscreenAriaLabel,
     title: args.modalTitle || transcriptionArgs.modalTitle,
     content: content
   };


### PR DESCRIPTION
- Ajoute la possibilité de paramétrer le titre de la modal de transcription dans le storybook
- Correction de la documentation transcription