### PR TITLE
docs(*): corrige des coquilles dans la documentation

### DIFF
--- a/src/dsfr/component/input/_part/doc/accessibility/index.md
+++ b/src/dsfr/component/input/_part/doc/accessibility/index.md
@@ -52,9 +52,9 @@ Son nom accessible est calculé par ordre de priorité à partir de&nbsp;:
 **Privilégier l’élément `<label>`** pour nommer le composant.
 
 >[!CAUTION]
->Le RGAA exige une **liaison explicite** entre l’attribut `for` de l’élément `<label>` et l'attribut `id` de la case à cocher.
+>Le RGAA exige une **liaison explicite** entre l’attribut `for` de l’élément `<label>` et l'attribut `id` du champ de saisie.
 >
->L’attribut `for` du label doit correspondre à l'attribut `id` de la case à cocher. La valeur de l’attribut `id` doit être unique dans la page.
+>L’attribut `for` du label doit correspondre à l'attribut `id` du champ de saisie. La valeur de l’attribut `id` doit être unique dans la page.
 
 La liaison explicite `for`/`id` permet&nbsp;:
 - d’assurer une compatibilité avec l’ensemble des technologies d’assistance (ex. le contrôle vocal),

--- a/src/dsfr/component/radio/_part/doc/accessibility/index.md
+++ b/src/dsfr/component/radio/_part/doc/accessibility/index.md
@@ -60,7 +60,7 @@ Son nom accessible est calculé par ordre de priorité à partir de&nbsp;:
 >[!CAUTION]
 >Le RGAA exige une **liaison explicite** entre l’attribut `for` de l’élément `<label>` et l'attribut `id` du bouton radio.
 >
->L’attribut `for` du label doit correspondre à l'attribut `id` de la case à cocher. La valeur de l’attribut `id` doit être unique dans la page.
+>L’attribut `for` du label doit correspondre à l'attribut `id` du bouton radio. La valeur de l’attribut `id` doit être unique dans la page.
 
 La liaison explicite `for`/`id` permet :
 - d’assurer une compatibilité avec l’ensemble des technologies d’assistance (ex. le contrôle vocal),

--- a/src/dsfr/component/toggle/_part/doc/accessibility/index.md
+++ b/src/dsfr/component/toggle/_part/doc/accessibility/index.md
@@ -70,7 +70,7 @@ La liaison explicite `for`/`id` permet&nbsp;:
 
 #### Étiquette visible et accolée
 
-L’étiquette est visible et doit être accolée à la case à cocher.
+L’étiquette est visible et doit être accolée à l’interrupteur.
 
 #### État désactivé
 


### PR DESCRIPTION
Hello, 

Voici trois petites corrections d'un copier/coller malheureux