### PR TITLE
📝 docs(checkbox): bug du storybook checkbox intederminée

### DIFF
--- a/src/dsfr/component/checkbox/_part/doc/design/index.md
+++ b/src/dsfr/component/checkbox/_part/doc/design/index.md
@@ -106,7 +106,7 @@ L'état désactivé indique que l’utilisateur ne peut pas interagir avec la ca
 
 L'état indéterminé peut être utilisé pour indiquer à l’utilisateur qu'un groupe de checkboxes avec une action commune est partiellement sélectionné. Typiquement, cet état pourra être utilisé lorsqu'un tableau proposera une case à cocher générale dans son en-tête et que l'ensemble des lignes ne seront pas sélectionnées.
 
-::dsfr-doc-storybook{storyId=checkbox-indeterminate}
+::dsfr-doc-storybook{storyId=checkbox--indeterminate}
 
 ### Personnalisation
 

--- a/src/dsfr/component/checkbox/template/stories/checkbox.stories.js
+++ b/src/dsfr/component/checkbox/template/stories/checkbox.stories.js
@@ -31,7 +31,7 @@ export const IndeterminateStory = {
   decorators: [
     (Story) => {
       const script = document.createElement('script');
-      script.src = '/js/checkbox/init-indeterminate.js';
+      script.src = './js/checkbox/init-indeterminate.js';
       script.type = 'module';
       document.head.appendChild(script);
 


### PR DESCRIPTION
- Corrige l'iframe dans le site de doc et l'url vers le js de la checkbox indéterminée.