### PR TITLE
:bug: fix(badge): utilisation de span dans groupe de badge

### DIFF
--- a/src/dsfr/component/badge/_part/doc/accessibility/index.md
+++ b/src/dsfr/component/badge/_part/doc/accessibility/index.md
@@ -39,7 +39,7 @@ Le composant Badge n’est pas interactif. Il n’y a donc pas d'interaction au 
 #### Structuration
 
 - Par défaut, utiliser un élément `<p>` lorsque le badge est utilisé seul.
-- Si le badge est utilisé à l’intérieur d’un élément qui possède une sémantique (`<p>`, `li`…), utiliser un élément `<span>`.
+- Si le badge est utilisé à l’intérieur d’un élément qui possède une sémantique (`<p>`, `<li>`…), utiliser un élément `<span>`.
 - En cas d’utilisation de plusieurs badges à la suite, les structurer dans une liste.
 
 #### Badge système avec icône

--- a/src/dsfr/component/badge/_part/doc/accessibility/index.md
+++ b/src/dsfr/component/badge/_part/doc/accessibility/index.md
@@ -22,7 +22,7 @@ Le badge est un élément d’indication permettant de valoriser une information
 
 - [Présentation](../index.md)
 - [Démo](../demo/index.md)
-- [Anatomie](../design/index.md)
+- [Design](../design/index.md)
 - [Code](../code/index.md)
 - Accessibilité
 

--- a/src/dsfr/component/badge/template/ejs/badges-group.ejs
+++ b/src/dsfr/component/badge/template/ejs/badges-group.ejs
@@ -25,6 +25,10 @@ const groupMarkup = badgesGroup.groupMarkup || 'ul';
 groupClasses.push(prefix + '-badges-group');
 const isList = groupMarkup === 'ul';
 
+badges.forEach((badge) => {
+  badge.markup = 'span';
+});
+
 switch(badgesGroup.size) {
   case 'sm':
     groupClasses.push(prefix + '-badges-group--sm');
@@ -37,7 +41,7 @@ switch(badgesGroup.size) {
   <% if (isList) { %>
     <li>
   <% } %>
-    <%- include('./badge.ejs', { badge:badges[i] }); %>
+    <%- include('./badge.ejs', { badge: badges[i] }); %>
   <% if (isList) { %>
     </li>
   <% } %>


### PR DESCRIPTION
Hello,

Voici une petite contribution pour :
* corriger la navigation tertiaire de la page "Accessibilité" ;
* harmoniser l'écriture des éléments HTML ;
* privilégier l'utilisation de l'élément HTML `<span>` quand les badges se trouvent dans un groupe comme la documentation le préconise :
  > Si le badge est utilisé à l’intérieur d’un élément qui possède une sémantique (&lt;p&gt;, li…), utiliser un élément &lt;span&gt;. 

:bowtie: