### PR TITLE
docs: remove unnecessary comma in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Il est également possible de récupérer le projet DSFR directement depuis Gith
 git clone https://github.com/GouvernementFR/dsfr.git
 ```
 
-Puis de se rendre dans le dossier du projet, consentir aux modalités d'utilisation, installer les dépendances et compiler le projet avec les commandes suivantes ::
+Puis de se rendre dans le dossier du projet, consentir aux modalités d'utilisation, installer les dépendances et compiler le projet avec les commandes suivantes :
 
 ```bash
 cd dsfr

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Il est également possible de récupérer le projet DSFR directement depuis Gith
 git clone https://github.com/GouvernementFR/dsfr.git
 ```
 
-Puis de se rendre dans le dossier du projet, consentir aux modalités d'utilisation, installer les dépendances, et compiler le projet avec les commandes suivantes :
+Puis de se rendre dans le dossier du projet, consentir aux modalités d'utilisation, installer les dépendances et compiler le projet avec les commandes suivantes ::
 
 ```bash
 cd dsfr


### PR DESCRIPTION
This PR removes an unnecessary comma in the French installation instructions to improve readability.