### PR TITLE
 🐛 fix(transcription): remplace la balise dialog par une balise div

### DIFF
--- a/src/dsfr/component/modal/template/ejs/modal.ejs
+++ b/src/dsfr/component/modal/template/ejs/modal.ejs
@@ -3,7 +3,7 @@
 
 * modal.id (string, required) : id de la modale
 
-* modal.markup (string, optional) : balise de la modale (dialog, div>)
+* modal.markup (string, optional) : balise de la modale (dialog, div)
 
 * modal.titleMarkup (string, optional) : balise du titre de la modale (h1, h2, h3, p, etc.), par défaut h1
 

--- a/src/dsfr/component/transcription/_part/doc/accessibility/index.md
+++ b/src/dsfr/component/transcription/_part/doc/accessibility/index.md
@@ -47,7 +47,7 @@ Voir les interactions au clavier pour le [composant Accordéon](../../../../acco
   - Le bouton d'ouverture de la modale dispose d'un attribut `aria-label` dont la valeur "Agrandir la transcription" explicite l'action d'ouverture de la modale.
   - Le bouton d'ouverture de la modale a l'attribut `aria-controls` défini sur l'ID de la modale.
   - Si la modale est visible, le bouton a l'attribut `data-fr-opened` défini sur true. Si la modale n'est pas visible, `data-fr-opened` est défini sur false.
-- La modale de transcription est un élément HTML "div" sans attribut `aria-modal`.
+- La modale de transcription est un élément HTML "div" avec la classe `fr-modal`.
   - La modale dispose d'un attribut `aria-labelledby` défini sur l'ID du titre de la modale.
 - La modale de transcription contient un titre de niveau `H1`.
 - La modale de transcription contient un bouton de fermeture de type="button".

--- a/src/dsfr/component/transcription/_part/doc/accessibility/index.md
+++ b/src/dsfr/component/transcription/_part/doc/accessibility/index.md
@@ -47,7 +47,7 @@ Voir les interactions au clavier pour le [composant Accordéon](../../../../acco
   - Le bouton d'ouverture de la modale dispose d'un attribut `aria-label` dont la valeur "Agrandir la transcription" explicite l'action d'ouverture de la modale.
   - Le bouton d'ouverture de la modale a l'attribut `aria-controls` défini sur l'ID de la modale.
   - Si la modale est visible, le bouton a l'attribut `data-fr-opened` défini sur true. Si la modale n'est pas visible, `data-fr-opened` est défini sur false.
-- La modale de transcription est un élément HTML "dialog" et dispose d'un attribut `aria-modal="true"` pour indiquer aux lecteurs d'écran que l'élément est une modale lorsqu'il est affiché.
+- La modale de transcription est un élément HTML "div" sans attribut `aria-modal`.
   - La modale dispose d'un attribut `aria-labelledby` défini sur l'ID du titre de la modale.
 - La modale de transcription contient un titre de niveau `H1`.
 - La modale de transcription contient un bouton de fermeture de type="button".

--- a/src/dsfr/component/transcription/_part/doc/code/index.md
+++ b/src/dsfr/component/transcription/_part/doc/code/index.md
@@ -52,7 +52,7 @@ Sa structure est la suivante :
         - Le bouton dispose d'un attribut `aria-label`, dont la valeur est "Agrandir la transcription".
         - Le bouton dispose d'un attribut `data-fr-opened`, sa valeur [true|false] défini si le collapse est ouvert ou fermé
         - Le bouton est lié à la modale via l'attribut `aria-controls`, sa valeur doit correspondre à l'attribut `id` de la modale.
-  - Le bloc refermable contient une modale, élément HTML `<div>` pour afficher le contenu en plein écran, définie par la classe `fr-modal`.
+  - Le bloc refermable contient une modale, élément HTML `<div>` définie par la classe `fr-modal`, pour afficher le contenu en plein écran.
     - Elle dispose d'un attribut `id` obligatoire, pour être lié au bouton d'ouverture.
     - la modale est lié à son titre via l'attribut `aria-labelledby`, dont la valeur doit correspondre à l'attribut `id` du titre.
     - Le contenu de la modale reprend la structure du composant [Modale](../../../../modal/_part/doc/index.md) et son contenu est libre, mais nécessite l'utilisation des balises adéquates, il n'est pas correcte de placer du texte directement dans une `<div>`.

--- a/src/dsfr/component/transcription/_part/doc/code/index.md
+++ b/src/dsfr/component/transcription/_part/doc/code/index.md
@@ -52,7 +52,7 @@ Sa structure est la suivante :
         - Le bouton dispose d'un attribut `aria-label`, dont la valeur est "Agrandir la transcription".
         - Le bouton dispose d'un attribut `data-fr-opened`, sa valeur [true|false] défini si le collapse est ouvert ou fermé
         - Le bouton est lié à la modale via l'attribut `aria-controls`, sa valeur doit correspondre à l'attribut `id` de la modale.
-  - Le bloc refermable contient une modale, élément HTML `<dialog>` pour afficher le contenu en plein écran, définie par la classe `fr-modal`.
+  - Le bloc refermable contient une modale, élément HTML `<div>` pour afficher le contenu en plein écran, définie par la classe `fr-modal`.
     - Elle dispose d'un attribut `id` obligatoire, pour être lié au bouton d'ouverture.
     - la modale est lié à son titre via l'attribut `aria-labelledby`, dont la valeur doit correspondre à l'attribut `id` du titre.
     - Le contenu de la modale reprend la structure du composant [Modale](../../../../modal/_part/doc/index.md) et son contenu est libre, mais nécessite l'utilisation des balises adéquates, il n'est pas correcte de placer du texte directement dans une `<div>`.
@@ -68,7 +68,7 @@ Sa structure est la suivante :
                 <button aria-controls="fr-transcription-modal" aria-label="Agrandir la transcription" data-fr-opened="false" type="button" class="fr-btn--fullscreen fr-btn">Agrandir</button>
             </div>
         </div>
-        <dialog id="fr-transcription-modal" class="fr-modal" aria-labelledby="fr-transcription-modal-title">
+        <div id="fr-transcription-modal" class="fr-modal" aria-labelledby="fr-transcription-modal-title">
             <div class="fr-container fr-container--fluid fr-container-md">
                 <div class="fr-grid-row fr-grid-row--center">
                     <div class="fr-col-12 fr-col-md-10 fr-col-lg-8">
@@ -86,7 +86,7 @@ Sa structure est la suivante :
                     </div>
                 </div>
             </div>
-        </dialog>
+        </div>
     </div>
 </div>
 ```

--- a/src/dsfr/component/transcription/template/ejs/transcription.ejs
+++ b/src/dsfr/component/transcription/template/ejs/transcription.ejs
@@ -30,7 +30,7 @@ const title = locals.getText('collapse.title', 'transcription');
 if (transcription.id) attributes.id = transcription.id;
 
 let modal = {
-  tag: 'div',
+  markup: 'div',
   title: transcription.title,
   body: transcription.content,
   id: transcription.modalId || uniqueId('modal-transcription'),


### PR DESCRIPTION
Hello,

Voici la correction de l'issue #1464 (ping @fxlair).

En fait cette correction a été traitée en 1.10 via https://github.com/GouvernementFR/dsfr/pull/684 (on le retrouve aussi dans la partie ["Code - Note de version" du composant](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/transcription/code-de-la-transcription#note-de-version)) mais c'est perdu en 1.13 lorsque `modal.tag` s'est transformée en `modal.markup` (cf. : PR [✨ feat: ajout de storybook & restructuration](https://github.com/GouvernementFR/dsfr/pull/945/changes#diff-e08cdc5a60739611c2846a9e0e3fe578ae3e708613f7b1c21e749fe9540709fa)).

Fin de l'histoire.