### PR TITLE
docs(readme): mise à jour de la commande yarn create

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Le Système de Design de l'État (ci-après, le DSFR) est disponible sur NPM .
 Une fois en place, vous pouvez installer le package `@gouvfr/dsfr` via la commande suivante :
 
 ```bash
-yarn create @gouvfr/dsfr
+yarn create @gouvfr/dsfr@latest
 ```
 
 Par défaut la version du DSFR installée sera la dernière version stable (latest). Il est possible d'installer une version spécifique du DSFR en ajoutant le numéro de version en paramètre, par exemple :
@@ -69,7 +69,7 @@ Puis de se rendre dans le dossier du projet, consentir aux modalités d'utilisat
 
 ```bash
 cd dsfr
-yarn create @gouvfr/dsfr
+yarn create @gouvfr/dsfr@latest
 yarn install
 yarn build
 ```

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -5,7 +5,7 @@ const log = require('../tool/utilities/log');
 const CONSENT_FILE_NAME = '.dsfr.yml';
 const ACCEPT_LICENSE_KEY = 'accept-license';
 const ACCEPT_LICENSE_ENV = 'DSFR_ACCEPT_LICENSE';
-const CREATE_DSFR_PACKAGE = '@gouvfr/dsfr';
+const CREATE_DSFR_PACKAGE = '@gouvfr/dsfr@latest';
 const CREATE_DSFR_COMMANDS = {
   npm: `npm create ${CREATE_DSFR_PACKAGE}`,
   pnpm: `pnpm create ${CREATE_DSFR_PACKAGE}`,


### PR DESCRIPTION
Hello,

Il semblerait que le fichier `README.md` n'est pas profité des mêmes corrections que la [documentation en ligne](https://www.systeme-de-design.gouv.fr/version-courante/fr/premiers-pas/vous-etes-developpeur/prise-en-main#installation-via-npm) sur la commande `yarn create`. 