### PR TITLE
docs: fix a typo in the alert module

### DIFF
--- a/src/dsfr/component/alert/template/stories/alert-arg-types.js
+++ b/src/dsfr/component/alert/template/stories/alert-arg-types.js
@@ -60,7 +60,7 @@ const alertArgTypes = {
         warning: 'Attention'
       }
     },
-    description: 'Type d\'alerte<br>Valeurs :<br>- Défaut : Alerte sans couleur<br>- Succès : Alerte verte pour indiquer une action ou une tâche terminée avec succès.<br>- Erreur : Alerte rouge à utiliser quand il y a plusieurs erreurs dans un formulaire, ou des erreurs bloquantes à remonter pour l’utilisateur.<br>- Information : Alerte bleue à utiliser pour mettre en exergue des informations importantes.<br>- Attention : Alerte orange à utiliser à utiliser pour mettre en exergue des risques ou points d’attention importants.',
+    description: 'Type d\'alerte<br>Valeurs :<br>- Défaut : Alerte sans couleur<br>- Succès : Alerte verte pour indiquer une action ou une tâche terminée avec succès.<br>- Erreur : Alerte rouge à utiliser quand il y a plusieurs erreurs dans un formulaire, ou des erreurs bloquantes à remonter pour l’utilisateur.<br>- Information : Alerte bleue à utiliser pour mettre en exergue des informations importantes.<br>- Attention : Alerte orange à utiliser pour mettre en exergue des risques ou points d’attention importants.',
     options: ['default', 'success', 'error', 'info', 'warning']
   },
   size: {


### PR DESCRIPTION
Corrige un texte en double dans la documentation du mode Alerte.