### PR TITLE
docs(checkbox): corrige les exemples indéterminés dans Storybook

### DIFF
--- a/src/dsfr/component/checkbox/template/stories/checkbox.stories.js
+++ b/src/dsfr/component/checkbox/template/stories/checkbox.stories.js
@@ -31,7 +31,7 @@ export const IndeterminateStory = {
   decorators: [
     (Story) => {
       const script = document.createElement('script');
-      script.src = '/js/checkbox/init-indeterminate.js';
+      script.src = 'js/checkbox/init-indeterminate.js';
       script.type = 'module';
       document.head.appendChild(script);
 


### PR DESCRIPTION
Hello,

Suite à un [retour de Kevin Genty sur Tchap](https://tchap.gouv.fr/#/room/!kAMDLjDiipYUJMsgzV:agent.pm.tchap.gouv.fr/$gFKzyXiF8gXz5jQhgXd81PM74Z0BThR-VhCpzMA25rA?via=agent.pm.tchap.gouv.fr&via=agent.finances.tchap.gouv.fr&via=agent.education.tchap.gouv.fr), les exemples de l'état indéterminé étaient KO dans Storybook. 

La structure/configuration d'URLs étant différente entre le répertorie et le déploiement, je suis passé à côté de cette erreur lors de ma contribution :relieved: 